### PR TITLE
feat: watch history page + next-episodes row

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const Settings = lazy(() => import('./pages/Settings').then(m => ({ default: m.S
 const WatchLater = lazy(() => import('./pages/WatchLater').then(m => ({ default: m.WatchLater })));
 const Favorites = lazy(() => import('./pages/Favorites').then(m => ({ default: m.Favorites })));
 const Downloads = lazy(() => import('./pages/Downloads').then(m => ({ default: m.Downloads })));
+const History = lazy(() => import('./pages/History').then(m => ({ default: m.History })));
 const PipWindow = lazy(() => import('./pages/PipWindow').then(m => ({ default: m.PipWindow })));
 
 function PageLoader() {
@@ -115,6 +116,7 @@ function App() {
               <Route path="watch-later" element={<WatchLater />} />
               <Route path="favorites" element={<Favorites />} />
               <Route path="downloads" element={<Downloads />} />
+              <Route path="history" element={<History />} />
               <Route path="settings" element={<Settings />} />
             </Route>
             <Route

--- a/src/components/NextEpisodes.tsx
+++ b/src/components/NextEpisodes.tsx
@@ -1,0 +1,185 @@
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { watchProgressService } from '../services/watchProgressService';
+import { LazyImage } from './LazyImage';
+import { useLanguage } from '../services/languageService';
+
+interface SeriesItem {
+    series_id: string | number;
+    name: string;
+    cover?: string;
+    stream_icon?: string;
+}
+
+interface NextEpisodeItem {
+    series: SeriesItem;
+    nextSeason: number;
+    nextEpisode: number;
+    lastWatchedAt: number;
+}
+
+interface NextEpisodesProps {
+    allSeries: SeriesItem[];
+}
+
+/**
+ * "Next episodes" row for the Home page.
+ *
+ * Episode counts per season are not stored locally, so the next episode is
+ * computed optimistically as lastWatched + 1 in the same season (no season
+ * rollover validation and no per-series provider API calls from Home).
+ * Clicking a card simply navigates to the Series section.
+ */
+export function NextEpisodes({ allSeries }: NextEpisodesProps) {
+    const navigate = useNavigate();
+    const { t } = useLanguage();
+
+    const nextEpisodes = useMemo<NextEpisodeItem[]>(() => {
+        const progressMap = watchProgressService.getContinueWatching();
+        const items: NextEpisodeItem[] = [];
+
+        progressMap.forEach((progress, seriesId) => {
+            const series = allSeries.find(s => String(s.series_id) === seriesId);
+            if (!series) return;
+
+            items.push({
+                series,
+                nextSeason: progress.lastWatchedSeason,
+                nextEpisode: progress.lastWatchedEpisode + 1,
+                lastWatchedAt: progress.lastWatchedAt
+            });
+        });
+
+        items.sort((a, b) => b.lastWatchedAt - a.lastWatchedAt);
+        return items.slice(0, 12);
+    }, [allSeries]);
+
+    if (nextEpisodes.length === 0) {
+        return null;
+    }
+
+    return (
+        <div style={{ marginBottom: 32, position: 'relative' }}>
+            <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                marginBottom: 16
+            }}>
+                <h2 style={{
+                    fontSize: 18,
+                    fontWeight: 600,
+                    color: 'white',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                    margin: 0
+                }}>
+                    {`⏭️ ${t('home', 'nextEpisodes')}`}
+                    <span style={{
+                        fontSize: 12,
+                        color: 'rgba(255, 255, 255, 0.5)',
+                        fontWeight: 400
+                    }}>({nextEpisodes.length})</span>
+                </h2>
+            </div>
+
+            <div style={{
+                display: 'flex',
+                gap: 16,
+                overflowX: 'auto',
+                overflowY: 'visible',
+                paddingBottom: 20,
+                paddingTop: 4,
+                scrollBehavior: 'smooth',
+                scrollbarWidth: 'none',
+                msOverflowStyle: 'none'
+            }}>
+                {nextEpisodes.map(({ series, nextSeason, nextEpisode }) => (
+                    <div
+                        key={series.series_id}
+                        className="content-card"
+                        onClick={() => navigate('/dashboard/series')}
+                        style={{
+                            position: 'relative',
+                            minWidth: 160,
+                            maxWidth: 160,
+                            borderRadius: '12px',
+                            overflow: 'visible',
+                            background: 'rgba(255, 255, 255, 0.05)',
+                            border: '1px solid rgba(255, 255, 255, 0.1)',
+                            flexShrink: 0,
+                            cursor: 'pointer'
+                        }}
+                    >
+                        <div style={{
+                            aspectRatio: '2/3',
+                            borderRadius: '12px 12px 0 0',
+                            position: 'relative',
+                            background: 'linear-gradient(135deg, rgba(30,30,50,1) 0%, rgba(50,50,80,1) 100%)',
+                            overflow: 'hidden'
+                        }}>
+                            <LazyImage
+                                src={series.cover || series.stream_icon || ''}
+                                alt={series.name}
+                                style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    objectFit: 'cover'
+                                }}
+                                fallback={
+                                    <div style={{
+                                        width: '100%',
+                                        height: '100%',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        fontSize: 48
+                                    }}>
+                                        📺
+                                    </div>
+                                }
+                            />
+
+                            {/* Next episode badge */}
+                            <div style={{
+                                position: 'absolute',
+                                bottom: 8,
+                                left: 8,
+                                right: 8,
+                                background: 'rgba(0, 0, 0, 0.85)',
+                                borderRadius: 6,
+                                padding: '5px 8px',
+                                fontSize: 10,
+                                fontWeight: 600,
+                                color: 'white',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                gap: 6
+                            }}>
+                                <span style={{ color: '#34d399' }}>▶</span>
+                                <span>T{nextSeason}E{nextEpisode}</span>
+                            </div>
+                        </div>
+
+                        <div style={{
+                            padding: '10px 12px',
+                            background: 'linear-gradient(180deg, rgba(15, 15, 35, 0.9) 0%, rgba(15, 15, 35, 1) 100%)',
+                            borderRadius: '0 0 12px 12px'
+                        }}>
+                            <div style={{
+                                fontSize: 12,
+                                fontWeight: 600,
+                                color: 'white',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap'
+                            }}>{series.name}</div>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useLocation } from 'react-router-dom';
-import { Tv, Film, PlaySquare, Settings, LogOut, Bookmark, Home, Users, Heart, Check, Download } from 'lucide-react';
+import { Tv, Film, PlaySquare, Settings, LogOut, Bookmark, Home, Users, Heart, Check, Download, History } from 'lucide-react';
 import { profileService } from '../services/profileService';
 import { useState, useEffect } from 'react';
 import { UpdateNotificationBadge } from './UpdateNotificationBadge';
@@ -94,6 +94,7 @@ export function Sidebar() {
         { icon: Bookmark, label: t('nav', 'myList'), path: '/dashboard/watch-later', emoji: '🔖', gradient: 'linear-gradient(135deg, #10b981, #059669)' },
         { icon: Heart, label: t('nav', 'favorites'), path: '/dashboard/favorites', emoji: '❤️', gradient: 'linear-gradient(135deg, #ef4444, #dc2626)' },
         { icon: Download, label: t('nav', 'downloads'), path: '/dashboard/downloads', emoji: '📥', gradient: 'linear-gradient(135deg, #06b6d4, #0891b2)' },
+        { icon: History, label: t('nav', 'history'), path: '/dashboard/history', emoji: '🕘', gradient: 'linear-gradient(135deg, #14b8a6, #0d9488)' },
         { icon: Settings, label: t('nav', 'settings'), path: '/dashboard/settings', emoji: '⚙️', gradient: 'linear-gradient(135deg, #6b7280, #4b5563)' },
     ];
 

--- a/src/locales/ui/en.json
+++ b/src/locales/ui/en.json
@@ -14,6 +14,7 @@
     "myList": "My List",
     "favorites": "Favorites",
     "downloads": "Downloads",
+    "history": "History",
     "settings": "Settings",
     "switchProfile": "Switch Profile",
     "manageProfiles": "Manage Profiles",
@@ -469,6 +470,7 @@
     "goodAfternoon": "Good afternoon",
     "goodEvening": "Good evening",
     "continueWatching": "Continue Watching",
+    "nextEpisodes": "Next Episodes",
     "recommendations": "Recommended For You",
     "recentSeries": "Recent Series",
     "recentMovies": "Recent Movies",
@@ -570,5 +572,19 @@
     "exploreSeries": "Explore Series",
     "availableOffline": "is available offline!",
     "failedTo": "Failed to download"
+  },
+  "history": {
+    "title": "History",
+    "item": "watched item",
+    "items": "watched items",
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "movie": "Movie",
+    "serie": "Series",
+    "watched": "watched",
+    "emptyTitle": "No history yet",
+    "emptyText": "Movies and episodes you watch will appear here",
+    "exploreMovies": "Explore Movies",
+    "exploreSeries": "Explore Series"
   }
 }

--- a/src/locales/ui/es.json
+++ b/src/locales/ui/es.json
@@ -14,6 +14,7 @@
     "myList": "Mi Lista",
     "favorites": "Favoritos",
     "downloads": "Descargas",
+    "history": "Historial",
     "settings": "Configuración",
     "switchProfile": "Cambiar Perfil",
     "manageProfiles": "Gestionar Perfiles",
@@ -469,6 +470,7 @@
     "goodAfternoon": "Buenas tardes",
     "goodEvening": "Buenas noches",
     "continueWatching": "Seguir Viendo",
+    "nextEpisodes": "Próximos Episodios",
     "recommendations": "Recomendados Para Ti",
     "recentSeries": "Series Recientes",
     "recentMovies": "Películas Recientes",
@@ -570,5 +572,19 @@
     "exploreSeries": "Explorar Series",
     "availableOffline": "¡está disponible sin conexión!",
     "failedTo": "Error al descargar"
+  },
+  "history": {
+    "title": "Historial",
+    "item": "elemento visto",
+    "items": "elementos vistos",
+    "today": "Hoy",
+    "yesterday": "Ayer",
+    "movie": "Película",
+    "serie": "Serie",
+    "watched": "visto",
+    "emptyTitle": "Aún no hay historial",
+    "emptyText": "Las películas y episodios que veas aparecerán aquí",
+    "exploreMovies": "Explorar Películas",
+    "exploreSeries": "Explorar Series"
   }
 }

--- a/src/locales/ui/pt.json
+++ b/src/locales/ui/pt.json
@@ -14,6 +14,7 @@
     "myList": "Minha Lista",
     "favorites": "Favoritos",
     "downloads": "Baixados",
+    "history": "Histórico",
     "settings": "Configurações",
     "switchProfile": "Trocar Perfil",
     "manageProfiles": "Gerenciar Perfis",
@@ -469,6 +470,7 @@
     "goodAfternoon": "Boa tarde",
     "goodEvening": "Boa noite",
     "continueWatching": "Continue Assistindo",
+    "nextEpisodes": "Próximos Episódios",
     "recommendations": "Recomendados Para Você",
     "recentSeries": "Séries Recentes",
     "recentMovies": "Filmes Recentes",
@@ -570,5 +572,19 @@
     "exploreSeries": "Explorar Séries",
     "availableOffline": "está disponível offline!",
     "failedTo": "Falha ao baixar"
+  },
+  "history": {
+    "title": "Histórico",
+    "item": "item assistido",
+    "items": "itens assistidos",
+    "today": "Hoje",
+    "yesterday": "Ontem",
+    "movie": "Filme",
+    "serie": "Série",
+    "watched": "assistido",
+    "emptyTitle": "Nenhum histórico ainda",
+    "emptyText": "Os filmes e episódios que você assistir aparecerão aqui",
+    "exploreMovies": "Explorar Filmes",
+    "exploreSeries": "Explorar Séries"
   }
 }

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,0 +1,628 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { movieProgressService } from '../services/movieProgressService';
+import { watchProgressService } from '../services/watchProgressService';
+import { LazyImage } from '../components/LazyImage';
+import { useLanguage } from '../services/languageService';
+
+interface SeriesData {
+    series_id: number | string;
+    name: string;
+    cover?: string;
+}
+
+interface MovieData {
+    stream_id: number | string;
+    name: string;
+    stream_icon?: string;
+    cover?: string;
+}
+
+interface HistoryEntry {
+    key: string;
+    kind: 'movie' | 'episode';
+    title: string;
+    cover?: string;
+    watchedAt: number;
+    /** 0-100, only set when the item was NOT finished */
+    progress?: number;
+}
+
+interface DayGroup {
+    label: string;
+    entries: HistoryEntry[];
+}
+
+export function History() {
+    const navigate = useNavigate();
+    const { t } = useLanguage();
+
+    // Reference timestamp for the Today/Yesterday groups (stable per mount)
+    const [now] = useState(() => Date.now());
+
+    // Optional metadata (names/posters) resolved from the cached content lists.
+    // The progress services don't store posters or series names, so we enrich
+    // entries when the lists are available and fall back to placeholders.
+    const [seriesById, setSeriesById] = useState<Map<string, SeriesData>>(new Map());
+    const [moviesById, setMoviesById] = useState<Map<string, MovieData>>(new Map());
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const loadMetadata = async () => {
+            try {
+                const seriesResult = await window.ipcRenderer.invoke('streams:get-series');
+                if (!cancelled && seriesResult?.success && Array.isArray(seriesResult.data)) {
+                    const map = new Map<string, SeriesData>();
+                    seriesResult.data.forEach((s: SeriesData) => map.set(String(s.series_id), s));
+                    setSeriesById(map);
+                }
+
+                const moviesResult = await window.ipcRenderer.invoke('streams:get-vod');
+                if (!cancelled && moviesResult?.success && Array.isArray(moviesResult.data)) {
+                    const map = new Map<string, MovieData>();
+                    moviesResult.data.forEach((m: MovieData) => map.set(String(m.stream_id), m));
+                    setMoviesById(map);
+                }
+            } catch (error) {
+                console.error('Failed to load history metadata:', error);
+            }
+        };
+
+        loadMetadata();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const entries = useMemo<HistoryEntry[]>(() => {
+        const list: HistoryEntry[] = [];
+
+        movieProgressService.getHistory().forEach((movie) => {
+            const meta = moviesById.get(String(movie.movieId));
+            const finished = movie.completed || movie.progress >= 95;
+            list.push({
+                key: `movie-${movie.movieId}`,
+                kind: 'movie',
+                title: meta?.name || movie.movieName,
+                cover: meta?.cover || meta?.stream_icon,
+                watchedAt: movie.watchedAt,
+                progress: finished ? undefined : Math.max(1, Math.round(movie.progress))
+            });
+        });
+
+        watchProgressService.getEpisodeHistory().forEach((ep) => {
+            const meta = seriesById.get(String(ep.seriesId));
+            const seriesName = meta?.name || t('history', 'serie');
+            const progressPercent = !ep.completed && ep.currentTime && ep.duration
+                ? Math.max(1, Math.round((ep.currentTime / ep.duration) * 100))
+                : undefined;
+            list.push({
+                key: `episode-${ep.seriesId}-${ep.seasonNumber}-${ep.episodeNumber}`,
+                kind: 'episode',
+                title: `${seriesName} — T${ep.seasonNumber}E${ep.episodeNumber}`,
+                cover: meta?.cover,
+                watchedAt: ep.watchedAt,
+                progress: ep.completed ? undefined : progressPercent
+            });
+        });
+
+        list.sort((a, b) => b.watchedAt - a.watchedAt);
+        return list;
+    }, [moviesById, seriesById, t]);
+
+    const dayGroups = useMemo<DayGroup[]>(() => {
+        const startOfDay = (timestamp: number) => {
+            const d = new Date(timestamp);
+            d.setHours(0, 0, 0, 0);
+            return d.getTime();
+        };
+
+        const todayStart = startOfDay(now);
+        const yesterdayStart = todayStart - 24 * 60 * 60 * 1000;
+
+        const groups: DayGroup[] = [];
+        const groupByDay = new Map<number, DayGroup>();
+
+        entries.forEach((entry) => {
+            const dayStart = startOfDay(entry.watchedAt);
+            let group = groupByDay.get(dayStart);
+            if (!group) {
+                let label: string;
+                if (dayStart === todayStart) {
+                    label = t('history', 'today');
+                } else if (dayStart === yesterdayStart) {
+                    label = t('history', 'yesterday');
+                } else {
+                    label = new Date(dayStart).toLocaleDateString(t('home', 'locale'), {
+                        weekday: 'long',
+                        day: 'numeric',
+                        month: 'long'
+                    });
+                }
+                group = { label, entries: [] };
+                groupByDay.set(dayStart, group);
+                groups.push(group);
+            }
+            group.entries.push(entry);
+        });
+
+        return groups;
+    }, [entries, t, now]);
+
+    const formatWatchedTime = (timestamp: number) => {
+        return new Date(timestamp).toLocaleTimeString(t('home', 'locale'), {
+            hour: '2-digit',
+            minute: '2-digit'
+        });
+    };
+
+    const handleEntryClick = (entry: HistoryEntry) => {
+        navigate(entry.kind === 'movie' ? '/dashboard/vod' : '/dashboard/series');
+    };
+
+    const renderPosterPlaceholder = (entry: HistoryEntry) => (
+        <div className="history-poster-fallback">
+            <span>{entry.title.trim().charAt(0).toUpperCase() || '🎬'}</span>
+        </div>
+    );
+
+    // Empty State
+    if (entries.length === 0) {
+        return (
+            <>
+                <style>{historyStyles}</style>
+                <div className="history-page">
+                    <div className="history-backdrop" />
+                    <div className="history-empty-state">
+                        <div className="history-empty-icon-container">
+                            <div className="history-empty-icon">🕘</div>
+                            <div className="history-empty-icon-glow" />
+                        </div>
+                        <h2 className="history-empty-title">{t('history', 'emptyTitle')}</h2>
+                        <p className="history-empty-text">{t('history', 'emptyText')}</p>
+                        <div className="history-empty-suggestions">
+                            <button
+                                className="history-suggestion-btn"
+                                onClick={() => navigate('/dashboard/vod')}
+                            >
+                                <span>🎬</span>
+                                <span>{t('history', 'exploreMovies')}</span>
+                            </button>
+                            <button
+                                className="history-suggestion-btn"
+                                onClick={() => navigate('/dashboard/series')}
+                            >
+                                <span>📺</span>
+                                <span>{t('history', 'exploreSeries')}</span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </>
+        );
+    }
+
+    return (
+        <>
+            <style>{historyStyles}</style>
+            <div className="history-page">
+                <div className="history-backdrop" />
+
+                {/* Header */}
+                <header className="history-header">
+                    <div className="history-header-title">
+                        <div className="history-title-icon">🕘</div>
+                        <div>
+                            <h1>{t('history', 'title')}</h1>
+                            <p className="history-subtitle">
+                                {entries.length} {entries.length === 1 ? t('history', 'item') : t('history', 'items')}
+                            </p>
+                        </div>
+                    </div>
+                </header>
+
+                {/* Day groups */}
+                <div className="history-content">
+                    {dayGroups.map((group, groupIndex) => (
+                        <section key={group.label} className="history-day-group">
+                            <h2 className="history-day-label">{group.label}</h2>
+                            <div className="history-rows">
+                                {group.entries.map((entry, index) => (
+                                    <div
+                                        key={entry.key}
+                                        className="history-row"
+                                        style={{ animationDelay: `${Math.min(groupIndex * 4 + index, 20) * 0.04}s` }}
+                                        onClick={() => handleEntryClick(entry)}
+                                    >
+                                        <div className="history-poster">
+                                            {entry.cover ? (
+                                                <LazyImage
+                                                    src={entry.cover.startsWith('http') ? entry.cover : `https://${entry.cover}`}
+                                                    alt={entry.title}
+                                                    style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                                                    fallback={renderPosterPlaceholder(entry)}
+                                                />
+                                            ) : (
+                                                renderPosterPlaceholder(entry)
+                                            )}
+                                        </div>
+
+                                        <div className="history-row-info">
+                                            <span className="history-row-title">{entry.title}</span>
+                                            <span className="history-row-meta">
+                                                <span className={`history-kind-badge ${entry.kind}`}>
+                                                    {entry.kind === 'movie' ? t('history', 'movie') : t('history', 'serie')}
+                                                </span>
+                                                {entry.progress !== undefined && (
+                                                    <span className="history-progress-badge">
+                                                        {entry.progress}% {t('history', 'watched')}
+                                                    </span>
+                                                )}
+                                            </span>
+                                        </div>
+
+                                        <div className="history-row-time">
+                                            {formatWatchedTime(entry.watchedAt)}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </section>
+                    ))}
+                </div>
+            </div>
+        </>
+    );
+}
+
+// CSS Styles
+const historyStyles = `
+/* Page Container */
+.history-page {
+    position: relative;
+    min-height: 100vh;
+    padding: 32px;
+    overflow-x: hidden;
+    background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+}
+
+/* Animated Backdrop */
+.history-backdrop {
+    position: fixed;
+    inset: 0;
+    background:
+        radial-gradient(ellipse at 20% 20%, rgba(168, 85, 247, 0.15) 0%, transparent 50%),
+        radial-gradient(ellipse at 80% 80%, rgba(236, 72, 153, 0.1) 0%, transparent 50%),
+        radial-gradient(ellipse at 50% 50%, rgba(59, 130, 246, 0.05) 0%, transparent 70%);
+    pointer-events: none;
+    z-index: 0;
+    animation: historyBackdropPulse 8s ease-in-out infinite;
+}
+
+@keyframes historyBackdropPulse {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 0.8; }
+}
+
+/* Header */
+.history-header {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 32px;
+    animation: historyFadeInDown 0.5s ease;
+}
+
+@keyframes historyFadeInDown {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.history-header-title {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+
+.history-title-icon {
+    font-size: 48px;
+    animation: historyIconBounce 2s ease-in-out infinite;
+}
+
+@keyframes historyIconBounce {
+    0%, 100% { transform: translateY(0) rotate(0deg); }
+    25% { transform: translateY(-5px) rotate(-5deg); }
+    75% { transform: translateY(-5px) rotate(5deg); }
+}
+
+.history-header-title h1 {
+    font-size: 42px;
+    font-weight: 800;
+    color: white;
+    letter-spacing: -0.02em;
+    background: linear-gradient(135deg, #fff 0%, #c4b5fd 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.history-subtitle {
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 14px;
+    margin-top: 4px;
+}
+
+/* Content */
+.history-content {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.history-day-label {
+    font-size: 18px;
+    font-weight: 700;
+    color: #c4b5fd;
+    margin: 0 0 14px 0;
+    text-transform: capitalize;
+}
+
+.history-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+/* Row */
+.history-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 10px 14px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 14px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    animation: historyRowSlideIn 0.4s ease backwards;
+}
+
+@keyframes historyRowSlideIn {
+    from {
+        opacity: 0;
+        transform: translateY(15px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.history-row:hover {
+    background: rgba(168, 85, 247, 0.1);
+    border-color: rgba(168, 85, 247, 0.4);
+    transform: translateX(4px);
+}
+
+/* Poster thumb */
+.history-poster {
+    width: 48px;
+    height: 72px;
+    flex-shrink: 0;
+    border-radius: 8px;
+    overflow: hidden;
+    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
+}
+
+.history-poster-fallback {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, rgba(168, 85, 247, 0.3), rgba(236, 72, 153, 0.3));
+    color: white;
+    font-size: 22px;
+    font-weight: 700;
+}
+
+/* Row info */
+.history-row-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.history-row-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: white;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.history-row:hover .history-row-title {
+    color: #c4b5fd;
+}
+
+.history-row-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.history-kind-badge {
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 700;
+    color: white;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.history-kind-badge.movie {
+    background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+}
+
+.history-kind-badge.episode {
+    background: linear-gradient(135deg, #a855f7 0%, #9333ea 100%);
+}
+
+.history-progress-badge {
+    padding: 3px 8px;
+    background: rgba(16, 185, 129, 0.2);
+    border: 1px solid rgba(16, 185, 129, 0.4);
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 600;
+    color: #34d399;
+}
+
+/* Watched time */
+.history-row-time {
+    flex-shrink: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.5);
+    font-variant-numeric: tabular-nums;
+}
+
+/* Empty State */
+.history-empty-state {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 80vh;
+    text-align: center;
+    animation: historyFadeIn 0.6s ease;
+}
+
+@keyframes historyFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.history-empty-icon-container {
+    position: relative;
+    margin-bottom: 32px;
+}
+
+.history-empty-icon {
+    font-size: 100px;
+    animation: historyFloatIcon 3s ease-in-out infinite;
+}
+
+@keyframes historyFloatIcon {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-15px); }
+}
+
+.history-empty-icon-glow {
+    position: absolute;
+    bottom: -20px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 80px;
+    height: 20px;
+    background: radial-gradient(ellipse, rgba(168, 85, 247, 0.4) 0%, transparent 70%);
+    border-radius: 50%;
+    animation: historyGlowPulse 3s ease-in-out infinite;
+}
+
+@keyframes historyGlowPulse {
+    0%, 100% { opacity: 0.6; transform: translateX(-50%) scale(1); }
+    50% { opacity: 1; transform: translateX(-50%) scale(1.2); }
+}
+
+.history-empty-title {
+    font-size: 32px;
+    font-weight: 700;
+    color: white;
+    margin-bottom: 12px;
+}
+
+.history-empty-text {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 16px;
+    max-width: 400px;
+    line-height: 1.6;
+    margin-bottom: 32px;
+}
+
+.history-empty-suggestions {
+    display: flex;
+    gap: 16px;
+}
+
+.history-suggestion-btn {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 16px 28px;
+    background: linear-gradient(135deg, rgba(168, 85, 247, 0.15) 0%, rgba(236, 72, 153, 0.15) 100%);
+    border: 1px solid rgba(168, 85, 247, 0.3);
+    color: white;
+    font-size: 15px;
+    font-weight: 600;
+    border-radius: 14px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.history-suggestion-btn:hover {
+    background: linear-gradient(135deg, rgba(168, 85, 247, 0.25) 0%, rgba(236, 72, 153, 0.25) 100%);
+    border-color: rgba(168, 85, 247, 0.5);
+    transform: translateY(-3px);
+    box-shadow: 0 10px 30px rgba(168, 85, 247, 0.2);
+}
+
+.history-suggestion-btn span:first-child {
+    font-size: 20px;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+    .history-page {
+        padding: 20px;
+    }
+
+    .history-header-title h1 {
+        font-size: 32px;
+    }
+
+    .history-title-icon {
+        font-size: 36px;
+    }
+
+    .history-row-time {
+        font-size: 12px;
+    }
+
+    .history-empty-suggestions {
+        flex-direction: column;
+        width: 100%;
+    }
+
+    .history-suggestion-btn {
+        justify-content: center;
+    }
+}
+`;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { watchProgressService, type SeriesProgress } from '../services/watchProgressService';
 import { movieProgressService } from '../services/movieProgressService';
 import { ContentDetailModal } from '../components/ContentDetailModal';
+import { NextEpisodes } from '../components/NextEpisodes';
 import AsyncVideoPlayer from '../components/AsyncVideoPlayer';
 import { ResumeModal } from '../components/ResumeModal';
 import { profileService } from '../services/profileService';
@@ -1427,6 +1428,9 @@ export function Home() {
                     showProgress={true}
                     sectionIndex={0}
                 />
+
+                {/* Next Episodes Section */}
+                <NextEpisodes allSeries={allSeries} />
 
                 {/* Recommendations Section */}
                 < ContentSection

--- a/src/services/movieProgressService.ts
+++ b/src/services/movieProgressService.ts
@@ -1,6 +1,6 @@
 import { profileService } from './profileService';
 
-interface MovieProgress {
+export interface MovieProgress {
     movieId: string;
     movieName: string;
     profileId: string;
@@ -103,6 +103,14 @@ class MovieProgressService {
                     (p.progress >= 95 || p.completed)
             )
             .map((p) => p.movieId);
+    }
+
+    // Read-only watch history for the active profile (every movie with progress)
+    getHistory(): MovieProgress[] {
+        const activeProfile = profileService.getActiveProfile();
+        if (!activeProfile) return [];
+
+        return this.getProgress().filter((p) => p.profileId === activeProfile.id);
     }
 
     // Clear movie progress

--- a/src/services/watchProgressService.ts
+++ b/src/services/watchProgressService.ts
@@ -1,6 +1,6 @@
 import { profileService } from './profileService';
 
-interface EpisodeProgress {
+export interface EpisodeProgress {
     seriesId: string;
     seasonNumber: number;
     episodeNumber: number;
@@ -218,6 +218,14 @@ class WatchProgressService {
         });
 
         return seriesMap;
+    }
+
+    // Read-only watch history for the active profile (every episode with progress)
+    getEpisodeHistory(): EpisodeProgress[] {
+        const activeProfile = profileService.getActiveProfile();
+        if (!activeProfile) return [];
+
+        return this.getProgress().filter((p) => p.profileId === activeProfile.id);
     }
 
     // Get last watched episode for a series (for auto-selection)


### PR DESCRIPTION
## Summary

Round 6, part 2a — first pair of product features.

### 🕘 Histórico (new page + sidebar entry)
Movies and episodes merged newest-first, grouped by day (Hoje/Ontem/date), with poster thumbs, watch time and a progress badge for unfinished items. Names/posters resolve from the already-loaded content lists — zero extra provider calls. Themed empty state with explore shortcuts (screenshot-verified in the running app).

### ▶ Próximos episódios (Home row)
Below Continue Watching: one card per in-progress series showing the next episode badge (optimistic `lastWatched+1` — episode counts aren't stored locally; documented). Hidden when empty.

Known UX simplifications (by design, documented in code): rows navigate to the section pages (no item deep-linking yet — separate feature), and the next-episode badge doesn't validate against season length.

## Verification
- `tsc -b` clean · `eslint` clean · `vitest` 53/53 · `vite build` OK (History as lazy chunk)
- Visual: sidebar icon + empty state confirmed in the live app
- Manual suggestion: watch a few minutes of a movie + an episode, then check Histórico ordering and the next-episode card