### PR TITLE
fix(dlna): complete casting overhaul — 704/402/701 root causes, raw SOAP, working discovery

### DIFF
--- a/electron/dlnaHandlers.ts
+++ b/electron/dlnaHandlers.ts
@@ -37,11 +37,6 @@ interface SsdpHeaders {
     location?: string
 }
 
-interface SsdpPeer {
-    on(event: 'found', callback: (headers: SsdpHeaders, address: string) => void): void
-    search(target: string): void
-}
-
 interface NativeSsdpResponse {
     headers: SsdpHeaders
     address: string
@@ -50,6 +45,7 @@ interface NativeSsdpResponse {
 interface MediaRendererClientInstance {
     on(event: 'error', callback: (error: Error) => void): void
     load(url: string, options: unknown, callback: (error?: Error | null) => void): void
+    callAction(service: string, action: string, params: Record<string, unknown>, callback: (error?: Error | null, result?: unknown) => void): void
     stop(callback: (error?: Error | null) => void): void
 }
 
@@ -59,11 +55,9 @@ const getErrorMessage = (error: unknown): string =>
     error instanceof Error ? error.message : String(error);
 
 let MediaRendererClient: MediaRendererClientConstructor | null = null;
-let ssdp: SsdpPeer | null = null;
 const discoveredDevices: Map<string, DlnaDevice> = new Map();
 let manualDevices: DlnaDevice[] = [];
 let isDiscovering = false;
-let ssdpListenerRegistered = false;
 let proxyServer: http.Server | null = null;
 let proxyPort: number | null = null;
 // token -> upstream URL, with creation time so stale entries can be pruned.
@@ -292,14 +286,6 @@ try {
     log.error('[DLNA] Failed to load upnp-mediarenderer-client:', error);
 }
 
-try {
-    const SSDP = require('peer-ssdp').Peer as new () => SsdpPeer;
-    ssdp = new SSDP();
-    log.info('[DLNA] SSDP peer loaded successfully');
-} catch (error) {
-    log.error('[DLNA] Failed to load SSDP:', error);
-}
-
 // Load saved devices from disk
 function loadSavedDevices(): void {
     try {
@@ -405,24 +391,37 @@ function createSearchMessage(target: string): string {
     ].join('\r\n')
 }
 
+function localIPv4Addresses(): string[] {
+    return Object.values(os.networkInterfaces())
+        .flat()
+        .filter((address): address is os.NetworkInterfaceInfo =>
+            Boolean(address) && address.family === 'IPv4' && !address.internal
+        )
+        .map((address) => address.address)
+}
+
 async function nativeSsdpSearch(targets: string[], timeoutMs = 5000): Promise<NativeSsdpResponse[]> {
     return new Promise((resolve) => {
-        const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
         const responses = new Map<string, NativeSsdpResponse>()
+        const sockets: dgram.Socket[] = []
+        const timers: NodeJS.Timeout[] = []
         let settled = false
 
         const finish = () => {
             if (settled) return
             settled = true
-            try {
-                socket.close()
-            } catch {
-                // Socket may already be closed.
+            timers.forEach(clearTimeout)
+            for (const socket of sockets) {
+                try {
+                    socket.close()
+                } catch {
+                    // Socket may already be closed.
+                }
             }
             resolve(Array.from(responses.values()))
         }
 
-        socket.on('message', (buffer, remote) => {
+        const onMessage = (buffer: Buffer, remote: dgram.RemoteInfo) => {
             const headers = parseSsdpMessage(buffer.toString('utf8'))
             if (!looksLikeMediaRenderer(headers)) return
 
@@ -433,27 +432,48 @@ async function nativeSsdpSearch(targets: string[], timeoutMs = 5000): Promise<Na
                 headers,
                 address: remote.address
             })
-        })
+        }
 
-        socket.on('error', (error) => {
-            log.warn('[DLNA] Native SSDP error:', getErrorMessage(error))
-            finish()
-        })
+        // One socket per local IPv4 interface: on multi-homed machines
+        // (VPN/virtual adapters) a single 0.0.0.0 socket multicasts out the
+        // default-route interface, which is often not the LAN where the TV is.
+        const localAddresses = localIPv4Addresses()
+        const bindAddresses = localAddresses.length > 0 ? localAddresses : ['0.0.0.0']
 
-        socket.bind(0, '0.0.0.0', () => {
-            try {
-                socket.setBroadcast(true)
-                socket.setMulticastTTL(4)
-            } catch {
-                // Some network adapters do not allow multicast options.
-            }
+        for (const localAddress of bindAddresses) {
+            const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+            sockets.push(socket)
 
-            for (const target of targets) {
-                const message = Buffer.from(createSearchMessage(target))
-                socket.send(message, 0, message.length, 1900, '239.255.255.250')
-                socket.send(message, 0, message.length, 1900, '255.255.255.255')
-            }
-        })
+            socket.on('message', onMessage)
+            socket.on('error', (error) => {
+                log.warn(`[DLNA] Native SSDP error on ${localAddress}:`, getErrorMessage(error))
+            })
+
+            socket.bind(0, localAddress, () => {
+                try {
+                    socket.setBroadcast(true)
+                    socket.setMulticastTTL(4)
+                    if (localAddress !== '0.0.0.0') socket.setMulticastInterface(localAddress)
+                } catch {
+                    // Some network adapters do not allow multicast options.
+                }
+
+                // SSDP is lossy UDP — devices routinely miss a single M-SEARCH.
+                // Re-send each target a few times across the search window.
+                const sendAll = () => {
+                    if (settled) return
+                    for (const target of targets) {
+                        const message = Buffer.from(createSearchMessage(target))
+                        socket.send(message, 0, message.length, 1900, '239.255.255.250')
+                        socket.send(message, 0, message.length, 1900, '255.255.255.255')
+                    }
+                }
+
+                sendAll()
+                timers.push(setTimeout(sendAll, 700))
+                timers.push(setTimeout(sendAll, 1800))
+            })
+        }
 
         setTimeout(finish, timeoutMs)
     })
@@ -585,66 +605,46 @@ async function resolveManualLocation(ip: string, port?: number): Promise<{ locat
     }
 }
 
-// Discover DLNA devices using SSDP
+// Discover DLNA devices via native SSDP M-SEARCH (dgram).
+// peer-ssdp was removed: it exports createPeer(), not Peer, so the previous
+// `new SSDP()` threw on load and a guard then skipped discovery entirely —
+// the search button returned an empty list instantly.
 async function discoverDevices(): Promise<DlnaDevice[]> {
-    return new Promise((resolve) => {
-        if (!ssdp || isDiscovering) {
-            resolve(Array.from(discoveredDevices.values()));
-            return;
-        }
+    if (isDiscovering) {
+        return Array.from(discoveredDevices.values());
+    }
 
-        isDiscovering = true;
-        discoveredDevices.clear();
+    isDiscovering = true;
+    discoveredDevices.clear();
 
-        try {
-            const searchTargets = [
-                'urn:schemas-upnp-org:device:MediaRenderer:1',
-                'urn:schemas-upnp-org:service:AVTransport:1',
-                'urn:schemas-upnp-org:service:RenderingControl:1',
-                'ssdp:all'
-            ]
+    try {
+        const searchTargets = [
+            'urn:schemas-upnp-org:device:MediaRenderer:1',
+            'urn:schemas-upnp-org:service:AVTransport:1',
+            'urn:schemas-upnp-org:service:RenderingControl:1',
+            'ssdp:all'
+        ]
 
-            if (!ssdpListenerRegistered) {
-                ssdp.on('found', (headers, address) => {
-                    if (!looksLikeMediaRenderer(headers)) return
+        const responses = await nativeSsdpSearch(searchTargets)
+        responses.forEach(({ headers, address }) => {
+            if (!looksLikeMediaRenderer(headers)) return
+            const device = createDiscoveredDevice(headers, address)
+            upsertDiscoveredDevice(device)
+            log.info('[DLNA] SSDP found device:', device.name, 'at', device.host)
+        })
 
-                    const server = getHeader(headers, 'SERVER')
-                    const device = createDiscoveredDevice(headers, address)
+        await Promise.all(Array.from(discoveredDevices.values()).map((device) =>
+            enrichDeviceFromDescription(device).then(upsertDiscoveredDevice)
+        ))
 
-                    upsertDiscoveredDevice(device)
-                    void enrichDeviceFromDescription(device, server).then(upsertDiscoveredDevice)
-                    log.info('[DLNA] Found device:', device.name, 'at', device.host);
-                });
-                ssdpListenerRegistered = true
-            }
-
-            searchTargets.forEach((target) => ssdp?.search(target));
-
-            void nativeSsdpSearch(searchTargets).then((responses) => {
-                responses.forEach(({ headers, address }) => {
-                    const server = getHeader(headers, 'SERVER')
-                    const device = createDiscoveredDevice(headers, address)
-                    upsertDiscoveredDevice(device)
-                    void enrichDeviceFromDescription(device, server).then(upsertDiscoveredDevice)
-                    log.info('[DLNA] Native SSDP found device:', device.name, 'at', device.host)
-                })
-            })
-
-            // Stop discovery after 5 seconds
-            setTimeout(async () => {
-                await Promise.all(Array.from(discoveredDevices.values()).map((device) =>
-                    enrichDeviceFromDescription(device).then(upsertDiscoveredDevice)
-                ))
-                isDiscovering = false;
-                log.info('[DLNA] Discovery complete. Found', discoveredDevices.size, 'devices');
-                resolve(Array.from(discoveredDevices.values()));
-            }, 7000);
-        } catch (error) {
-            log.error('[DLNA] Discovery error:', error);
-            isDiscovering = false;
-            resolve([]);
-        }
-    });
+        log.info('[DLNA] Discovery complete. Found', discoveredDevices.size, 'devices');
+        return Array.from(discoveredDevices.values());
+    } catch (error) {
+        log.error('[DLNA] Discovery error:', error);
+        return [];
+    } finally {
+        isDiscovering = false;
+    }
 }
 
 export function setupDLNAHandlers() {
@@ -781,38 +781,48 @@ export function setupDLNAHandlers() {
                 ? createProxyUrl(url, device.host)
                 : url
 
-            const tryLoad = (mime: string) => new Promise((resolve, reject) => {
-                const timeout = setTimeout(() => {
-                    reject(new Error('Connection timeout - Check if TV is on and DLNA is enabled'));
-                }, 10000);
+            const escapeXml = (value: string) => value
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&apos;');
 
-                client.on('error', (err) => {
-                    clearTimeout(timeout);
-                    reject(err);
+            const callAvTransport = (action: string, params: Record<string, unknown>) =>
+                new Promise((resolve, reject) => {
+                    const timeout = setTimeout(() => {
+                        reject(new Error('Connection timeout - Check if TV is on and DLNA is enabled'));
+                    }, 10000);
+                    client.callAction('AVTransport', action, params, (err, result) => {
+                        clearTimeout(timeout);
+                        if (err) reject(err);
+                        else resolve(result);
+                    });
                 });
 
-                client.load(castUrl, {
-                    autoplay: true,
-                    contentType: mime,
-                    // Without explicit DLNA.ORG_* features in protocolInfo many
-                    // renderers (Samsung/LG) reject SetAVTransportURI with 704.
-                    dlnaFeatures: DLNA_FEATURES,
-                    metadata: {
-                        title: title || 'Video',
-                        type: 'video',
-                        creator: 'NeoStream IPTV'
-                    }
-                }, (err) => {
-                    clearTimeout(timeout);
-                    if (err) {
-                        log.error(`[DLNA] Cast error (mime=${mime}):`, err);
-                        reject(err);
-                    } else {
-                        log.info(`[DLNA] Media loaded successfully (mime=${mime})`);
-                        resolve(true);
-                    }
-                });
-            });
+            // Deliberately NOT using client.load(): it first calls
+            // ConnectionManager#PrepareForConnection, which Samsung TVs
+            // advertise but refuse with UPnP 704 "Local restrictions",
+            // killing the cast before SetAVTransportURI even runs.
+            // Calling AVTransport directly on InstanceID 0 works
+            // (verified by hand against a TU7000 that returned 704 via load()).
+            const tryLoad = async (mime: string) => {
+                const protocolInfo = `http-get:*:${mime}:${DLNA_FEATURES}`;
+                const didl = `<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:sec="http://www.sec.co.kr/"><item id="0" parentID="-1" restricted="false"><upnp:class>object.item.videoItem.movie</upnp:class><dc:title>${escapeXml(title || 'Video')}</dc:title><res protocolInfo="${protocolInfo}">${escapeXml(castUrl)}</res></item></DIDL-Lite>`;
+
+                try {
+                    await callAvTransport('SetAVTransportURI', {
+                        InstanceID: 0,
+                        CurrentURI: castUrl,
+                        CurrentURIMetaData: didl
+                    });
+                    await callAvTransport('Play', { InstanceID: 0, Speed: '1' });
+                    log.info(`[DLNA] Media loaded successfully (mime=${mime})`);
+                } catch (err) {
+                    log.error(`[DLNA] Cast error (mime=${mime}):`, err);
+                    throw err;
+                }
+            };
 
             const primaryMime = getMimeForUrl(url);
             try {

--- a/electron/dlnaHandlers.ts
+++ b/electron/dlnaHandlers.ts
@@ -42,19 +42,9 @@ interface NativeSsdpResponse {
     address: string
 }
 
-interface MediaRendererClientInstance {
-    on(event: 'error', callback: (error: Error) => void): void
-    load(url: string, options: unknown, callback: (error?: Error | null) => void): void
-    callAction(service: string, action: string, params: Record<string, unknown>, callback: (error?: Error | null, result?: unknown) => void): void
-    stop(callback: (error?: Error | null) => void): void
-}
-
-type MediaRendererClientConstructor = new (location: string) => MediaRendererClientInstance;
-
 const getErrorMessage = (error: unknown): string =>
     error instanceof Error ? error.message : String(error);
 
-let MediaRendererClient: MediaRendererClientConstructor | null = null;
 const discoveredDevices: Map<string, DlnaDevice> = new Map();
 let manualDevices: DlnaDevice[] = [];
 let isDiscovering = false;
@@ -170,13 +160,115 @@ async function fetchUpstream(url: string, range?: string) {
 // when the server doesn't answer like a DLNA media server.
 const DLNA_FEATURES = 'DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000'
 
-function dlnaHeaders(extra: Record<string, string | undefined>): Record<string, string | undefined> {
-    return {
+const AVTRANSPORT_SERVICE = 'urn:schemas-upnp-org:service:AVTransport:1'
+
+function escapeXml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;')
+}
+
+// location (device description URL) -> resolved AVTransport control URL
+const controlUrlCache: Map<string, string> = new Map()
+
+async function getAvTransportControlUrl(location: string): Promise<string> {
+    const cached = controlUrlCache.get(location)
+    if (cached) return cached
+
+    const fetch = (await import('node-fetch')).default
+    const response = await fetch(location, { headers: { 'User-Agent': 'NeoStream IPTV DLNA/1.0' } })
+    if (!response.ok) {
+        throw new Error(`Device description unavailable (HTTP ${response.status})`)
+    }
+    const xml = await response.text()
+
+    // Find the <service> block for AVTransport and its <controlURL>.
+    const serviceBlock = xml.split(/<service>/i)
+        .find((block) => block.includes(AVTRANSPORT_SERVICE))
+    const controlPath = serviceBlock ? getXmlTagValue(serviceBlock, 'controlURL') : undefined
+    if (!controlPath) {
+        throw new Error('Device does not expose an AVTransport control URL')
+    }
+
+    const controlUrl = new URL(controlPath, location).toString()
+    controlUrlCache.set(location, controlUrl)
+    return controlUrl
+}
+
+// Raw SOAP caller for AVTransport actions.
+//
+// We intentionally do NOT use upnp-mediarenderer-client / upnp-device-client:
+// 1. load() calls ConnectionManager#PrepareForConnection first, which Samsung
+//    TVs advertise but refuse with UPnP 704 "Local restrictions", killing the
+//    cast before SetAVTransportURI even runs.
+// 2. upnp-device-client sets Content-Length to xml.length (UTF-16 code
+//    units, not bytes), so any multibyte title — e.g. CJK series names —
+//    truncates the SOAP body and the TV answers 402 "Invalid Args".
+function sendAvTransportAction(
+    controlUrl: string,
+    action: string,
+    paramsXml: string,
+    timeoutMs = 10000
+): Promise<string> {
+    const envelope = `<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:${action} xmlns:u="${AVTRANSPORT_SERVICE}">${paramsXml}</u:${action}></s:Body></s:Envelope>`
+    const body = Buffer.from(envelope, 'utf8')
+    const parsed = new URL(controlUrl)
+
+    return new Promise((resolve, reject) => {
+        const request = http.request({
+            hostname: parsed.hostname,
+            port: parsed.port || 80,
+            path: parsed.pathname + parsed.search,
+            method: 'POST',
+            timeout: timeoutMs,
+            headers: {
+                'Content-Type': 'text/xml; charset="utf-8"',
+                'SOAPAction': `"${AVTRANSPORT_SERVICE}#${action}"`,
+                'Content-Length': body.length,
+                'User-Agent': 'NeoStream IPTV DLNA/1.0',
+                'Connection': 'close'
+            }
+        }, (response) => {
+            const chunks: Buffer[] = []
+            response.on('data', (chunk) => chunks.push(chunk))
+            response.on('end', () => {
+                const text = Buffer.concat(chunks).toString('utf8')
+                const errorCode = getXmlTagValue(text, 'errorCode')
+                const errorDescription = getXmlTagValue(text, 'errorDescription')
+                if (errorCode) {
+                    reject(new Error(`${errorDescription || 'UPnP error'} (${errorCode})`))
+                } else if (response.statusCode && response.statusCode >= 400) {
+                    reject(new Error(`HTTP ${response.statusCode} from device for ${action}`))
+                } else {
+                    resolve(text)
+                }
+            })
+        })
+
+        request.on('error', reject)
+        request.on('timeout', () => {
+            request.destroy()
+            reject(new Error('Connection timeout - Check if TV is on and DLNA is enabled'))
+        })
+        request.end(body)
+    })
+}
+
+function dlnaHeaders(extra: Record<string, string | undefined>): Record<string, string> {
+    const headers: Record<string, string> = {
         'transferMode.dlna.org': 'Streaming',
         'contentFeatures.dlna.org': DLNA_FEATURES,
-        'Access-Control-Allow-Origin': '*',
-        ...extra
+        'Access-Control-Allow-Origin': '*'
     }
+    // Drop undefined values — writeHead throws on them (live TS streams have
+    // no Content-Length, for example).
+    for (const [key, value] of Object.entries(extra)) {
+        if (value !== undefined) headers[key] = value
+    }
+    return headers
 }
 
 async function ensureProxyServer(): Promise<number> {
@@ -276,14 +368,6 @@ async function ensureProxyServer(): Promise<number> {
     }
 
     throw new Error('Failed to start DLNA media proxy')
-}
-
-// Initialize dependencies
-try {
-    MediaRendererClient = require('upnp-mediarenderer-client') as MediaRendererClientConstructor;
-    log.info('[DLNA] upnp-mediarenderer-client loaded successfully');
-} catch (error) {
-    log.error('[DLNA] Failed to load upnp-mediarenderer-client:', error);
 }
 
 // Load saved devices from disk
@@ -748,10 +832,6 @@ export function setupDLNAHandlers() {
         try {
             log.info('[DLNA] Cast requested:', { deviceId, title });
 
-            if (!MediaRendererClient) {
-                throw new Error('DLNA client not available');
-            }
-
             // Find device (from manual or discovered)
             let device = manualDevices.find(d => d.id === deviceId);
             if (!device) {
@@ -765,7 +845,17 @@ export function setupDLNAHandlers() {
             const location = device.location || `http://${device.host}:${device.port || 9197}/dmr`;
             log.info('[DLNA] Connecting to:', location);
 
-            const client = new MediaRendererClient(location);
+            const controlUrl = await getAvTransportControlUrl(location);
+
+            // Samsung's DLNA player does not decode HLS playlists ("file not
+            // supported" on the TV OSD). Xtream panels expose the same live
+            // channel as a continuous MPEG-TS stream at the .ts variant of the
+            // URL, which DLNA renderers play fine — prefer it for casting.
+            let streamUrl = url;
+            if (/\/live\//i.test(url) && /\.m3u8(\?|$)/i.test(url)) {
+                streamUrl = url.replace(/\.m3u8(\?|$)/i, '.ts$1');
+                log.info(`[DLNA] Live HLS detected; casting MPEG-TS variant instead: ${streamUrl}`);
+            }
 
             // Always route remote streams through the local proxy. IPTV
             // providers often reject the TV's direct request (single-connection
@@ -773,50 +863,41 @@ export function setupDLNAHandlers() {
             // reports UPnP 704 ("format not supported" / "local restrictions").
             // Through the proxy the TV fetches from this machine, which talks
             // to the provider with the app's HTTPS agent and headers.
-            const isRemoteHttp = /^https?:\/\//i.test(url)
+            const isRemoteHttp = /^https?:\/\//i.test(streamUrl)
             if (isRemoteHttp) {
                 await ensureProxyServer()
             }
             const castUrl = isRemoteHttp
-                ? createProxyUrl(url, device.host)
-                : url
+                ? createProxyUrl(streamUrl, device.host)
+                : streamUrl
 
-            const escapeXml = (value: string) => value
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;')
-                .replace(/'/g, '&apos;');
-
-            const callAvTransport = (action: string, params: Record<string, unknown>) =>
-                new Promise((resolve, reject) => {
-                    const timeout = setTimeout(() => {
-                        reject(new Error('Connection timeout - Check if TV is on and DLNA is enabled'));
-                    }, 10000);
-                    client.callAction('AVTransport', action, params, (err, result) => {
-                        clearTimeout(timeout);
-                        if (err) reject(err);
-                        else resolve(result);
-                    });
-                });
-
-            // Deliberately NOT using client.load(): it first calls
-            // ConnectionManager#PrepareForConnection, which Samsung TVs
-            // advertise but refuse with UPnP 704 "Local restrictions",
-            // killing the cast before SetAVTransportURI even runs.
-            // Calling AVTransport directly on InstanceID 0 works
-            // (verified by hand against a TU7000 that returned 704 via load()).
             const tryLoad = async (mime: string) => {
                 const protocolInfo = `http-get:*:${mime}:${DLNA_FEATURES}`;
                 const didl = `<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:sec="http://www.sec.co.kr/"><item id="0" parentID="-1" restricted="false"><upnp:class>object.item.videoItem.movie</upnp:class><dc:title>${escapeXml(title || 'Video')}</dc:title><res protocolInfo="${protocolInfo}">${escapeXml(castUrl)}</res></item></DIDL-Lite>`;
 
+                log.info(`[DLNA] tryLoad mime=${mime} castUrl=${castUrl} title=${JSON.stringify(title)}`);
+
                 try {
-                    await callAvTransport('SetAVTransportURI', {
-                        InstanceID: 0,
-                        CurrentURI: castUrl,
-                        CurrentURIMetaData: didl
-                    });
-                    await callAvTransport('Play', { InstanceID: 0, Speed: '1' });
+                    await sendAvTransportAction(controlUrl, 'SetAVTransportURI',
+                        `<InstanceID>0</InstanceID><CurrentURI>${escapeXml(castUrl)}</CurrentURI><CurrentURIMetaData>${escapeXml(didl)}</CurrentURIMetaData>`);
+                    try {
+                        await sendAvTransportAction(controlUrl, 'Play',
+                            '<InstanceID>0</InstanceID><Speed>1</Speed>');
+                    } catch (playError) {
+                        // Samsung renderers auto-play on SetAVTransportURI; an
+                        // explicit Play that lands while TRANSITIONING returns
+                        // 701 "Transition not available" even though playback
+                        // is starting. Check the real transport state before
+                        // declaring failure.
+                        if (!/\b701\b/.test(getErrorMessage(playError))) throw playError;
+                        log.warn('[DLNA] Play returned 701; checking transport state...');
+                        await new Promise(resolve => setTimeout(resolve, 1500));
+                        const info = await sendAvTransportAction(controlUrl, 'GetTransportInfo',
+                            '<InstanceID>0</InstanceID>');
+                        const state = getXmlTagValue(info, 'CurrentTransportState') || '';
+                        log.info(`[DLNA] Transport state after 701: ${state}`);
+                        if (!/PLAYING|TRANSITIONING/i.test(state)) throw playError;
+                    }
                     log.info(`[DLNA] Media loaded successfully (mime=${mime})`);
                 } catch (err) {
                     log.error(`[DLNA] Cast error (mime=${mime}):`, err);
@@ -824,7 +905,7 @@ export function setupDLNAHandlers() {
                 }
             };
 
-            const primaryMime = getMimeForUrl(url);
+            const primaryMime = getMimeForUrl(streamUrl);
             try {
                 await tryLoad(primaryMime);
             } catch (firstError) {
@@ -870,17 +951,8 @@ export function setupDLNAHandlers() {
             }
 
             const location = device.location || `http://${device.host}:${device.port || 9197}/dmr`;
-            const client = new MediaRendererClient(location);
-
-            await new Promise((resolve, reject) => {
-                client.stop((err) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(true);
-                    }
-                });
-            });
+            const controlUrl = await getAvTransportControlUrl(location);
+            await sendAvTransportAction(controlUrl, 'Stop', '<InstanceID>0</InstanceID>');
 
             return { success: true };
         } catch (error: unknown) {

--- a/electron/dlnaHandlers.ts
+++ b/electron/dlnaHandlers.ts
@@ -8,6 +8,7 @@ import http from 'http';
 import os from 'os';
 import { randomUUID } from 'crypto';
 import { getProviderHttpsAgent } from './certificatePolicy';
+import log from './logger';
 
 const require = createRequire(import.meta.url);
 
@@ -192,7 +193,7 @@ async function ensureProxyServer(): Promise<number> {
             const requestUrl = new URL(request.url || '/', `http://${request.headers.host || 'localhost'}`)
             const token = requestUrl.pathname.replace('/dlna-proxy/', '')
             const upstreamUrl = proxyUrls.get(token)?.url
-            console.log(`[DLNA] Proxy ${request.method} token=${token.slice(0, 8)}… range=${request.headers.range || '-'} known=${Boolean(upstreamUrl)}`)
+            log.info(`[DLNA] Proxy ${request.method} token=${token.slice(0, 8)}… range=${request.headers.range || '-'} known=${Boolean(upstreamUrl)}`)
 
             if (!upstreamUrl) {
                 response.writeHead(404)
@@ -247,7 +248,7 @@ async function ensureProxyServer(): Promise<number> {
                 // If the upstream stream dies mid-transfer the headers are already
                 // sent — just tear the socket down instead of writeHead-ing again.
                 upstreamResponse.body.on('error', (error: Error) => {
-                    console.warn('[DLNA] Proxy upstream stream error:', error.message)
+                    log.warn('[DLNA] Proxy upstream stream error:', error.message)
                     response.destroy()
                 })
                 response.on('close', () => {
@@ -276,7 +277,7 @@ async function ensureProxyServer(): Promise<number> {
     const address = proxyServer.address()
     if (typeof address === 'object' && address?.port) {
         proxyPort = address.port
-        console.log('[DLNA] Local media proxy started on port', proxyPort)
+        log.info('[DLNA] Local media proxy started on port', proxyPort)
         return proxyPort
     }
 
@@ -286,17 +287,17 @@ async function ensureProxyServer(): Promise<number> {
 // Initialize dependencies
 try {
     MediaRendererClient = require('upnp-mediarenderer-client') as MediaRendererClientConstructor;
-    console.log('[DLNA] upnp-mediarenderer-client loaded successfully');
+    log.info('[DLNA] upnp-mediarenderer-client loaded successfully');
 } catch (error) {
-    console.error('[DLNA] Failed to load upnp-mediarenderer-client:', error);
+    log.error('[DLNA] Failed to load upnp-mediarenderer-client:', error);
 }
 
 try {
     const SSDP = require('peer-ssdp').Peer as new () => SsdpPeer;
     ssdp = new SSDP();
-    console.log('[DLNA] SSDP peer loaded successfully');
+    log.info('[DLNA] SSDP peer loaded successfully');
 } catch (error) {
-    console.error('[DLNA] Failed to load SSDP:', error);
+    log.error('[DLNA] Failed to load SSDP:', error);
 }
 
 // Load saved devices from disk
@@ -310,10 +311,10 @@ function loadSavedDevices(): void {
         if (fs.existsSync(savePath)) {
             const data = fs.readFileSync(savePath, 'utf8');
             manualDevices = JSON.parse(data);
-            console.log('[DLNA] Loaded', manualDevices.length, 'saved devices');
+            log.info('[DLNA] Loaded', manualDevices.length, 'saved devices');
         }
     } catch (error) {
-        console.error('[DLNA] Error loading saved devices:', error);
+        log.error('[DLNA] Error loading saved devices:', error);
     }
 }
 
@@ -326,9 +327,9 @@ function saveDevices(): void {
         const savePath = path.join(app.getPath('userData'), 'dlna-devices.json');
 
         fs.writeFileSync(savePath, JSON.stringify(manualDevices, null, 2));
-        console.log('[DLNA] Saved', manualDevices.length, 'devices');
+        log.info('[DLNA] Saved', manualDevices.length, 'devices');
     } catch (error) {
-        console.error('[DLNA] Error saving devices:', error);
+        log.error('[DLNA] Error saving devices:', error);
     }
 }
 
@@ -435,7 +436,7 @@ async function nativeSsdpSearch(targets: string[], timeoutMs = 5000): Promise<Na
         })
 
         socket.on('error', (error) => {
-            console.warn('[DLNA] Native SSDP error:', getErrorMessage(error))
+            log.warn('[DLNA] Native SSDP error:', getErrorMessage(error))
             finish()
         })
 
@@ -612,7 +613,7 @@ async function discoverDevices(): Promise<DlnaDevice[]> {
 
                     upsertDiscoveredDevice(device)
                     void enrichDeviceFromDescription(device, server).then(upsertDiscoveredDevice)
-                    console.log('[DLNA] Found device:', device.name, 'at', device.host);
+                    log.info('[DLNA] Found device:', device.name, 'at', device.host);
                 });
                 ssdpListenerRegistered = true
             }
@@ -625,7 +626,7 @@ async function discoverDevices(): Promise<DlnaDevice[]> {
                     const device = createDiscoveredDevice(headers, address)
                     upsertDiscoveredDevice(device)
                     void enrichDeviceFromDescription(device, server).then(upsertDiscoveredDevice)
-                    console.log('[DLNA] Native SSDP found device:', device.name, 'at', device.host)
+                    log.info('[DLNA] Native SSDP found device:', device.name, 'at', device.host)
                 })
             })
 
@@ -635,11 +636,11 @@ async function discoverDevices(): Promise<DlnaDevice[]> {
                     enrichDeviceFromDescription(device).then(upsertDiscoveredDevice)
                 ))
                 isDiscovering = false;
-                console.log('[DLNA] Discovery complete. Found', discoveredDevices.size, 'devices');
+                log.info('[DLNA] Discovery complete. Found', discoveredDevices.size, 'devices');
                 resolve(Array.from(discoveredDevices.values()));
             }, 7000);
         } catch (error) {
-            console.error('[DLNA] Discovery error:', error);
+            log.error('[DLNA] Discovery error:', error);
             isDiscovering = false;
             resolve([]);
         }
@@ -653,7 +654,7 @@ export function setupDLNAHandlers() {
     // Discover devices
     ipcMain.handle('dlna:discover', async () => {
         try {
-            console.log('[DLNA] Starting device discovery...');
+            log.info('[DLNA] Starting device discovery...');
             const discovered = await discoverDevices();
 
             // Combine discovered and manual devices
@@ -667,7 +668,7 @@ export function setupDLNAHandlers() {
                 devices: allDevices
             };
         } catch (error: unknown) {
-            console.error('[DLNA] Discover error:', error);
+            log.error('[DLNA] Discover error:', error);
             return {
                 success: false,
                 error: getErrorMessage(error),
@@ -692,7 +693,7 @@ export function setupDLNAHandlers() {
     // Add manual device
     ipcMain.handle('dlna:add-device', async (_, { name, ip, port }) => {
         try {
-            console.log('[DLNA] Adding manual device:', { name, ip, port });
+            log.info('[DLNA] Adding manual device:', { name, ip, port });
             const resolved = await resolveManualLocation(ip, port)
 
             const device = {
@@ -723,7 +724,7 @@ export function setupDLNAHandlers() {
                 }
             };
         } catch (error: unknown) {
-            console.error('[DLNA] Add device error:', error);
+            log.error('[DLNA] Add device error:', error);
             return {
                 success: false,
                 error: getErrorMessage(error)
@@ -745,7 +746,7 @@ export function setupDLNAHandlers() {
     // Cast media to DLNA device
     ipcMain.handle('dlna:cast', async (_, { deviceId, url, title }) => {
         try {
-            console.log('[DLNA] Cast requested:', { deviceId, title });
+            log.info('[DLNA] Cast requested:', { deviceId, title });
 
             if (!MediaRendererClient) {
                 throw new Error('DLNA client not available');
@@ -762,7 +763,7 @@ export function setupDLNAHandlers() {
             }
 
             const location = device.location || `http://${device.host}:${device.port || 9197}/dmr`;
-            console.log('[DLNA] Connecting to:', location);
+            log.info('[DLNA] Connecting to:', location);
 
             const client = new MediaRendererClient(location);
 
@@ -804,10 +805,10 @@ export function setupDLNAHandlers() {
                 }, (err) => {
                     clearTimeout(timeout);
                     if (err) {
-                        console.error(`[DLNA] Cast error (mime=${mime}):`, err);
+                        log.error(`[DLNA] Cast error (mime=${mime}):`, err);
                         reject(err);
                     } else {
-                        console.log(`[DLNA] Media loaded successfully (mime=${mime})`);
+                        log.info(`[DLNA] Media loaded successfully (mime=${mime})`);
                         resolve(true);
                     }
                 });
@@ -821,7 +822,7 @@ export function setupDLNAHandlers() {
                 // etc.) but accept a generic video/mp4 and sniff the stream.
                 const message = getErrorMessage(firstError);
                 if (primaryMime !== 'video/mp4' && /\b704\b|restrict|format/i.test(message)) {
-                    console.warn(`[DLNA] ${primaryMime} refused (${message}); retrying as video/mp4`);
+                    log.warn(`[DLNA] ${primaryMime} refused (${message}); retrying as video/mp4`);
                     await tryLoad('video/mp4');
                 } else {
                     throw firstError;
@@ -830,7 +831,7 @@ export function setupDLNAHandlers() {
 
             return { success: true };
         } catch (error: unknown) {
-            console.error('[DLNA] Cast error:', error);
+            log.error('[DLNA] Cast error:', error);
             const message = getErrorMessage(error);
             let friendly = message;
             if (/\b704\b|restrict|format not supported|not implemented/i.test(message)) {
@@ -847,7 +848,7 @@ export function setupDLNAHandlers() {
     // Stop casting
     ipcMain.handle('dlna:stop', async (_, { deviceId }) => {
         try {
-            console.log('[DLNA] Stop requested:', deviceId);
+            log.info('[DLNA] Stop requested:', deviceId);
 
             let device = manualDevices.find(d => d.id === deviceId);
             if (!device) {
@@ -873,7 +874,7 @@ export function setupDLNAHandlers() {
 
             return { success: true };
         } catch (error: unknown) {
-            console.error('[DLNA] Stop error:', error);
+            log.error('[DLNA] Stop error:', error);
             return {
                 success: false,
                 error: getErrorMessage(error)
@@ -881,5 +882,5 @@ export function setupDLNAHandlers() {
         }
     });
 
-    console.log('[DLNA] IPC Handlers initialized with auto-discovery');
+    log.info('[DLNA] IPC Handlers initialized with auto-discovery');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.554.0",
         "node-fetch": "^3.3.2",
-        "peer-ssdp": "^0.0.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-i18next": "^16.3.5",
@@ -8861,11 +8860,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/peer-ssdp": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/peer-ssdp/-/peer-ssdp-0.0.5.tgz",
-      "integrity": "sha512-ckMRz+ZaaX54i/r4ZP/JyBxaGs/bxT4Q4I7sDHqcRGazfHCurXRh22PxNaJr+W6s9cQjfa5fKXqU4BO3YHiszw=="
     },
     "node_modules/pend": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "react-i18next": "^16.3.5",
         "react-router-dom": "^7.9.6",
         "tailwind-merge": "^3.4.0",
-        "upnp-mediarenderer-client": "^1.4.0",
         "vidstack": "^1.12.13"
       },
       "devDependencies": {
@@ -4524,6 +4523,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/builder-util": {
@@ -4899,51 +4899,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/concat-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/conf": {
       "version": "15.0.2",
       "resolved": "https://registry.npmjs.org/conf/-/conf-15.0.2.tgz",
@@ -5105,6 +5060,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/crc": {
@@ -5924,24 +5880,6 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/elementtree": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
-      "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "sax": "1.1.4"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/elementtree/node_modules/sax": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-      "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
-      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -7428,6 +7366,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -7533,6 +7472,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isbinaryfile": {
@@ -8494,15 +8434,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/network-address": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/network-address/-/network-address-1.1.2.tgz",
-      "integrity": "sha512-Q6878fmvItA1mE7H9Il46lONgFgTzX2f98zkS0c2YlkCACzNjwvum/8Kq693IQpxe9zy+w+Zm/4p0wQreLEtZw==",
-      "license": "MIT",
-      "bin": {
-        "network-address": "cli.js"
-      }
-    },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
@@ -8990,6 +8921,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -10332,12 +10264,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -10460,59 +10386,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/upnp-device-client": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/upnp-device-client/-/upnp-device-client-1.0.2.tgz",
-      "integrity": "sha512-5BcYJJU5wXR6xGko/UuLSavybAA0sZx17Hka4ikOXwA9Ze3fiExmgUDytAXE5qjdbKzARl0lOLC3hPSUwAa3eQ==",
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "^1.4.8",
-        "debug": "^2.1.3",
-        "elementtree": "~0.1.6",
-        "network-address": "^1.0.0"
-      }
-    },
-    "node_modules/upnp-device-client/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/upnp-device-client/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/upnp-mediarenderer-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/upnp-mediarenderer-client/-/upnp-mediarenderer-client-1.4.0.tgz",
-      "integrity": "sha512-F+C3Yceoz0j3ZWEchz5tpaOEqkbpObRUmeuPGc9+2u2YvC1CDbXGQ6mjbM10MDhnUJ0tTWYTufpj6xsWctnULw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.1.3",
-        "elementtree": "^0.1.6",
-        "upnp-device-client": "^1.0.0"
-      }
-    },
-    "node_modules/upnp-mediarenderer-client/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/upnp-mediarenderer-client/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -10543,6 +10416,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.554.0",
     "node-fetch": "^3.3.2",
-    "peer-ssdp": "^0.0.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-i18next": "^16.3.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-i18next": "^16.3.5",
     "react-router-dom": "^7.9.6",
     "tailwind-merge": "^3.4.0",
-    "upnp-mediarenderer-client": "^1.4.0",
     "vidstack": "^1.12.13"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Definitive DLNA casting fix, diagnosed live against a Samsung TU7000 with raw SOAP probes and an instrumented proxy. **All three scenarios verified playing on the TV: live channel, series (CJK title), movie.**

### Root causes found & fixed (in order of discovery)
1. **UPnP 704 "Local restrictions"**: `upnp-mediarenderer-client.load()` calls `PrepareForConnection`, which Samsung advertises but refuses with 704 (the spec's error string for that code). Bypassed.
2. **UPnP 402 "Invalid Args" on series**: `upnp-device-client` sets `Content-Length: xml.length` (UTF-16 units, not bytes) — any CJK/multibyte title truncates the SOAP body. **Both libs removed**; cast/stop now speak raw SOAP via `node:http` with `Buffer.byteLength`.
3. **UPnP 701 on live channels**: Samsung auto-plays on `SetAVTransportURI`; the explicit `Play` lands mid-TRANSITIONING and fails while playback actually starts. On 701 we check `GetTransportInfo` and accept PLAYING/TRANSITIONING.
4. **"File not supported" (TV OSD) on live**: Samsung's DLNA player can't decode HLS playlists. Xtream live URLs are rewritten `.m3u8 → .ts` (continuous MPEG-TS) for casting.
5. **Discovery returned instantly empty**: `peer-ssdp` exports `createPeer()`, not `Peer` — `new SSDP()` threw at load since day one and a guard skipped discovery. Removed; native dgram M-SEARCH is the path, now multi-interface (one socket per IPv4 NIC — machine has 5 adapters) with repeated sends. **Now finds both Samsung TVs on the network.**
6. **electron-log in dlnaHandlers** (original scope): packaged builds now write cast traces to main.log.

### Dependencies removed
`upnp-mediarenderer-client`, `peer-ssdp` — the DLNA stack is now fully first-party (~150 lines of SOAP/SSDP).

## Verification
- `tsc -b` clean · `eslint` clean · `vitest` 17/17
- **Manual on TU7000: live channel ✅ · series with CJK title ✅ · movie ✅** (user confirmed)