### PR TITLE
feat: multi-OS release pipeline + app-themed NSIS installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,82 +1,59 @@
+# Multi-OS release pipeline: push a v*.*.* tag and this builds Windows
+# (NSIS + portable), Linux (AppImage + deb) and macOS (dmg + zip), then
+# attaches everything — including the latest*.yml auto-update feeds — to
+# the GitHub release for that tag. Release notes are edited afterwards.
 name: Build and Release
 
 on:
   push:
     tags:
-      - 'v*.*.*'  # Triggers on version tags like v1.0.0, v1.0.1, etc.
+      - 'v*.*.*'
+
+permissions:
+  contents: write
 
 jobs:
   release:
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
-    
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-      
+          node-version: 22
+          cache: npm
+
       - name: Install dependencies
         run: npm ci
-      
+
+      # --publish never: electron-builder only builds; the release step
+      # below uploads. (With GH_TOKEN visible, builder would double-publish.)
       - name: Build application
-        run: npm run build
+        run: npm run build -- --publish never
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Upload artifacts (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-installers
-          path: |
-            release/**/*.exe
-            release/**/*.yml
-          retention-days: 5
-      
-      - name: Upload artifacts (macOS)
-        if: matrix.os == 'macos-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-installers
-          path: |
-            release/**/*.dmg
-            release/**/*.zip
-            release/**/*.yml
-          retention-days: 5
-      
-      - name: Upload artifacts (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-installers
-          path: |
-            release/**/*.AppImage
-            release/**/*.deb
-            release/**/*.yml
-          retention-days: 5
-      
-      # Publish to GitHub Releases
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+          VITE_TMDB_API_KEY: ${{ secrets.VITE_TMDB_API_KEY }}
+          # macOS: no signing identity in CI — skip signing instead of failing.
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Attach artifacts to the release
+        uses: softprops/action-gh-release@v2
         with:
           files: |
-            release/**/*.exe
-            release/**/*.dmg
-            release/**/*.zip
-            release/**/*.AppImage
-            release/**/*.deb
-            release/**/*.yml
+            release/*.exe
+            release/*.exe.blockmap
+            release/*.dmg
+            release/*.zip
+            release/*.AppImage
+            release/*.deb
+            release/latest*.yml
           draft: false
           prerelease: false
-          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -7,10 +7,21 @@
 ; NOTE: MUI_ICON, MUI_UNICON are managed by electron-builder
 
 ; ═══════════════════════════════════════════════════════════════════════
-; BRANDING TEXT
+; APP THEME — dark background + light text on every MUI page
+; Palette: #0f0f1a (bg) / #c4b5fd (light purple) / #ffffff (text)
 ; ═══════════════════════════════════════════════════════════════════════
 
-BrandingText "NeoStream IPTV v3.9.0"
+!define MUI_BGCOLOR "0F0F1A"
+!define MUI_TEXTCOLOR "FFFFFF"
+
+; Install-progress page: light-purple log text on the app's dark bg
+!define MUI_INSTFILESPAGE_COLORS "C4B5FD 0F0F1A"
+
+; ═══════════════════════════════════════════════════════════════════════
+; BRANDING TEXT (VERSION macro is provided by electron-builder)
+; ═══════════════════════════════════════════════════════════════════════
+
+BrandingText "NeoStream IPTV v${VERSION}"
 
 ; ═══════════════════════════════════════════════════════════════════════
 ; WELCOME PAGE CUSTOMIZATION

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
       "createStartMenuShortcut": true,
       "shortcutName": "NeoStream IPTV",
       "include": "build/installer.nsh",
+      "installerHeader": "build/installer-header.bmp",
       "installerSidebar": "build/installer-sidebar.bmp",
       "uninstallerSidebar": "build/uninstaller-sidebar.bmp",
       "license": "build/license_pt.txt",


### PR DESCRIPTION
## Summary

Round 6, part 1 — distribution upgrades.

### 🚀 Multi-OS releases (Linux/macOS users finally get builds)
`release.yml` rewritten: pushing a `v*.*.*` tag builds **Windows + Linux (AppImage/deb) + macOS (dmg/zip)** in CI and attaches everything (including `latest*.yml` auto-update feeds) to the GitHub release. **The local build step is retired** — next release is: merge → tag push → CI does the rest → edit notes.

Fixes vs the broken old workflow: Node 22 (builder 26 needs ≥20), `VITE_TMDB_API_KEY` injected from repo secrets (✅ already set), macOS signing skipped instead of failing, no electron-builder/action double-publish.

### 🎨 App-themed installer (user request)
- Purple→pink gradient header image wired in (it was generated but never used)
- All installer pages now use the app palette: `#0f0f1a` background, white text, light-purple install log
- Footer branding shows the real version (was hardcoded "v3.9.0")
- Existing PT texts, sidebar art and running-app guards preserved

## Verification
- NSIS smoke-built locally with the theme — compiles clean, no MUI define conflicts
- The pipeline's real test is the next tag push (v3.12.0) — if a matrix job fails we'll see it in Actions before publishing notes