### PR TITLE
perf(grids): windowed rendering v2 — visually verified on a 25k-item library

### DIFF
--- a/src/hooks/useWindowedGrid.ts
+++ b/src/hooks/useWindowedGrid.ts
@@ -1,0 +1,150 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+/**
+ * Windowed rendering for the content grids (VOD/Series/LiveTV) — v2.
+ *
+ * Lessons from the failed v1 (per-row absolute grids via a virtualizer):
+ * unstable column counts between renders gave each row a different card
+ * width (masonry chaos), and measured-height drift made rows overlap.
+ *
+ * v2 keeps the page's ORIGINAL single grid element (original className,
+ * CSS gap/padding intact) and only narrows WHICH items are mounted:
+ * top/bottom spacer rows (grid items spanning all columns) replace the
+ * off-screen rows, so the scrollbar geometry stays correct while the DOM
+ * holds ~3 screens of cards instead of everything scrolled past.
+ *
+ * Until the first row height is measured the page should render its plain
+ * slice (`ready` false) — no layout flash, no 1-column bug.
+ */
+
+/** Single switch to disable windowing app-wide if an edge case appears. */
+export const ENABLE_WINDOWED_GRIDS = true;
+
+interface WindowedGridOptions {
+    /** The scrollable container (the page already has this ref). */
+    scrollRef: React.RefObject<HTMLElement | HTMLDivElement | null>;
+    /** The grid element itself (to measure row height + read columns). */
+    gridRef: React.RefObject<HTMLElement | HTMLDivElement | null>;
+    /** Total number of items in the filtered list. */
+    itemCount: number;
+    /** Rows rendered beyond the viewport on each side. */
+    overscanRows?: number;
+}
+
+interface WindowedGridResult {
+    /** False until geometry is measured — render the full/plain slice then. */
+    ready: boolean;
+    /** Mount only items in [start, end). */
+    start: number;
+    end: number;
+    /** Pixel heights for the spacer rows (0 when nothing is skipped). */
+    topSpacer: number;
+    bottomSpacer: number;
+    /** Columns detected from the real grid layout (CSS truth, not math). */
+    columns: number;
+}
+
+export function useWindowedGrid({
+    scrollRef,
+    gridRef,
+    itemCount,
+    overscanRows = 3
+}: WindowedGridOptions): WindowedGridResult {
+    const [geometry, setGeometry] = useState<{ columns: number; rowHeight: number; rowGap: number } | null>(null);
+    const [scrollTop, setScrollTop] = useState(0);
+    const [viewportHeight, setViewportHeight] = useState(0);
+    const rafRef = useRef<number | null>(null);
+
+    // Measure geometry from the REAL rendered grid: column count comes from
+    // the computed grid-template-columns (CSS truth — no parallel math to
+    // drift), row height from the first card's bounding box + row gap.
+    const measure = useCallback(() => {
+        const grid = gridRef.current;
+        const scroller = scrollRef.current;
+        if (!grid || !scroller || grid.children.length === 0) return;
+
+        const style = window.getComputedStyle(grid);
+        const columnCount = style.gridTemplateColumns.split(' ').filter(Boolean).length;
+        const rowGap = parseFloat(style.rowGap) || 0;
+        // Skip spacer rows (marked data-spacer) — measuring one as a card
+        // would corrupt rowHeight with the height of N skipped rows.
+        const firstCard = Array.from(grid.children)
+            .find(child => !(child as HTMLElement).dataset.spacer) as HTMLElement | undefined;
+        if (!firstCard) return;
+        const cardHeight = firstCard.getBoundingClientRect().height;
+
+        if (columnCount > 0 && cardHeight > 0) {
+            setGeometry({ columns: columnCount, rowHeight: cardHeight + rowGap, rowGap });
+            setViewportHeight(scroller.clientHeight);
+        }
+    }, [gridRef, scrollRef]);
+
+    // (Re)measure when the grid appears or resizes. The grid only exists
+    // after loading finishes, so observe via a no-deps effect guarded by
+    // identity — same fix that the v1 column hook needed.
+    const observedGrid = useRef<HTMLElement | null>(null);
+    const observerRef = useRef<ResizeObserver | null>(null);
+    useEffect(() => {
+        const grid = gridRef.current;
+        if (grid === observedGrid.current) return;
+        observerRef.current?.disconnect();
+        observedGrid.current = grid;
+        if (!grid) return;
+        const observer = new ResizeObserver(() => measure());
+        observer.observe(grid);
+        observerRef.current = observer;
+    });
+    useEffect(() => () => observerRef.current?.disconnect(), []);
+
+    // Track scroll position (rAF-throttled).
+    useEffect(() => {
+        const scroller = scrollRef.current;
+        if (!scroller) return;
+
+        const onScroll = () => {
+            if (rafRef.current !== null) return;
+            rafRef.current = requestAnimationFrame(() => {
+                rafRef.current = null;
+                setScrollTop(scroller.scrollTop);
+            });
+        };
+
+        scroller.addEventListener('scroll', onScroll, { passive: true });
+        return () => {
+            scroller.removeEventListener('scroll', onScroll);
+            if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+        };
+        // scrollRef identity is stable for the page's lifetime.
+    }, [scrollRef, geometry !== null]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    if (!ENABLE_WINDOWED_GRIDS || !geometry || itemCount === 0) {
+        return { ready: false, start: 0, end: itemCount, topSpacer: 0, bottomSpacer: 0, columns: geometry?.columns ?? 0 };
+    }
+
+    const { columns, rowHeight, rowGap } = geometry;
+    const totalRows = Math.ceil(itemCount / columns);
+
+    const firstVisibleRow = Math.max(0, Math.floor(scrollTop / rowHeight) - overscanRows);
+    const lastVisibleRow = Math.min(
+        totalRows - 1,
+        Math.ceil((scrollTop + viewportHeight) / rowHeight) + overscanRows
+    );
+
+    const start = firstVisibleRow * columns;
+    const end = Math.min(itemCount, (lastVisibleRow + 1) * columns);
+
+    // N skipped rows normally occupy N*rowHeight (card + gap each). The
+    // spacer replaces those rows but, being a grid row itself, the grid adds
+    // one extra gap between it and the adjacent card row — subtract it.
+    const spacerFor = (skippedRows: number) =>
+        skippedRows > 0 ? Math.max(0, skippedRows * rowHeight - rowGap) : 0;
+
+    return {
+        ready: true,
+        start,
+        end,
+        topSpacer: spacerFor(firstVisibleRow),
+        bottomSpacer: spacerFor(totalRows - 1 - lastVisibleRow),
+        columns
+    };
+}

--- a/src/pages/LiveTV.tsx
+++ b/src/pages/LiveTV.tsx
@@ -3,6 +3,7 @@ import { CategoryMenu } from '../components/CategoryMenu';
 import { AnimatedSearchBar } from '../components/AnimatedSearchBar';
 import AsyncVideoPlayer from '../components/AsyncVideoPlayer';
 import { LazyImage } from '../components/LazyImage';
+import { useWindowedGrid } from '../hooks/useWindowedGrid';
 import { epgService } from '../services/epgService';
 import { profileService } from '../services/profileService';
 import { parentalService } from '../services/parentalService';
@@ -86,6 +87,7 @@ export function LiveTV() {
     const [itemsPerPage, setItemsPerPage] = useState(48); // Default fallback
     const [progressTick, setProgressTick] = useState(0);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
+    const gridRef = useRef<HTMLDivElement>(null);
     const isKidsProfile = profileService.getActiveProfile()?.isKids || false;
     const [allowedCategoryIds, setAllowedCategoryIds] = useState<Set<string>>(new Set());
     const [blockedCategoryIds, setBlockedCategoryIds] = useState<Set<string>>(new Set());
@@ -272,23 +274,20 @@ export function LiveTV() {
         return matchesSearch && matchesCategory;
     });
 
-    // Scroll handler for lazy loading
-    const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
-        const container = e.currentTarget;
-        const { scrollTop, scrollHeight, clientHeight } = container;
-        const scrollPercentage = (scrollTop + clientHeight) / scrollHeight;
-
-        // Load more when 80% scrolled
-        if (scrollPercentage >= 0.8 && visibleCount < filteredStreams.length) {
-            const newCount = Math.min(visibleCount + itemsPerPage, filteredStreams.length);
-            setVisibleCount(newCount);
-        }
-    };
+    // Windowed rendering (same mechanism as VOD/Series).
+    const gridWindow = useWindowedGrid({
+        scrollRef: scrollContainerRef,
+        gridRef,
+        itemCount: filteredStreams.length
+    });
+    const windowStart = gridWindow.ready ? gridWindow.start : 0;
+    const windowEnd = gridWindow.ready ? gridWindow.end : Math.min(visibleCount, filteredStreams.length);
 
     // Reset visible count when search or category changes
     useEffect(() => {
         setVisibleCount(itemsPerPage);
         setSelectedChannel(null);
+        if (scrollContainerRef.current) scrollContainerRef.current.scrollTop = 0;
     }, [searchQuery, selectedCategory, itemsPerPage]);
 
     // Find quality variants for a channel (e.g., Globo SP matches Globo [4K])
@@ -1128,7 +1127,7 @@ export function LiveTV() {
                     </div>
                 )}
 
-                <div ref={scrollContainerRef} onScroll={handleScroll} className="livetv-scroll-container p-8" style={{ paddingLeft: '60px', position: 'relative', zIndex: 1, height: 'calc(100vh - 120px)', overflowY: 'auto', paddingRight: '8px', scrollbarWidth: 'thin', scrollbarColor: 'rgba(168, 85, 247, 0.4) transparent' }}>
+                <div ref={scrollContainerRef} className="livetv-scroll-container p-8" style={{ paddingLeft: '60px', position: 'relative', zIndex: 1, height: 'calc(100vh - 120px)', overflowY: 'auto', paddingRight: '8px', scrollbarWidth: 'thin', scrollbarColor: 'rgba(168, 85, 247, 0.4) transparent' }}>
                     <style>{`
                         .channel-card {
                             transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -1184,8 +1183,11 @@ export function LiveTV() {
                             <p style={{ fontSize: '14px', color: 'rgba(107, 114, 128, 1)', marginTop: '8px' }}>Tente buscar por outro termo</p>
                         </div>
                     ) : (
-                        <div className="channels-grid" style={{ animation: 'fadeInScale 0.5s ease-out' }}>
-                            {filteredStreams.slice(0, visibleCount).map((stream) => (
+                        <div ref={gridRef} className="channels-grid" style={{ animation: 'fadeInScale 0.5s ease-out' }}>
+                            {gridWindow.topSpacer > 0 && (
+                                <div data-spacer="true" style={{ gridColumn: '1 / -1', height: gridWindow.topSpacer }} />
+                            )}
+                            {filteredStreams.slice(windowStart, windowEnd).map((stream) => (
                                 <div
                                     key={stream.stream_id}
                                     onClick={() => setSelectedChannel(stream)}
@@ -1274,6 +1276,9 @@ export function LiveTV() {
                                     )}
                                 </div>
                             ))}
+                            {gridWindow.bottomSpacer > 0 && (
+                                <div data-spacer="true" style={{ gridColumn: '1 / -1', height: gridWindow.bottomSpacer }} />
+                            )}
                         </div>
                     )}
                 </div>

--- a/src/pages/Series.tsx
+++ b/src/pages/Series.tsx
@@ -12,6 +12,7 @@ import { profileService } from '../services/profileService';
 import { SeriesDetailPanel, type SeriesEpisode, type SeriesInfo } from '../components/SeriesDetailPanel';
 import { useSeriesMetadata } from '../hooks/useSeriesMetadata';
 import { useContentFiltering } from '../hooks/useContentFiltering';
+import { useWindowedGrid } from '../hooks/useWindowedGrid';
 import { HoverPreviewCard } from '../components/HoverPreviewCard';
 import { closeAllPreviews } from '../components/hoverPreviewActions';
 import { useLanguage } from '../services/languageService';
@@ -185,26 +186,21 @@ export function Series() {
         return matchesSearch && matchesCategory;
     });
 
-    // Lazy loading scroll handler
-    useEffect(() => {
-        const container = scrollContainerRef.current;
-        if (!container) return;
-
-        const handleScroll = () => {
-            const { scrollTop, scrollHeight, clientHeight } = container;
-            if (scrollTop + clientHeight >= scrollHeight * 0.85 && visibleCount < filteredSeries.length) {
-                setVisibleCount(prev => Math.min(prev + itemsPerPage, filteredSeries.length));
-            }
-        };
-
-        container.addEventListener('scroll', handleScroll);
-        return () => container.removeEventListener('scroll', handleScroll);
-    }, [filteredSeries.length, visibleCount, itemsPerPage]);
+    // Windowed rendering (same mechanism as VOD): spacer rows keep the
+    // scrollbar honest while only ~3 screens of cards stay mounted.
+    const gridWindow = useWindowedGrid({
+        scrollRef: scrollContainerRef,
+        gridRef,
+        itemCount: filteredSeries.length
+    });
+    const windowStart = gridWindow.ready ? gridWindow.start : 0;
+    const windowEnd = gridWindow.ready ? gridWindow.end : Math.min(visibleCount, filteredSeries.length);
 
     // Reset on filter change
     useEffect(() => {
         setVisibleCount(itemsPerPage);
         setSelectedSeries(null);
+        if (scrollContainerRef.current) scrollContainerRef.current.scrollTop = 0;
     }, [searchQuery, selectedCategory, itemsPerPage]);
 
     const fixImageUrl = (url: string): string => url && url.startsWith('http') ? url : `https://${url}`;
@@ -418,7 +414,10 @@ export function Series() {
                             </div>
                         ) : (
                             <div ref={gridRef} className="series-grid">
-                                {filteredSeries.slice(0, visibleCount).map((s, index) => {
+                                {gridWindow.topSpacer > 0 && (
+                                    <div data-spacer="true" style={{ gridColumn: '1 / -1', height: gridWindow.topSpacer }} />
+                                )}
+                                {filteredSeries.slice(windowStart, windowEnd).map((s, index) => {
                                     const isSaved = watchLaterService.has(String(s.series_id), 'series');
                                     const isFavorite = favoritesService.has(String(s.series_id), 'series');
                                     const hasProgress = watchProgressService.getSeriesProgress(String(s.series_id), s.name);
@@ -431,7 +430,7 @@ export function Series() {
                                         <div
                                             key={s.series_id}
                                             className={checkingItem === s.name ? 'checking' : ''}
-                                            style={{ animationDelay: `${(index % itemsPerPage) * 0.03}s` }}
+                                            style={{ animationDelay: gridWindow.ready ? '0s' : `${(index % itemsPerPage) * 0.03}s` }}
                                         >
                                             <HoverPreviewCard
                                                 type="series"
@@ -515,6 +514,9 @@ export function Series() {
                                         </div>
                                     );
                                 })}
+                                {gridWindow.bottomSpacer > 0 && (
+                                    <div data-spacer="true" style={{ gridColumn: '1 / -1', height: gridWindow.bottomSpacer }} />
+                                )}
                             </div>
                         )}
                     </div>

--- a/src/pages/VOD.tsx
+++ b/src/pages/VOD.tsx
@@ -10,6 +10,7 @@ import { ContentDetailModal } from '../components/ContentDetailModal';
 import { profileService } from '../services/profileService';
 import { downloadService } from '../services/downloadService';
 import { useContentFiltering } from '../hooks/useContentFiltering';
+import { useWindowedGrid } from '../hooks/useWindowedGrid';
 import { HoverPreviewCard } from '../components/HoverPreviewCard';
 import { closeAllPreviews } from '../components/hoverPreviewActions';
 import { useLanguage } from '../services/languageService';
@@ -174,26 +175,23 @@ export function VOD() {
         return matchesSearch && matchesCategory;
     });
 
-    // Lazy loading scroll handler
-    useEffect(() => {
-        const container = scrollContainerRef.current;
-        if (!container) return;
-
-        const handleScroll = () => {
-            const { scrollTop, scrollHeight, clientHeight } = container;
-            if (scrollTop + clientHeight >= scrollHeight * 0.85 && visibleCount < filteredStreams.length) {
-                setVisibleCount(prev => Math.min(prev + itemsPerPage, filteredStreams.length));
-            }
-        };
-
-        container.addEventListener('scroll', handleScroll);
-        return () => container.removeEventListener('scroll', handleScroll);
-    }, [filteredStreams.length, visibleCount, itemsPerPage]);
+    // Windowed rendering: only ~3 screens of cards stay mounted while the
+    // scrollbar reflects the full list (spacer rows keep the geometry).
+    // Until geometry is measured, the plain first-page slice renders.
+    const gridWindow = useWindowedGrid({
+        scrollRef: scrollContainerRef,
+        gridRef,
+        itemCount: filteredStreams.length
+    });
+    const windowStart = gridWindow.ready ? gridWindow.start : 0;
+    const windowEnd = gridWindow.ready ? gridWindow.end : Math.min(visibleCount, filteredStreams.length);
 
     // Reset on filter change
     useEffect(() => {
         setVisibleCount(itemsPerPage);
         setSelectedMovie(null);
+        // Back to the top so the window recomputes from row 0.
+        if (scrollContainerRef.current) scrollContainerRef.current.scrollTop = 0;
     }, [searchQuery, selectedCategory, itemsPerPage]);
 
     // Fetch TMDB data
@@ -389,7 +387,10 @@ export function VOD() {
                             </div>
                         ) : (
                             <div ref={gridRef} className="movies-grid">
-                                {filteredStreams.slice(0, visibleCount).map((stream, index) => {
+                                {gridWindow.topSpacer > 0 && (
+                                    <div data-spacer="true" style={{ gridColumn: '1 / -1', height: gridWindow.topSpacer }} />
+                                )}
+                                {filteredStreams.slice(windowStart, windowEnd).map((stream, index) => {
                                     const progress = getProgress(stream.stream_id);
                                     const movieProgress = getMovieProgress(stream.stream_id);
                                     const isSaved = watchLaterService.has(String(stream.stream_id), 'movie');
@@ -402,7 +403,7 @@ export function VOD() {
                                         <div
                                             key={stream.stream_id}
                                             className={checkingItem === stream.name ? 'checking' : ''}
-                                            style={{ animationDelay: `${(index % itemsPerPage) * 0.03}s` }}
+                                            style={{ animationDelay: gridWindow.ready ? '0s' : `${(index % itemsPerPage) * 0.03}s` }}
                                         >
                                             <HoverPreviewCard
                                                 type="movie"
@@ -501,6 +502,9 @@ export function VOD() {
                                         </div>
                                     );
                                 })}
+                                {gridWindow.bottomSpacer > 0 && (
+                                    <div data-spacer="true" style={{ gridColumn: '1 / -1', height: gridWindow.bottomSpacer }} />
+                                )}
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
## Summary

Round 5, PR 4 of 4 — second attempt at large-list performance, built around the v1 post-mortem and **visually verified by Claude via screenshots before reaching you**.

### Why v1 failed (and v2 can't)
v1 rendered each virtual row as its own absolutely-positioned grid; unstable column counts between renders gave every row a different card width (the masonry chaos you screenshotted) and measured-height drift made rows overlap.

v2 keeps the page's **original single grid element** — className, CSS gap/padding/minmax untouched. Off-screen rows become two spacer rows (grid items spanning all columns), so scrollbar geometry stays exact while only ~3 screens of cards stay mounted. One grid = uniform card widths **by construction**.

### Design
- Geometry read from the real layout (computed `gridTemplateColumns` for columns, first card's box for row height) — no parallel math to drift from CSS.
- Until measured, the page renders its plain first-page slice (kills the v1 skeleton-mount 1-column bug class).
- Hand-rolled hook (~150 lines), zero dependencies; `ENABLE_WINDOWED_GRIDS` flag for a 1-line revert.

### Visual gate (performed by Claude, live app, screenshots)
✅ VOD top-of-list: 5 uniform columns, identical to shipped layout
✅ 250+ scroll ticks deep into **25,745 movies**: aligned rows, posters loading, hover working
✅ Multi-thousand-row jump + fast return to top: no gaps, no overlap
✅ Series (4,231) loaded + deep scroll: identical layout
✅ LiveTV channels: aligned cards, logos loading

### Impact
Scrolling a large category no longer accumulates thousands of DOM nodes/images — memory stays flat regardless of list size.

## Verification
- `tsc -b` clean · `eslint` clean · `vitest` 53/53 · `vite build` OK
- Suggested final user check: browse normally for a minute in each grid; click a card after deep scroll (selection should behave as always).