### PR TITLE
ci: pass --publish never to electron-builder in the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,17 +34,19 @@ jobs:
       - name: Run lint
         run: npm run lint
       
+      # --publish never: this workflow only produces artifacts. Without it,
+      # electron-builder sees the publish config + CI env and demands GH_TOKEN.
       - name: Build Electron app (Windows)
         if: matrix.os == 'windows-latest'
-        run: npm run build:win
-        
+        run: npm run build:win -- --publish never
+
       - name: Build Electron app (macOS)
         if: matrix.os == 'macos-latest'
-        run: npm run build:mac
-        
+        run: npm run build:mac -- --publish never
+
       - name: Build Electron app (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: npm run build:linux
+        run: npm run build:linux -- --publish never
       
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
One-liner fix for the remaining `Build NeoStream` failure on main: the workflow only produces artifacts, but electron-builder sees the `publish` config in package.json + CI env and aborts demanding `GH_TOKEN`. `--publish never` (npm run `--` passthrough reaches the trailing electron-builder call) makes it a pure build.

Node 22 from #13 already fixed the previous ESM error — windows/ubuntu/macos all reached the packaging step; macOS surfaced this publish abort.