### PR TITLE
fix: kids-filter cache TTL + renderer errors in main.log

### DIFF
--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -21,6 +21,15 @@ const OPEN_SUBTITLES_PASSWORD = process.env.OPEN_SUBTITLES_PASSWORD
 export function setupIpcHandlers() {
     ipcMain.handle('ping', () => 'pong')
 
+    // Renderer errors land in main.log so packaged-app bug reports include
+    // the UI side, not just the main process.
+    ipcMain.on('log:renderer', (_event, payload: { level?: string; message?: string; stack?: string }) => {
+        const message = `[Renderer] ${String(payload?.message ?? 'unknown error').slice(0, 2000)}`
+        const stack = payload?.stack ? `\n${String(payload.stack).slice(0, 4000)}` : ''
+        if (payload?.level === 'warn') log.warn(message + stack)
+        else log.error(message + stack)
+    })
+
     // Window controls for custom title bar
     ipcMain.handle('window:minimize', () => {
         const win = BrowserWindow.getFocusedWindow()

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -72,6 +72,7 @@ const invokeChannels = new Set([
 ])
 
 const sendChannels = new Set([
+    'log:renderer',
     'pip:control',
     'pip:state',
 ])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,11 @@ function App() {
     // Force refresh content by clearing cache timestamp
     localStorage.removeItem('contentLastFetch');
 
+    // Best-effort sweep of expired certification cache (30-day TTL).
+    void import('./services/indexedDBCache').then(({ indexedDBCache }) =>
+      indexedDBCache.cleanupExpired()
+    );
+
     // Initialize profile service (migrate old data if needed)
     profileService.initialize();
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,33 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+// Forward uncaught renderer errors to the main process so they land in
+// main.log — packaged-app bug reports were blind to the UI side.
+// Throttled so an error loop can't flood the log file.
+const REPORT_LIMIT = 20
+let reportedErrors = 0
+
+function reportRendererError(message: string, stack?: string, level: 'error' | 'warn' = 'error') {
+  if (reportedErrors >= REPORT_LIMIT) return
+  reportedErrors += 1
+  try {
+    window.ipcRenderer?.send('log:renderer', { level, message, stack })
+  } catch {
+    // Preload bridge unavailable (e.g. tests) — nothing to do.
+  }
+}
+
+window.addEventListener('error', (event) => {
+  reportRendererError(event.message, event.error?.stack)
+})
+
+window.addEventListener('unhandledrejection', (event) => {
+  const reason = event.reason
+  const message = reason instanceof Error ? reason.message : String(reason)
+  const stack = reason instanceof Error ? reason.stack : undefined
+  reportRendererError(`Unhandled rejection: ${message}`, stack)
+})
+
 // Note: StrictMode was removed because it causes video player issues
 // (double mounting causes video to reinitialize and seek operations to fail)
 createRoot(document.getElementById('root')!).render(

--- a/src/services/cacheExpiry.test.ts
+++ b/src/services/cacheExpiry.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { isExpired, KIDS_FILTER_CACHE_TTL_MS } from './cacheExpiry'
+
+const NOW = 1_750_000_000_000
+
+describe('isExpired', () => {
+    it('keeps fresh entries', () => {
+        expect(isExpired(NOW - 1000, KIDS_FILTER_CACHE_TTL_MS, NOW)).toBe(false)
+        expect(isExpired(NOW, KIDS_FILTER_CACHE_TTL_MS, NOW)).toBe(false)
+    })
+
+    it('expires entries older than the TTL', () => {
+        expect(isExpired(NOW - KIDS_FILTER_CACHE_TTL_MS - 1, KIDS_FILTER_CACHE_TTL_MS, NOW)).toBe(true)
+    })
+
+    it('boundary: exactly at the TTL is still fresh', () => {
+        expect(isExpired(NOW - KIDS_FILTER_CACHE_TTL_MS, KIDS_FILTER_CACHE_TTL_MS, NOW)).toBe(false)
+    })
+
+    it('treats legacy records without a timestamp as expired', () => {
+        expect(isExpired(undefined, KIDS_FILTER_CACHE_TTL_MS, NOW)).toBe(true)
+        expect(isExpired(NaN, KIDS_FILTER_CACHE_TTL_MS, NOW)).toBe(true)
+    })
+})

--- a/src/services/cacheExpiry.ts
+++ b/src/services/cacheExpiry.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure cache-expiry rules, shared by indexedDBCache and unit-testable
+ * without an IndexedDB environment.
+ */
+
+/** Certification/genre data is stable; refresh monthly. */
+export const KIDS_FILTER_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function isExpired(
+    cachedAt: number | undefined,
+    ttlMs: number,
+    now: number = Date.now()
+): boolean {
+    // Legacy records without a timestamp are treated as expired so they
+    // get refreshed (and re-stamped) on next use.
+    if (typeof cachedAt !== 'number' || !Number.isFinite(cachedAt)) return true;
+    return now - cachedAt > ttlMs;
+}

--- a/src/services/indexedDBCache.ts
+++ b/src/services/indexedDBCache.ts
@@ -4,6 +4,8 @@
  * Future-ready for migration to Supabase
  */
 
+import { isExpired, KIDS_FILTER_CACHE_TTL_MS } from './cacheExpiry';
+
 const DB_NAME = 'iptv_kids_filter';
 const DB_VERSION = 1;
 const MOVIES_STORE = 'movies_cache';
@@ -65,25 +67,39 @@ function normalizeName(name: string): string {
     return name.toLowerCase().trim().replace(/[^a-z0-9\s]/gi, '').replace(/\s+/g, ' ');
 }
 
+// Read a cache entry, treating expired/legacy records as misses (and
+// deleting them opportunistically so the store doesn't grow forever).
+async function getFreshCacheItem(storeName: string, name: string): Promise<CacheItem | null> {
+    try {
+        const db = await openDB();
+        const key = normalizeName(name);
+
+        return new Promise((resolve) => {
+            const tx = db.transaction(storeName, 'readwrite');
+            const store = tx.objectStore(storeName);
+            const request = store.get(key);
+
+            request.onsuccess = () => {
+                const item = (request.result as CacheItem | undefined) || null;
+                if (item && isExpired(item.cachedAt, KIDS_FILTER_CACHE_TTL_MS)) {
+                    store.delete(key);
+                    resolve(null);
+                    return;
+                }
+                resolve(item);
+            };
+            request.onerror = () => resolve(null);
+        });
+    } catch {
+        return null;
+    }
+}
+
 export const indexedDBCache = {
     // ==================== MOVIE CACHE ====================
 
     async getCachedMovie(name: string): Promise<CacheItem | null> {
-        try {
-            const db = await openDB();
-            const key = normalizeName(name);
-
-            return new Promise((resolve) => {
-                const tx = db.transaction(MOVIES_STORE, 'readonly');
-                const store = tx.objectStore(MOVIES_STORE);
-                const request = store.get(key);
-
-                request.onsuccess = () => resolve(request.result || null);
-                request.onerror = () => resolve(null);
-            });
-        } catch {
-            return null;
-        }
+        return getFreshCacheItem(MOVIES_STORE, name);
     },
 
     async setCacheMovie(name: string, certification: string | null, genres: string[]): Promise<void> {
@@ -113,21 +129,7 @@ export const indexedDBCache = {
     // ==================== SERIES CACHE ====================
 
     async getCachedSeries(name: string): Promise<CacheItem | null> {
-        try {
-            const db = await openDB();
-            const key = normalizeName(name);
-
-            return new Promise((resolve) => {
-                const tx = db.transaction(SERIES_STORE, 'readonly');
-                const store = tx.objectStore(SERIES_STORE);
-                const request = store.get(key);
-
-                request.onsuccess = () => resolve(request.result || null);
-                request.onerror = () => resolve(null);
-            });
-        } catch {
-            return null;
-        }
+        return getFreshCacheItem(SERIES_STORE, name);
     },
 
     async setCacheSeries(name: string, certification: string | null, genres: string[]): Promise<void> {
@@ -225,6 +227,41 @@ export const indexedDBCache = {
 
     // ==================== UTILITIES ====================
 
+    /**
+     * Delete expired certification entries from both stores. Called once at
+     * app startup; without it the cache grew unbounded across sessions.
+     */
+    async cleanupExpired(): Promise<number> {
+        let removed = 0;
+        try {
+            const db = await openDB();
+
+            const sweep = (storeName: string) => new Promise<void>((resolve) => {
+                const tx = db.transaction(storeName, 'readwrite');
+                const store = tx.objectStore(storeName);
+                const request = store.openCursor();
+
+                request.onsuccess = () => {
+                    const cursor = request.result;
+                    if (!cursor) return;
+                    const item = cursor.value as CacheItem;
+                    if (isExpired(item.cachedAt, KIDS_FILTER_CACHE_TTL_MS)) {
+                        cursor.delete();
+                        removed += 1;
+                    }
+                    cursor.continue();
+                };
+                tx.oncomplete = () => resolve();
+                tx.onerror = () => resolve();
+            });
+
+            await Promise.all([sweep(MOVIES_STORE), sweep(SERIES_STORE)]);
+        } catch {
+            // Silently fail — cleanup is best-effort.
+        }
+        return removed;
+    },
+
     async clearAll(): Promise<void> {
         try {
             const db = await openDB();
@@ -266,6 +303,7 @@ export const indexedDBCache = {
                     const items = request.result as CacheItem[];
                     const map = new Map<string, string | null>();
                     items.forEach(item => {
+                        if (isExpired(item.cachedAt, KIDS_FILTER_CACHE_TTL_MS)) return;
                         map.set(item.name, item.certification);
                     });
                     resolve(map);
@@ -290,6 +328,7 @@ export const indexedDBCache = {
                     const items = request.result as CacheItem[];
                     const map = new Map<string, string | null>();
                     items.forEach(item => {
+                        if (isExpired(item.cachedAt, KIDS_FILTER_CACHE_TTL_MS)) return;
                         map.set(item.name, item.certification);
                     });
                     resolve(map);


### PR DESCRIPTION
## Summary

Round 5, PR 1 of 4 (robustness).

### 🗄 IndexedDB cache TTL
The kids-filter certification cache stamped `cachedAt` but never read it — unbounded growth, stale ratings forever. Now: reads treat >30-day (and legacy unstamped) entries as misses with opportunistic deletion; startup runs a best-effort `cleanupExpired()` sweep; bulk reads skip expired entries. Expiry rule is a pure module with 4 unit tests.

### 📋 Renderer errors in main.log
`window.onerror` + `unhandledrejection` forward to a new allowlisted `log:renderer` IPC channel, written via electron-log as `[Renderer] ...`. Throttled (20/session) and size-clamped. Packaged-app bug reports now cover both processes.

## Verification
- `tsc -b` clean · `eslint` clean · `vitest` **43/43** · `vite build` OK
- Manual: in dev, `throw new Error('teste')` in the DevTools console → `[Renderer] teste` appears in main.log