### PR TITLE
feat: player keyboard shortcuts, profile delete copy, backup/restore

### DIFF
--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow, screen } from 'electron'
+import { ipcMain, BrowserWindow, dialog, screen } from 'electron'
 import { XtreamClient } from './xtreamClient'
 import store from './store'
 import { getCertificateSettings, getProviderHttpsAgent, registerApprovedProviderUrl, setAllowInvalidProviderCertificates } from './certificatePolicy'
@@ -550,6 +550,53 @@ export function setupIpcHandlers() {
             }
         } catch (error: unknown) {
             log.error('[OpenSubtitles] Error:', getErrorMessage(error))
+            return { success: false, error: getErrorMessage(error) }
+        }
+    })
+
+    // Save a user-data backup JSON to a file chosen by the user
+    ipcMain.handle('backup:save-file', async (_, { json }: { json: string }) => {
+        try {
+            const date = new Date().toISOString().slice(0, 10)
+            const result = await dialog.showSaveDialog({
+                title: 'Save backup',
+                defaultPath: `neostream-backup-${date}.json`,
+                filters: [{ name: 'JSON', extensions: ['json'] }]
+            })
+
+            if (result.canceled || !result.filePath) {
+                return { success: false, canceled: true }
+            }
+
+            const fs = await import('fs/promises')
+            await fs.writeFile(result.filePath, json, 'utf-8')
+            log.info('[Backup] Saved to', result.filePath)
+            return { success: true, path: result.filePath }
+        } catch (error: unknown) {
+            log.error('[Backup] Save error:', getErrorMessage(error))
+            return { success: false, error: getErrorMessage(error) }
+        }
+    })
+
+    // Load a user-data backup JSON from a file chosen by the user
+    ipcMain.handle('backup:load-file', async () => {
+        try {
+            const result = await dialog.showOpenDialog({
+                title: 'Open backup',
+                filters: [{ name: 'JSON', extensions: ['json'] }],
+                properties: ['openFile']
+            })
+
+            if (result.canceled || result.filePaths.length === 0) {
+                return { success: false, canceled: true }
+            }
+
+            const fs = await import('fs/promises')
+            const json = await fs.readFile(result.filePaths[0], 'utf-8')
+            log.info('[Backup] Loaded from', result.filePaths[0])
+            return { success: true, json }
+        } catch (error: unknown) {
+            log.error('[Backup] Load error:', getErrorMessage(error))
             return { success: false, error: getErrorMessage(error) }
         }
     })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -11,6 +11,8 @@ const invokeChannels = new Set([
     'auth:get-credentials',
     'auth:login',
     'auth:logout',
+    'backup:load-file',
+    'backup:save-file',
     'categories:get-live',
     'categories:get-series',
     'categories:get-vod',

--- a/src/components/ProfileManager.tsx
+++ b/src/components/ProfileManager.tsx
@@ -398,22 +398,22 @@ export function ProfileManager({ onClose }: ProfileManagerProps) {
                     <div className="pm-modal pm-modal-delete" onClick={(e) => e.stopPropagation()}>
                         <div className="pm-modal-header">
                             <span className="pm-modal-icon danger">🗑️</span>
-                            <h2>{t('profile', 'deleteProfile')}?</h2>
+                            <h2>{t('profile', 'confirmDeleteTitle')}</h2>
                         </div>
 
                         <p className="pm-delete-msg">
-                            {t('profile', 'confirmDelete').replace('este perfil', '')} <strong>{deleteConfirm.name}</strong>?
+                            <strong>{deleteConfirm.name}</strong>
                             <br />
-                            <span className="pm-delete-warning">{t('profile', 'actionCannotBeUndone')}</span>
+                            <span className="pm-delete-warning">{t('profile', 'confirmDeleteMessage')}</span>
                         </p>
 
                         <div className="pm-modal-buttons">
                             <button className="pm-btn pm-btn-cancel" onClick={() => setDeleteConfirm(null)}>
-                                {t('profile', 'cancel')}
+                                {t('profile', 'confirmDeleteCancel')}
                             </button>
                             <button className="pm-btn pm-btn-danger" onClick={confirmDelete}>
                                 <Trash2 size={18} />
-                                {t('profile', 'deleteProfile')}
+                                {t('profile', 'confirmDeleteConfirm')}
                             </button>
                         </div>
                     </div>

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -417,9 +417,21 @@ function VideoPlayerImpl<TSwitchContent extends SwitchableContent = SwitchableCo
         };
     }, [subtitleUrl]);
 
-    // Keyboard shortcuts
-    const handleKeyDown = useCallback((e: KeyboardEvent) => {
-        if (e.target instanceof HTMLInputElement) return;
+    // Keyboard shortcuts — the latest handler lives in a ref so a single
+    // stable document listener is attached for the whole player lifetime.
+    const handleKeyDownRef = useRef<(e: KeyboardEvent) => void>(() => { });
+    handleKeyDownRef.current = (e: KeyboardEvent) => {
+        // Ignore keystrokes aimed at form fields or editable content
+        const target = e.target as HTMLElement | null;
+        if (target && (
+            target.tagName === 'INPUT' ||
+            target.tagName === 'TEXTAREA' ||
+            target.tagName === 'SELECT' ||
+            target.isContentEditable
+        )) return;
+
+        // Ignore while the cast device selector modal is open
+        if (showDeviceSelector) return;
 
         switch (e.key.toLowerCase()) {
             case ' ':
@@ -455,6 +467,13 @@ function VideoPlayerImpl<TSwitchContent extends SwitchableContent = SwitchableCo
                     document.exitFullscreen();
                 }
                 break;
+            case 'c':
+                // The CC button runs an async fetch flow; the shortcut only
+                // toggles visibility when a subtitle is already loaded.
+                if (vttContent) {
+                    setSubtitlesEnabled(prev => !prev);
+                }
+                break;
             case 'escape':
                 if (document.fullscreenElement) {
                     document.exitFullscreen();
@@ -463,12 +482,13 @@ function VideoPlayerImpl<TSwitchContent extends SwitchableContent = SwitchableCo
                 }
                 break;
         }
-    }, [controls, state.currentTime, state.duration, state.volume, onClose]);
+    };
 
     useEffect(() => {
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [handleKeyDown]);
+        const listener = (e: KeyboardEvent) => handleKeyDownRef.current(e);
+        document.addEventListener('keydown', listener);
+        return () => document.removeEventListener('keydown', listener);
+    }, []);
 
     // Progress bar hover preview
     const handleProgressHover = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/src/hooks/useVideoPlayer.ts
+++ b/src/hooks/useVideoPlayer.ts
@@ -181,47 +181,9 @@ export function useVideoPlayer() {
         };
     }, [state.volume]);
 
-    // Keyboard Shortcuts
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (!videoRef.current) return;
-
-            switch (e.key) {
-                case ' ':
-                case 'k':
-                    e.preventDefault();
-                    togglePlay();
-                    break;
-                case 'f':
-                    e.preventDefault();
-                    toggleFullscreen();
-                    break;
-                case 'm':
-                    e.preventDefault();
-                    toggleMute();
-                    break;
-                case 'ArrowLeft':
-                    e.preventDefault();
-                    seek(Math.max(0, state.currentTime - 5));
-                    break;
-                case 'ArrowRight':
-                    e.preventDefault();
-                    seek(Math.min(state.duration, state.currentTime + 5));
-                    break;
-                case 'ArrowUp':
-                    e.preventDefault();
-                    setVolume(state.volume + 0.05);
-                    break;
-                case 'ArrowDown':
-                    e.preventDefault();
-                    setVolume(state.volume - 0.05);
-                    break;
-            }
-        };
-
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [state.currentTime, state.duration, state.volume, togglePlay, toggleFullscreen, toggleMute, seek, setVolume]);
+    // Keyboard shortcuts are intentionally NOT registered here: each consumer
+    // (VideoPlayer, PipWindow) owns a single document-level listener so the
+    // same key never fires two competing handlers.
 
     return {
         videoRef,

--- a/src/locales/ui/en.json
+++ b/src/locales/ui/en.json
@@ -1,6 +1,7 @@
 {
   "nav": {
     "updates": "Updates",
+    "backup": "Backup",
     "playback": "Playback",
     "epg": "EPG",
     "stats": "Statistics",
@@ -112,7 +113,11 @@
     "enterPinToDelete": "Enter PIN to delete",
     "actionCannotBeUndone": "This action cannot be undone.",
     "pinActive": "PIN Active",
-    "currentPinIncorrect": "Current PIN is incorrect"
+    "currentPinIncorrect": "Current PIN is incorrect",
+    "confirmDeleteTitle": "Delete profile?",
+    "confirmDeleteMessage": "This action cannot be undone. This profile's watch progress and favorites will be lost.",
+    "confirmDeleteConfirm": "Delete profile",
+    "confirmDeleteCancel": "Cancel"
   },
   "cast": {
     "title": "Cast to TV",
@@ -269,6 +274,26 @@
     "autoPlayNextDesc": "Automatically play the next episode",
     "clickThrough": "Click-Through Mode (PiP)",
     "clickThroughDesc": "Allows mouse to pass through PiP without interacting (F9 to toggle)"
+  },
+  "backup": {
+    "title": "Backup & Restore",
+    "description": "Export or restore your profiles, progress and preferences",
+    "exportTitle": "Export backup",
+    "exportDesc": "Saves profiles, favorites, watch progress, statistics and settings to a JSON file",
+    "exportButton": "Export Backup",
+    "exported": "✓ Backup saved",
+    "exportError": "Error exporting the backup",
+    "importTitle": "Import backup",
+    "importDesc": "Restores data from a backup file created by NeoStream",
+    "importButton": "Import Backup",
+    "importError": "Error importing the backup",
+    "invalidFile": "Invalid or incompatible backup file",
+    "confirmImportTitle": "Restore backup?",
+    "confirmImportMessage": "Current data (profiles, favorites, progress and settings) will be overwritten by the backup data. This action cannot be undone.",
+    "confirmImportConfirm": "Restore",
+    "confirmImportCancel": "Cancel",
+    "importSuccess": "Backup restored successfully! Restart the app to apply all changes.",
+    "credentialsNote": "IPTV provider credentials are NOT included in the backup."
   },
   "epg": {
     "title": "Program Guide (EPG)",

--- a/src/locales/ui/es.json
+++ b/src/locales/ui/es.json
@@ -1,6 +1,7 @@
 {
   "nav": {
     "updates": "Actualizaciones",
+    "backup": "Copia de seguridad",
     "playback": "Reproducción",
     "epg": "EPG",
     "stats": "Estadísticas",
@@ -112,7 +113,11 @@
     "enterPinToDelete": "Ingresa el PIN para eliminar",
     "actionCannotBeUndone": "Esta acción no se puede deshacer.",
     "pinActive": "PIN Activo",
-    "currentPinIncorrect": "El PIN actual es incorrecto"
+    "currentPinIncorrect": "El PIN actual es incorrecto",
+    "confirmDeleteTitle": "¿Eliminar perfil?",
+    "confirmDeleteMessage": "Esta acción no se puede deshacer. El progreso de visualización y los favoritos de este perfil se perderán.",
+    "confirmDeleteConfirm": "Eliminar perfil",
+    "confirmDeleteCancel": "Cancelar"
   },
   "cast": {
     "title": "Transmitir a TV",
@@ -269,6 +274,26 @@
     "autoPlayNextDesc": "Reproducir automáticamente el siguiente episodio",
     "clickThrough": "Modo Click-Through (PiP)",
     "clickThroughDesc": "Permite que el mouse pase por el PiP sin interactuar (F9 para alternar)"
+  },
+  "backup": {
+    "title": "Copia de Seguridad y Restauración",
+    "description": "Exporta o restaura tus perfiles, progreso y preferencias",
+    "exportTitle": "Exportar copia de seguridad",
+    "exportDesc": "Guarda perfiles, favoritos, progreso de visualización, estadísticas y configuración en un archivo JSON",
+    "exportButton": "Exportar Copia",
+    "exported": "✓ Copia guardada",
+    "exportError": "Error al exportar la copia de seguridad",
+    "importTitle": "Importar copia de seguridad",
+    "importDesc": "Restaura los datos de un archivo de copia creado por NeoStream",
+    "importButton": "Importar Copia",
+    "importError": "Error al importar la copia de seguridad",
+    "invalidFile": "Archivo de copia de seguridad inválido o incompatible",
+    "confirmImportTitle": "¿Restaurar copia de seguridad?",
+    "confirmImportMessage": "Los datos actuales (perfiles, favoritos, progreso y configuración) serán sobrescritos por los datos de la copia. Esta acción no se puede deshacer.",
+    "confirmImportConfirm": "Restaurar",
+    "confirmImportCancel": "Cancelar",
+    "importSuccess": "¡Copia restaurada con éxito! Reinicia la aplicación para aplicar todos los cambios.",
+    "credentialsNote": "Las credenciales del proveedor IPTV NO se incluyen en la copia de seguridad."
   },
   "epg": {
     "title": "Guía de Programación (EPG)",

--- a/src/locales/ui/pt.json
+++ b/src/locales/ui/pt.json
@@ -1,6 +1,7 @@
 {
   "nav": {
     "updates": "Atualizações",
+    "backup": "Backup",
     "playback": "Reprodução",
     "epg": "EPG",
     "stats": "Estatísticas",
@@ -112,7 +113,11 @@
     "enterPinToDelete": "Digite o PIN para deletar",
     "actionCannotBeUndone": "Esta ação não pode ser desfeita.",
     "pinActive": "PIN Ativo",
-    "currentPinIncorrect": "PIN atual incorreto"
+    "currentPinIncorrect": "PIN atual incorreto",
+    "confirmDeleteTitle": "Excluir perfil?",
+    "confirmDeleteMessage": "Esta ação não pode ser desfeita. O progresso de exibição e os favoritos deste perfil serão perdidos.",
+    "confirmDeleteConfirm": "Excluir perfil",
+    "confirmDeleteCancel": "Cancelar"
   },
   "cast": {
     "title": "Transmitir para TV",
@@ -210,6 +215,26 @@
     "lastCheck": "Última verificação",
     "checkNow": "Verificar Atualizações Agora",
     "checking": "Verificando..."
+  },
+  "backup": {
+    "title": "Backup e Restauração",
+    "description": "Exporte ou restaure seus perfis, progresso e preferências",
+    "exportTitle": "Exportar backup",
+    "exportDesc": "Salva perfis, favoritos, progresso de exibição, estatísticas e configurações em um arquivo JSON",
+    "exportButton": "Exportar Backup",
+    "exported": "✓ Backup salvo",
+    "exportError": "Erro ao exportar o backup",
+    "importTitle": "Importar backup",
+    "importDesc": "Restaura os dados de um arquivo de backup criado pelo NeoStream",
+    "importButton": "Importar Backup",
+    "importError": "Erro ao importar o backup",
+    "invalidFile": "Arquivo de backup inválido ou incompatível",
+    "confirmImportTitle": "Restaurar backup?",
+    "confirmImportMessage": "Os dados atuais (perfis, favoritos, progresso e configurações) serão sobrescritos pelos dados do backup. Esta ação não pode ser desfeita.",
+    "confirmImportConfirm": "Restaurar",
+    "confirmImportCancel": "Cancelar",
+    "importSuccess": "Backup restaurado com sucesso! Reinicie o aplicativo para aplicar todas as alterações.",
+    "credentialsNote": "As credenciais do provedor IPTV não são incluídas no backup."
   },
   "epg": {
     "title": "Guia de Programação (EPG)",

--- a/src/pages/PipWindow.tsx
+++ b/src/pages/PipWindow.tsx
@@ -275,6 +275,32 @@ export function PipWindow() {
         }
     }, [videoRef]);
 
+    // Keyboard shortcuts: Space toggles play, M toggles mute
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            const target = e.target as HTMLElement | null;
+            if (target && (
+                target.tagName === 'INPUT' ||
+                target.tagName === 'TEXTAREA' ||
+                target.tagName === 'SELECT' ||
+                target.isContentEditable
+            )) return;
+
+            switch (e.key.toLowerCase()) {
+                case ' ':
+                    e.preventDefault();
+                    handleTogglePlay();
+                    break;
+                case 'm':
+                    handleToggleMute();
+                    break;
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [handleTogglePlay, handleToggleMute]);
+
     // Send state updates to main window
     useEffect(() => {
         const video = videoRef.current;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import { NetworkSection } from './settings/NetworkSection';
 import { EpgSection, type EpgResultsFilter, type EpgCountryFilter } from './settings/EpgSection';
 import { StatsSection } from './settings/StatsSection';
 import { ParentalSection } from './settings/ParentalSection';
+import { BackupSection } from './settings/BackupSection';
 import { AboutSection } from './settings/AboutSection';
 
 
@@ -37,6 +38,7 @@ export function Settings() {
         { id: 'epg', icon: '📡', label: 'EPG', color: '#06b6d4' },
         { id: 'stats', icon: '📊', label: t('nav', 'stats'), color: '#8b5cf6' },
         { id: 'parental', icon: '👨‍👩‍👧', label: t('nav', 'parental'), color: '#ef4444' },
+        { id: 'backup', icon: '💾', label: t('nav', 'backup'), color: '#64748b' },
         { id: 'about', icon: 'ℹ️', label: t('nav', 'about'), color: '#f59e0b' }
     ];
 
@@ -106,6 +108,9 @@ export function Settings() {
 
                         {/* Parental Control Section */}
                         {activeSection === 'parental' && <ParentalSection />}
+
+                        {/* Backup Section */}
+                        {activeSection === 'backup' && <BackupSection />}
 
                         {/* About Section */}
                         {activeSection === 'about' && <AboutSection />}

--- a/src/pages/settings/BackupSection.tsx
+++ b/src/pages/settings/BackupSection.tsx
@@ -1,0 +1,226 @@
+import { useState } from 'react';
+import { useLanguage } from '../../services/languageService';
+import { collectBackup, applyBackup } from '../../services/backupService';
+import { useSaveAnimation } from './useSaveAnimation';
+
+interface BackupFileResult {
+    success: boolean;
+    canceled?: boolean;
+    path?: string;
+    json?: string;
+    error?: string;
+}
+
+export function BackupSection() {
+    const { t } = useLanguage();
+    const { saveAnimation, triggerSaveAnimation } = useSaveAnimation();
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const [pendingImportJson, setPendingImportJson] = useState<string | null>(null);
+    const [busy, setBusy] = useState(false);
+
+    const handleExport = async () => {
+        setErrorMessage(null);
+        setSuccessMessage(null);
+        setBusy(true);
+        try {
+            const payload = collectBackup();
+            const result = await window.ipcRenderer.invoke(
+                'backup:save-file',
+                { json: JSON.stringify(payload, null, 2) }
+            ) as BackupFileResult;
+
+            if (result.success) {
+                triggerSaveAnimation('export');
+            } else if (!result.canceled) {
+                setErrorMessage(t('backup', 'exportError'));
+            }
+        } catch (error) {
+            console.error('[Backup] Export failed:', error);
+            setErrorMessage(t('backup', 'exportError'));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleImportClick = async () => {
+        setErrorMessage(null);
+        setSuccessMessage(null);
+        setBusy(true);
+        try {
+            const result = await window.ipcRenderer.invoke('backup:load-file') as BackupFileResult;
+            if (result.success && result.json) {
+                // Ask for confirmation before overwriting current data
+                setPendingImportJson(result.json);
+            } else if (!result.canceled) {
+                setErrorMessage(t('backup', 'importError'));
+            }
+        } catch (error) {
+            console.error('[Backup] Load failed:', error);
+            setErrorMessage(t('backup', 'importError'));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleConfirmImport = () => {
+        if (!pendingImportJson) return;
+
+        try {
+            const parsed: unknown = JSON.parse(pendingImportJson);
+            applyBackup(parsed);
+            setSuccessMessage(t('backup', 'importSuccess'));
+        } catch (error) {
+            console.error('[Backup] Apply failed:', error);
+            setErrorMessage(t('backup', 'invalidFile'));
+        } finally {
+            setPendingImportJson(null);
+        }
+    };
+
+    return (
+        <div className="section-card">
+            <div className="section-header">
+                <div className="section-icon" style={{ background: 'linear-gradient(135deg, #64748b, #475569)' }}>💾</div>
+                <div>
+                    <h2>{t('backup', 'title')}</h2>
+                    <p>{t('backup', 'description')}</p>
+                </div>
+            </div>
+
+            <div className="settings-group">
+                {/* Export */}
+                <div className="setting-item">
+                    <div className="setting-info">
+                        <label>{t('backup', 'exportTitle')}</label>
+                        <p>{t('backup', 'exportDesc')}</p>
+                    </div>
+                    <button
+                        className="check-btn"
+                        style={{ width: 'auto', padding: '14px 24px' }}
+                        onClick={handleExport}
+                        disabled={busy}
+                    >
+                        <span>📤</span>
+                        <span>{t('backup', 'exportButton')}</span>
+                    </button>
+                    {saveAnimation === 'export' && (
+                        <span className="save-indicator">{t('backup', 'exported')}</span>
+                    )}
+                </div>
+
+                {/* Import */}
+                <div className="setting-item">
+                    <div className="setting-info">
+                        <label>{t('backup', 'importTitle')}</label>
+                        <p>{t('backup', 'importDesc')}</p>
+                    </div>
+                    <button
+                        className="check-btn"
+                        style={{ width: 'auto', padding: '14px 24px' }}
+                        onClick={handleImportClick}
+                        disabled={busy}
+                    >
+                        <span>📥</span>
+                        <span>{t('backup', 'importButton')}</span>
+                    </button>
+                </div>
+
+                {/* Credentials are not part of the backup */}
+                <div className="certificate-warning">
+                    {t('backup', 'credentialsNote')}
+                </div>
+
+                {errorMessage && (
+                    <div className="certificate-warning" style={{ borderColor: 'rgba(239, 68, 68, 0.4)', background: 'rgba(239, 68, 68, 0.12)' }}>
+                        ⚠️ {errorMessage}
+                    </div>
+                )}
+
+                {successMessage && (
+                    <div className="last-check">
+                        <span className="check-icon">✅</span>
+                        <span>{successMessage}</span>
+                    </div>
+                )}
+            </div>
+
+            {/* Import confirmation modal */}
+            {pendingImportJson && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        inset: 0,
+                        background: 'rgba(0, 0, 0, 0.85)',
+                        backdropFilter: 'blur(8px)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        zIndex: 10001
+                    }}
+                    onClick={() => setPendingImportJson(null)}
+                >
+                    <div
+                        style={{
+                            background: 'linear-gradient(135deg, #1e293b 0%, #0f172a 100%)',
+                            borderRadius: 24,
+                            padding: 32,
+                            maxWidth: 480,
+                            width: '90%',
+                            border: '1px solid rgba(168, 85, 247, 0.2)',
+                            boxShadow: '0 25px 80px rgba(0, 0, 0, 0.5)'
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <div style={{ textAlign: 'center', marginBottom: 24 }}>
+                            <span style={{ fontSize: 48, display: 'block', marginBottom: 12 }}>⚠️</span>
+                            <h2 style={{ color: 'white', fontSize: 24, fontWeight: 700, margin: 0 }}>
+                                {t('backup', 'confirmImportTitle')}
+                            </h2>
+                        </div>
+
+                        <p style={{ color: '#9ca3af', textAlign: 'center', lineHeight: 1.6, marginBottom: 28 }}>
+                            {t('backup', 'confirmImportMessage')}
+                        </p>
+
+                        <div style={{ display: 'flex', gap: 12 }}>
+                            <button
+                                style={{
+                                    flex: 1,
+                                    padding: '14px 20px',
+                                    borderRadius: 12,
+                                    fontSize: 15,
+                                    fontWeight: 600,
+                                    cursor: 'pointer',
+                                    border: '2px solid rgba(255, 255, 255, 0.2)',
+                                    background: 'rgba(255, 255, 255, 0.1)',
+                                    color: 'rgba(255, 255, 255, 0.8)'
+                                }}
+                                onClick={() => setPendingImportJson(null)}
+                            >
+                                {t('backup', 'confirmImportCancel')}
+                            </button>
+                            <button
+                                style={{
+                                    flex: 1,
+                                    padding: '14px 20px',
+                                    borderRadius: 12,
+                                    fontSize: 15,
+                                    fontWeight: 600,
+                                    cursor: 'pointer',
+                                    border: 'none',
+                                    background: 'linear-gradient(135deg, #ef4444, #dc2626)',
+                                    color: 'white',
+                                    boxShadow: '0 8px 24px rgba(239, 68, 68, 0.3)'
+                                }}
+                                onClick={handleConfirmImport}
+                            >
+                                {t('backup', 'confirmImportConfirm')}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/services/backupService.test.ts
+++ b/src/services/backupService.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { collectBackup, applyBackup, BACKUP_VERSION, BACKUP_APP } from './backupService';
+
+describe('backupService', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    describe('collectBackup', () => {
+        it('collects user-data keys (exact and prefixed)', () => {
+            localStorage.setItem('neostream_profiles', '{"profiles":[]}');
+            localStorage.setItem('neostream_profile_abc123', '{"favorites":[]}');
+            localStorage.setItem('playbackConfig', '{"bufferSize":10}');
+            localStorage.setItem('playbackConfig_abc123', '{"bufferSize":20}');
+            localStorage.setItem('parentalConfig', '{"enabled":false}');
+            localStorage.setItem('series_watch_progress_abc123', '{}');
+            localStorage.setItem('movie_watch_progress', '{}');
+            localStorage.setItem('usage_stats_abc123', '{}');
+            localStorage.setItem('neostream_language', 'pt');
+            localStorage.setItem('playerVolume', '0.8');
+
+            const backup = collectBackup();
+
+            expect(backup.version).toBe(BACKUP_VERSION);
+            expect(backup.app).toBe(BACKUP_APP);
+            expect(typeof backup.exportedAt).toBe('string');
+            expect(Object.keys(backup.data).sort()).toEqual([
+                'movie_watch_progress',
+                'neostream_language',
+                'neostream_profile_abc123',
+                'neostream_profiles',
+                'parentalConfig',
+                'playbackConfig',
+                'playbackConfig_abc123',
+                'playerVolume',
+                'series_watch_progress_abc123',
+                'usage_stats_abc123',
+            ].sort());
+        });
+
+        it('excludes cache and transient keys', () => {
+            localStorage.setItem('tmdb_cache_movies', '{}');
+            localStorage.setItem('tmdb_movie_details', '{}');
+            localStorage.setItem('epg_test_results', '{}');
+            localStorage.setItem('contentLastFetch', '12345');
+            localStorage.setItem('shouldAutoPlayNextEpisode', 'true');
+            localStorage.setItem('parentalUnlocked', 'true');
+            localStorage.setItem('neostream_profiles', '{"profiles":[]}');
+
+            const backup = collectBackup();
+
+            expect(Object.keys(backup.data)).toEqual(['neostream_profiles']);
+        });
+    });
+
+    describe('round trip', () => {
+        it('collect -> clear -> apply restores all values', () => {
+            localStorage.setItem('neostream_profiles', '{"profiles":[{"id":"p1"}],"activeProfileId":"p1"}');
+            localStorage.setItem('neostream_profile_p1', '{"favorites":[{"id":"42"}]}');
+            localStorage.setItem('series_watch_progress_p1', '{"99":{"1":{"2":300}}}');
+            localStorage.setItem('neostream_language', 'es');
+
+            const backup = collectBackup();
+            localStorage.clear();
+            expect(localStorage.getItem('neostream_profiles')).toBeNull();
+
+            // Simulate file round trip through JSON
+            const report = applyBackup(JSON.parse(JSON.stringify(backup)));
+
+            expect(report.applied).toBe(4);
+            expect(report.skipped).toEqual([]);
+            expect(localStorage.getItem('neostream_profiles')).toBe('{"profiles":[{"id":"p1"}],"activeProfileId":"p1"}');
+            expect(localStorage.getItem('neostream_profile_p1')).toBe('{"favorites":[{"id":"42"}]}');
+            expect(localStorage.getItem('series_watch_progress_p1')).toBe('{"99":{"1":{"2":300}}}');
+            expect(localStorage.getItem('neostream_language')).toBe('es');
+        });
+    });
+
+    describe('applyBackup validation', () => {
+        const validPayload = () => ({
+            version: BACKUP_VERSION,
+            exportedAt: new Date().toISOString(),
+            app: BACKUP_APP,
+            data: { neostream_language: 'pt' }
+        });
+
+        it('rejects unsupported versions', () => {
+            expect(() => applyBackup({ ...validPayload(), version: 2 })).toThrow(/version/);
+            expect(() => applyBackup({ ...validPayload(), version: undefined })).toThrow(/version/);
+        });
+
+        it('rejects payloads from other apps', () => {
+            expect(() => applyBackup({ ...validPayload(), app: 'other' })).toThrow(/neostream/);
+        });
+
+        it('rejects garbage payloads', () => {
+            expect(() => applyBackup(null)).toThrow();
+            expect(() => applyBackup('garbage')).toThrow();
+            expect(() => applyBackup(42)).toThrow();
+            expect(() => applyBackup([])).toThrow();
+            expect(() => applyBackup({})).toThrow();
+            expect(() => applyBackup({ ...validPayload(), data: 'not-an-object' })).toThrow(/data/);
+            expect(() => applyBackup({ ...validPayload(), data: ['x'] })).toThrow(/data/);
+        });
+
+        it('skips unknown keys and non-string values, applies the rest', () => {
+            const report = applyBackup({
+                ...validPayload(),
+                data: {
+                    neostream_language: 'en',
+                    tmdb_cache_movies: '{}',           // cache key — not restorable
+                    evil_key: 'value',                  // unknown key
+                    playerVolume: 0.5                   // non-string value
+                }
+            });
+
+            expect(report.applied).toBe(1);
+            expect(report.skipped.sort()).toEqual(['evil_key', 'playerVolume', 'tmdb_cache_movies'].sort());
+            expect(localStorage.getItem('neostream_language')).toBe('en');
+            expect(localStorage.getItem('tmdb_cache_movies')).toBeNull();
+            expect(localStorage.getItem('evil_key')).toBeNull();
+        });
+    });
+});

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -1,0 +1,97 @@
+// Backup/restore of user data stored in localStorage.
+//
+// The backup intentionally includes only user data (profiles, favorites,
+// watch-later, watch progress, configs, stats, language) and EXCLUDES:
+//   - provider credentials (they live in the Electron main-process store)
+//   - caches (tmdb_*, EPG test results, contentLastFetch)
+//   - transient flags (shouldAutoPlayNextEpisode, parentalUnlocked)
+
+export const BACKUP_VERSION = 1;
+export const BACKUP_APP = 'neostream';
+
+export interface BackupPayload {
+    version: number;
+    exportedAt: string;
+    app: typeof BACKUP_APP;
+    data: Record<string, string>;
+}
+
+export interface ApplyReport {
+    applied: number;
+    skipped: string[];
+}
+
+// Keys included by exact name
+const EXACT_KEYS = [
+    'neostream_profiles',     // profiles + active profile + watch-later lists
+    'neostream_language',     // UI language
+    'parentalConfig',         // parental control config (PIN hash included)
+    'movie_watch_progress',   // movie resume positions
+    'playerVolume',           // last player volume
+    'watchLater',             // legacy pre-profile watch-later list
+];
+
+// Keys included when they start with one of these prefixes
+const PREFIX_KEYS = [
+    'neostream_profile_',     // per-profile data (favorites)
+    'playbackConfig',         // playbackConfig and playbackConfig_<profileId>
+    'series_watch_progress',  // series_watch_progress and _<profileId>
+    'usage_stats',            // usage_stats_<profileId> / usage_stats_default
+];
+
+export function isBackupKey(key: string): boolean {
+    return EXACT_KEYS.includes(key) || PREFIX_KEYS.some(prefix => key.startsWith(prefix));
+}
+
+export function collectBackup(): BackupPayload {
+    const data: Record<string, string> = {};
+
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key === null || !isBackupKey(key)) continue;
+
+        const value = localStorage.getItem(key);
+        if (value !== null) {
+            data[key] = value;
+        }
+    }
+
+    return {
+        version: BACKUP_VERSION,
+        exportedAt: new Date().toISOString(),
+        app: BACKUP_APP,
+        data
+    };
+}
+
+export function applyBackup(parsed: unknown): ApplyReport {
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Invalid backup: payload is not an object');
+    }
+
+    const payload = parsed as Partial<BackupPayload>;
+
+    if (payload.app !== BACKUP_APP) {
+        throw new Error(`Invalid backup: not a ${BACKUP_APP} backup file`);
+    }
+    if (payload.version !== BACKUP_VERSION) {
+        throw new Error(`Invalid backup: unsupported version "${String(payload.version)}" (expected ${BACKUP_VERSION})`);
+    }
+    if (payload.data === null || typeof payload.data !== 'object' || Array.isArray(payload.data)) {
+        throw new Error('Invalid backup: missing data object');
+    }
+
+    let applied = 0;
+    const skipped: string[] = [];
+
+    for (const [key, value] of Object.entries(payload.data)) {
+        if (typeof value !== 'string' || !isBackupKey(key)) {
+            skipped.push(key);
+            continue;
+        }
+        localStorage.setItem(key, value);
+        applied++;
+    }
+
+    return { applied, skipped };
+}


### PR DESCRIPTION
## Summary

Round 5, PR 2 of 4 (user features). **Stacked on #18** — merge that first, I'll retarget this to main.

### ⌨️ Player keyboard shortcuts
Space/K play-pause · ←/→ seek ±10s · ↑/↓ volume ±10% · M mute · F fullscreen · C subtitles (when loaded). Guarded against typing targets and the cast modal. PipWindow: Space/M.
**Bonus bug fix**: `useVideoPlayer` registered a competing window keydown listener — every shortcut double-fired (M/F net no-op, conflicting seeks). Single stable listener now.

### 👤 Profile delete confirmation
The modal existed but built its message by string-mangling another translation. Dedicated PT/EN/ES keys warning about irreversibility and progress/favorites loss.

### 💾 Backup/restore (new Settings section)
Export: versioned JSON (profiles + watch-later + favorites, watch progress, playback/parental configs, language, volume) via save dialog. Import: shape/version validation, confirmation modal, restart recommendation. Excluded by design (UI states it): TMDB/EPG caches, session flags, **provider credentials**.
`backupService` is pure localStorage logic with 7 unit tests. IPC: `backup:save-file`/`backup:load-file`.

## Verification
- `tsc -b` clean · `eslint` clean · `vitest` **50/50** · `vite build` OK
- Manual checklist: shortcuts during local playback; delete a (test) profile; export → wipe → import round-trip.
