### PR TITLE
feat: grade de EPG completa (Guia de TV) + fix CORS nas fontes mi.tv/meuguia

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect, lazy, Suspense } from 'react';
 
 const Home = lazy(() => import('./pages/Home').then(m => ({ default: m.Home })));
 const LiveTV = lazy(() => import('./pages/LiveTV').then(m => ({ default: m.LiveTV })));
+const EpgGuide = lazy(() => import('./pages/EpgGuide').then(m => ({ default: m.EpgGuide })));
 const VOD = lazy(() => import('./pages/VOD').then(m => ({ default: m.VOD })));
 const Series = lazy(() => import('./pages/Series').then(m => ({ default: m.Series })));
 const Settings = lazy(() => import('./pages/Settings').then(m => ({ default: m.Settings })));
@@ -111,6 +112,7 @@ function App() {
               <Route index element={<Navigate to="home" replace />} />
               <Route path="home" element={<Home />} />
               <Route path="live" element={<LiveTV />} />
+              <Route path="guide" element={<EpgGuide />} />
               <Route path="vod" element={<VOD />} />
               <Route path="series" element={<Series />} />
               <Route path="watch-later" element={<WatchLater />} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useLocation } from 'react-router-dom';
-import { Tv, Film, PlaySquare, Settings, LogOut, Bookmark, Home, Users, Heart, Check, Download, History, Search } from 'lucide-react';
+import { Tv, Film, PlaySquare, Settings, LogOut, Bookmark, Home, Users, Heart, Check, Download, History, Search, CalendarRange } from 'lucide-react';
 import { GLOBAL_SEARCH_OPEN_EVENT } from './GlobalSearch';
 import { profileService } from '../services/profileService';
 import { useState, useEffect } from 'react';
@@ -90,6 +90,7 @@ export function Sidebar() {
     const menuItems = [
         { icon: Home, label: t('nav', 'home'), path: '/dashboard/home', emoji: '🏠', gradient: 'linear-gradient(135deg, #f59e0b, #d97706)' },
         { icon: Tv, label: t('nav', 'liveTV'), path: '/dashboard/live', emoji: '📺', gradient: 'linear-gradient(135deg, #a855f7, #7c3aed)' },
+        { icon: CalendarRange, label: t('nav', 'guide'), path: '/dashboard/guide', emoji: '🗓️', gradient: 'linear-gradient(135deg, #8b5cf6, #6d28d9)' },
         { icon: Film, label: t('nav', 'movies'), path: '/dashboard/vod', emoji: '🎬', gradient: 'linear-gradient(135deg, #3b82f6, #1d4ed8)' },
         { icon: PlaySquare, label: t('nav', 'series'), path: '/dashboard/series', emoji: '📺', gradient: 'linear-gradient(135deg, #ec4899, #db2777)' },
         { icon: Bookmark, label: t('nav', 'myList'), path: '/dashboard/watch-later', emoji: '🔖', gradient: 'linear-gradient(135deg, #10b981, #059669)' },

--- a/src/locales/ui/en.json
+++ b/src/locales/ui/en.json
@@ -9,6 +9,7 @@
     "about": "About",
     "home": "Home",
     "liveTV": "Live TV",
+    "guide": "TV Guide",
     "movies": "Movies",
     "series": "Series",
     "myList": "My List",
@@ -586,6 +587,17 @@
     "emptyText": "Movies and episodes you watch will appear here",
     "exploreMovies": "Explore Movies",
     "exploreSeries": "Explore Series"
+  },
+  "guide": {
+    "title": "TV Guide",
+    "category": "Category",
+    "channels": "channels",
+    "channelsHeader": "Channels",
+    "loading": "Loading guide...",
+    "loadingEpg": "Loading...",
+    "noEpg": "No program data",
+    "noChannels": "No channels in this category",
+    "now": "Now"
   },
   "search": {
     "placeholder": "Search channels, movies and series...",

--- a/src/locales/ui/es.json
+++ b/src/locales/ui/es.json
@@ -9,6 +9,7 @@
     "about": "Acerca de",
     "home": "Inicio",
     "liveTV": "TV en Vivo",
+    "guide": "Guía de TV",
     "movies": "Películas",
     "series": "Series",
     "myList": "Mi Lista",
@@ -586,6 +587,17 @@
     "emptyText": "Las películas y episodios que veas aparecerán aquí",
     "exploreMovies": "Explorar Películas",
     "exploreSeries": "Explorar Series"
+  },
+  "guide": {
+    "title": "Guía de TV",
+    "category": "Categoría",
+    "channels": "canales",
+    "channelsHeader": "Canales",
+    "loading": "Cargando guía...",
+    "loadingEpg": "Cargando...",
+    "noEpg": "Sin programación",
+    "noChannels": "No hay canales en esta categoría",
+    "now": "Ahora"
   },
   "search": {
     "placeholder": "Buscar canales, películas y series...",

--- a/src/locales/ui/pt.json
+++ b/src/locales/ui/pt.json
@@ -9,6 +9,7 @@
     "about": "Sobre",
     "home": "Início",
     "liveTV": "TV ao Vivo",
+    "guide": "Guia de TV",
     "movies": "Filmes",
     "series": "Séries",
     "myList": "Minha Lista",
@@ -586,6 +587,17 @@
     "emptyText": "Os filmes e episódios que você assistir aparecerão aqui",
     "exploreMovies": "Explorar Filmes",
     "exploreSeries": "Explorar Séries"
+  },
+  "guide": {
+    "title": "Guia de TV",
+    "category": "Categoria",
+    "channels": "canais",
+    "channelsHeader": "Canais",
+    "loading": "Carregando guia...",
+    "loadingEpg": "Carregando...",
+    "noEpg": "Sem programação",
+    "noChannels": "Nenhum canal nesta categoria",
+    "now": "Agora"
   },
   "search": {
     "placeholder": "Buscar canais, filmes e séries...",

--- a/src/pages/EpgGuide.tsx
+++ b/src/pages/EpgGuide.tsx
@@ -1,0 +1,578 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import AsyncVideoPlayer from '../components/AsyncVideoPlayer';
+import { LazyImage } from '../components/LazyImage';
+import { epgService } from '../services/epgService';
+import { profileService } from '../services/profileService';
+import { parentalService } from '../services/parentalService';
+import { useLanguage } from '../services/languageService';
+import {
+    getGuideWindow,
+    buildTimeTicks,
+    programToBlock,
+    nowOffsetPx,
+    isAiringNow,
+    formatGuideTime,
+    PX_PER_HALF_HOUR,
+    WINDOW_HALF_HOURS
+} from '../utils/epgGuide';
+
+interface LiveStream {
+    num: number;
+    name: string;
+    stream_type: string;
+    stream_id: number;
+    stream_icon: string;
+    epg_channel_id: string;
+    added: string;
+    category_id: string;
+    custom_sid: string;
+    tv_archive: number;
+    direct_source: string;
+    tv_archive_duration: number;
+}
+
+interface LiveCategory {
+    category_id: string;
+    category_name: string;
+    parent_id: number;
+}
+
+interface EPGProgram {
+    id: string;
+    start: string;
+    end: string;
+    title: string;
+    description?: string;
+    channel_id: string;
+}
+
+// Same gating patterns LiveTV uses (kids whitelist / parental blocklist)
+const KIDS_ALLOWED_PATTERNS = ['infantil', 'infantis', 'kids', 'criança', '24 horas infantis'];
+const BLOCKED_CATEGORY_PATTERNS = ['adult', 'adulto', '+18', '18+', 'xxx', 'erotic', 'erótico'];
+
+const CHANNEL_COL_WIDTH = 220;
+const ROW_HEIGHT = 64;
+const HEADER_HEIGHT = 40;
+const TIMELINE_WIDTH = WINDOW_HALF_HOURS * PX_PER_HALF_HOUR;
+const INITIAL_ROWS = 25;
+const ROWS_INCREMENT = 25;
+const MAX_CONCURRENT_EPG = 4;
+
+// ---------------------------------------------------------------------------
+// Module-level EPG cache + concurrency limiter (persists across page visits)
+// ---------------------------------------------------------------------------
+const epgCache = new Map<string, EPGProgram[]>();
+const epgPending = new Map<string, Promise<EPGProgram[]>>();
+let epgInFlight = 0;
+const epgWaiters: Array<() => void> = [];
+
+async function acquireEpgSlot(): Promise<void> {
+    if (epgInFlight >= MAX_CONCURRENT_EPG) {
+        await new Promise<void>(resolve => epgWaiters.push(resolve));
+    }
+    epgInFlight++;
+}
+
+function releaseEpgSlot(): void {
+    epgInFlight--;
+    const next = epgWaiters.shift();
+    if (next) next();
+}
+
+function loadChannelEpg(channel: LiveStream): Promise<EPGProgram[]> {
+    const key = channel.name;
+    const cached = epgCache.get(key);
+    if (cached) return Promise.resolve(cached);
+
+    let pending = epgPending.get(key);
+    if (!pending) {
+        pending = (async () => {
+            await acquireEpgSlot();
+            try {
+                const programs = await epgService.fetchChannelEPG(channel.epg_channel_id || '', channel.name);
+                epgCache.set(key, programs);
+                return programs;
+            } catch {
+                epgCache.set(key, []);
+                return [];
+            } finally {
+                releaseEpgSlot();
+                epgPending.delete(key);
+            }
+        })();
+        epgPending.set(key, pending);
+    }
+    return pending;
+}
+
+export function EpgGuide() {
+    const [streams, setStreams] = useState<LiveStream[]>([]);
+    const [categories, setCategories] = useState<LiveCategory[]>([]);
+    const [selectedCategory, setSelectedCategory] = useState<string>('');
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+    const [visibleRows, setVisibleRows] = useState(INITIAL_ROWS);
+    const [epgByChannel, setEpgByChannel] = useState<Record<string, EPGProgram[] | undefined>>({});
+    const [now, setNow] = useState(() => Date.now());
+    const [playingChannel, setPlayingChannel] = useState<LiveStream | null>(null);
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const isKidsProfile = profileService.getActiveProfile()?.isKids || false;
+    const { t } = useLanguage();
+
+    // Fixed window for the page's lifetime; the "now" line moves within it.
+    const guideWindow = useMemo(() => getGuideWindow(), []);
+    const ticks = useMemo(() => buildTimeTicks(guideWindow), [guideWindow]);
+
+    // "Now" line updates every minute
+    useEffect(() => {
+        const id = setInterval(() => setNow(Date.now()), 60000);
+        return () => clearInterval(id);
+    }, []);
+
+    // Load channels + categories, applying the same gating as LiveTV
+    useEffect(() => {
+        let cancelled = false;
+        const load = async () => {
+            setLoading(true);
+            setError('');
+            try {
+                const [streamsResult, categoriesResult] = await Promise.all([
+                    window.ipcRenderer.invoke('streams:get-live'),
+                    window.ipcRenderer.invoke('categories:get-live')
+                ]);
+                if (cancelled) return;
+
+                if (!streamsResult.success) {
+                    setError(streamsResult.error || 'Failed to load channels');
+                    return;
+                }
+
+                const allCategories: LiveCategory[] = categoriesResult?.success ? (categoriesResult.data || []) : [];
+                const parentalConfig = parentalService.getConfig();
+                const blockParental = parentalConfig.enabled && parentalConfig.blockAdultCategories && !parentalService.isSessionUnlocked();
+
+                const allowedCategories = allCategories.filter(cat => {
+                    const lowerName = cat.category_name.toLowerCase();
+                    if (blockParental && BLOCKED_CATEGORY_PATTERNS.some(p => lowerName.includes(p))) return false;
+                    if (isKidsProfile && !KIDS_ALLOWED_PATTERNS.some(p => lowerName.includes(p))) return false;
+                    return true;
+                });
+                const allowedIds = new Set(allowedCategories.map(c => c.category_id));
+
+                const allowedStreams = (streamsResult.data || []).filter(
+                    (s: LiveStream) => allowedIds.has(s.category_id)
+                );
+
+                setCategories(allowedCategories);
+                setStreams(allowedStreams);
+                setSelectedCategory(prev =>
+                    prev && allowedIds.has(prev) ? prev : (allowedCategories[0]?.category_id || '')
+                );
+            } catch (err: unknown) {
+                if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to connect to server');
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+        void load();
+        return () => { cancelled = true; };
+    }, [isKidsProfile]);
+
+    // Channels of the selected category (only these render rows)
+    const categoryStreams = useMemo(
+        () => streams.filter(s => s.category_id === selectedCategory),
+        [streams, selectedCategory]
+    );
+    const renderedStreams = useMemo(
+        () => categoryStreams.slice(0, visibleRows),
+        [categoryStreams, visibleRows]
+    );
+
+    // Reset windowed rows when category changes
+    useEffect(() => {
+        setVisibleRows(INITIAL_ROWS);
+        if (scrollRef.current) scrollRef.current.scrollTop = 0;
+    }, [selectedCategory]);
+
+    // Lazy EPG fetch for the rendered rows (concurrency-limited, module-cached)
+    useEffect(() => {
+        let cancelled = false;
+        for (const channel of renderedStreams) {
+            const cached = epgCache.get(channel.name);
+            if (cached) {
+                if (epgByChannel[channel.name] === undefined) {
+                    setEpgByChannel(prev =>
+                        prev[channel.name] === undefined ? { ...prev, [channel.name]: cached } : prev
+                    );
+                }
+                continue;
+            }
+            void loadChannelEpg(channel).then(programs => {
+                if (!cancelled) {
+                    setEpgByChannel(prev => ({ ...prev, [channel.name]: programs }));
+                }
+            });
+        }
+        return () => { cancelled = true; };
+        // epgByChannel intentionally omitted: it is only written here, and
+        // including it would re-run the loop on every fetch resolution.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [renderedStreams]);
+
+    // Load more rows when scrolling near the bottom
+    const handleScroll = useCallback(() => {
+        const el = scrollRef.current;
+        if (!el) return;
+        if (el.scrollTop + el.clientHeight >= el.scrollHeight - ROW_HEIGHT * 4) {
+            setVisibleRows(prev =>
+                prev < categoryStreams.length ? Math.min(prev + ROWS_INCREMENT, categoryStreams.length) : prev
+            );
+        }
+    }, [categoryStreams.length]);
+
+    const buildLiveStreamUrl = async (channel: LiveStream): Promise<string> => {
+        const result = await window.ipcRenderer.invoke('auth:get-credentials');
+        if (result.success) {
+            const { url, username, password } = result.credentials;
+            return `${url}/live/${username}/${password}/${channel.stream_id}.m3u8`;
+        }
+        throw new Error('Credenciais não encontradas');
+    };
+
+    const nowLineLeft = nowOffsetPx(now, guideWindow);
+
+    if (loading) {
+        return (
+            <div style={pageWrapperStyle}>
+                <div style={backdropStyle} />
+                <div style={{ position: 'relative', zIndex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: '16px' }}>
+                    <div style={{
+                        width: '48px', height: '48px', borderRadius: '50%',
+                        border: '3px solid rgba(168, 85, 247, 0.2)', borderTopColor: '#a855f7',
+                        animation: 'guideSpin 0.8s linear infinite'
+                    }} />
+                    <span style={{ color: 'rgba(255,255,255,0.7)', fontSize: '15px', fontWeight: 500 }}>
+                        {t('guide', 'loading')}
+                    </span>
+                    <style>{`@keyframes guideSpin { to { transform: rotate(360deg); } }`}</style>
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div style={pageWrapperStyle}>
+                <div style={backdropStyle} />
+                <div style={{ position: 'relative', zIndex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: '12px' }}>
+                    <span style={{ fontSize: '40px' }}>📡</span>
+                    <p style={{ color: '#f87171', fontSize: '14px', maxWidth: '420px', textAlign: 'center' }}>{error}</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div style={pageWrapperStyle}>
+            <div style={backdropStyle} />
+            <style>{`
+                .guide-scroll::-webkit-scrollbar { width: 6px; height: 6px; }
+                .guide-scroll::-webkit-scrollbar-track { background: transparent; }
+                .guide-scroll::-webkit-scrollbar-thumb {
+                    background: linear-gradient(180deg, #a855f7, #ec4899);
+                    border-radius: 3px;
+                }
+                .guide-program:hover { filter: brightness(1.25); }
+                .guide-channel-cell:hover { background: rgba(168, 85, 247, 0.12) !important; }
+            `}</style>
+
+            {/* Header: title + category selector */}
+            <div style={{
+                position: 'relative', zIndex: 2,
+                display: 'flex', alignItems: 'center', gap: '20px', flexWrap: 'wrap',
+                padding: '20px 24px 16px 60px'
+            }}>
+                <h1 style={{
+                    fontSize: '24px', fontWeight: 800, margin: 0,
+                    background: 'linear-gradient(135deg, #ffffff 0%, #c4b5fd 100%)',
+                    WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent'
+                }}>
+                    {t('guide', 'title')}
+                </h1>
+                <select
+                    value={selectedCategory}
+                    onChange={(e) => setSelectedCategory(e.target.value)}
+                    aria-label={t('guide', 'category')}
+                    style={{
+                        background: 'rgba(31, 41, 55, 0.9)',
+                        color: 'white',
+                        border: '1px solid rgba(168, 85, 247, 0.4)',
+                        borderRadius: '10px',
+                        padding: '8px 14px',
+                        fontSize: '14px',
+                        fontWeight: 500,
+                        cursor: 'pointer',
+                        outline: 'none',
+                        maxWidth: '320px'
+                    }}
+                >
+                    {categories.map(cat => (
+                        <option key={cat.category_id} value={cat.category_id}>
+                            {cat.category_name}
+                        </option>
+                    ))}
+                </select>
+                <span style={{ fontSize: '13px', color: 'rgba(148, 163, 184, 0.9)' }}>
+                    {categoryStreams.length} {t('guide', 'channels')}
+                </span>
+            </div>
+
+            {/* Guide grid */}
+            <div
+                ref={scrollRef}
+                onScroll={handleScroll}
+                className="guide-scroll"
+                style={{
+                    position: 'relative', zIndex: 1,
+                    flex: 1, overflow: 'auto',
+                    marginLeft: '60px', marginRight: '12px', marginBottom: '12px',
+                    border: '1px solid rgba(255, 255, 255, 0.08)',
+                    borderRadius: '14px',
+                    background: 'rgba(15, 15, 26, 0.6)'
+                }}
+            >
+                {categoryStreams.length === 0 ? (
+                    <div style={{ padding: '60px 20px', textAlign: 'center', color: 'rgba(156, 163, 175, 1)' }}>
+                        <div style={{ fontSize: '48px', marginBottom: '12px', opacity: 0.5 }}>📺</div>
+                        {t('guide', 'noChannels')}
+                    </div>
+                ) : (
+                    <div style={{ position: 'relative', width: CHANNEL_COL_WIDTH + TIMELINE_WIDTH, minWidth: '100%' }}>
+                        {/* Sticky time header */}
+                        <div style={{
+                            position: 'sticky', top: 0, zIndex: 30,
+                            display: 'flex', height: HEADER_HEIGHT,
+                            background: 'linear-gradient(180deg, #1a1a2e 0%, #16162a 100%)',
+                            borderBottom: '1px solid rgba(168, 85, 247, 0.25)'
+                        }}>
+                            <div style={{
+                                position: 'sticky', left: 0, zIndex: 31,
+                                width: CHANNEL_COL_WIDTH, minWidth: CHANNEL_COL_WIDTH,
+                                display: 'flex', alignItems: 'center', paddingLeft: '14px',
+                                background: 'linear-gradient(180deg, #1a1a2e 0%, #16162a 100%)',
+                                borderRight: '1px solid rgba(255, 255, 255, 0.08)',
+                                fontSize: '11px', fontWeight: 700, letterSpacing: '1px',
+                                textTransform: 'uppercase', color: 'rgba(196, 181, 253, 0.9)'
+                            }}>
+                                {t('guide', 'channelsHeader')}
+                            </div>
+                            {ticks.map(tick => (
+                                <div key={tick} style={{
+                                    width: PX_PER_HALF_HOUR, minWidth: PX_PER_HALF_HOUR,
+                                    display: 'flex', alignItems: 'center', paddingLeft: '8px',
+                                    borderLeft: '1px solid rgba(255, 255, 255, 0.06)',
+                                    fontSize: '12px', fontWeight: 600, color: 'rgba(203, 213, 225, 0.9)'
+                                }}>
+                                    {formatGuideTime(tick)}
+                                </div>
+                            ))}
+                        </div>
+
+                        {/* Channel rows */}
+                        <div style={{ position: 'relative' }}>
+                            {/* "Now" vertical line over all rows */}
+                            {nowLineLeft !== null && (
+                                <div style={{
+                                    position: 'absolute',
+                                    left: CHANNEL_COL_WIDTH + nowLineLeft,
+                                    top: 0, bottom: 0, width: '2px',
+                                    background: 'linear-gradient(180deg, #a855f7, #ec4899)',
+                                    boxShadow: '0 0 8px rgba(168, 85, 247, 0.7)',
+                                    zIndex: 20, pointerEvents: 'none'
+                                }}>
+                                    <span style={{
+                                        position: 'absolute', top: '2px', left: '4px',
+                                        fontSize: '9px', fontWeight: 700, letterSpacing: '0.5px',
+                                        textTransform: 'uppercase', color: '#c4b5fd', whiteSpace: 'nowrap'
+                                    }}>
+                                        {t('guide', 'now')}
+                                    </span>
+                                </div>
+                            )}
+
+                            {renderedStreams.map(channel => {
+                                const programs = epgByChannel[channel.name];
+                                return (
+                                    <div key={channel.stream_id} style={{
+                                        display: 'flex', height: ROW_HEIGHT,
+                                        borderBottom: '1px solid rgba(255, 255, 255, 0.05)'
+                                    }}>
+                                        {/* Sticky channel cell */}
+                                        <div
+                                            className="guide-channel-cell"
+                                            onClick={() => setPlayingChannel(channel)}
+                                            title={channel.name}
+                                            style={{
+                                                position: 'sticky', left: 0, zIndex: 10,
+                                                width: CHANNEL_COL_WIDTH, minWidth: CHANNEL_COL_WIDTH,
+                                                display: 'flex', alignItems: 'center', gap: '10px',
+                                                padding: '0 12px',
+                                                background: 'linear-gradient(90deg, #14142299 0%, #14142299 100%), #0f0f1a',
+                                                borderRight: '1px solid rgba(255, 255, 255, 0.08)',
+                                                cursor: 'pointer',
+                                                transition: 'background 0.2s ease'
+                                            }}
+                                        >
+                                            <div style={{
+                                                width: '40px', height: '40px', minWidth: '40px',
+                                                borderRadius: '8px', overflow: 'hidden',
+                                                background: 'linear-gradient(145deg, rgba(55, 65, 81, 1) 0%, rgba(31, 41, 55, 1) 100%)',
+                                                display: 'flex', alignItems: 'center', justifyContent: 'center'
+                                            }}>
+                                                {channel.stream_icon ? (
+                                                    <LazyImage
+                                                        src={channel.stream_icon}
+                                                        alt=""
+                                                        style={{ width: '100%', height: '100%', objectFit: 'contain', padding: '3px' }}
+                                                        fallback={<ChannelLetterFallback name={channel.name} />}
+                                                    />
+                                                ) : (
+                                                    <ChannelLetterFallback name={channel.name} />
+                                                )}
+                                            </div>
+                                            <span style={{
+                                                fontSize: '13px', fontWeight: 500, color: 'rgba(229, 231, 235, 1)',
+                                                whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+                                            }}>
+                                                {channel.name}
+                                            </span>
+                                        </div>
+
+                                        {/* Timeline cell */}
+                                        <div style={{ position: 'relative', width: TIMELINE_WIDTH, minWidth: TIMELINE_WIDTH }}>
+                                            {/* 30-min gridlines */}
+                                            {ticks.map((tick, i) => i > 0 && (
+                                                <div key={tick} style={{
+                                                    position: 'absolute', left: i * PX_PER_HALF_HOUR, top: 0, bottom: 0,
+                                                    width: '1px', background: 'rgba(255, 255, 255, 0.04)'
+                                                }} />
+                                            ))}
+
+                                            {programs === undefined ? (
+                                                <span style={rowPlaceholderStyle}>{t('guide', 'loadingEpg')}</span>
+                                            ) : (() => {
+                                                const blocks = programs
+                                                    .map(p => ({ program: p, block: programToBlock(p.start, p.end, guideWindow) }))
+                                                    .filter((e): e is { program: EPGProgram; block: NonNullable<ReturnType<typeof programToBlock>> } => e.block !== null);
+                                                if (blocks.length === 0) {
+                                                    return <span style={rowPlaceholderStyle}>{t('guide', 'noEpg')}</span>;
+                                                }
+                                                return blocks.map(({ program, block }) => {
+                                                    const airing = isAiringNow(program.start, program.end, now);
+                                                    return (
+                                                        <div
+                                                            key={program.id + program.start}
+                                                            className="guide-program"
+                                                            onClick={airing ? () => setPlayingChannel(channel) : undefined}
+                                                            title={program.description ? `${program.title}\n${program.description}` : program.title}
+                                                            style={{
+                                                                position: 'absolute',
+                                                                left: block.left + 2,
+                                                                width: Math.max(block.width - 4, 6),
+                                                                top: 5, bottom: 5,
+                                                                borderRadius: '8px',
+                                                                padding: '6px 8px',
+                                                                overflow: 'hidden',
+                                                                cursor: airing ? 'pointer' : 'default',
+                                                                background: airing
+                                                                    ? 'linear-gradient(135deg, rgba(168, 85, 247, 0.35) 0%, rgba(236, 72, 153, 0.25) 100%)'
+                                                                    : 'rgba(255, 255, 255, 0.05)',
+                                                                border: airing
+                                                                    ? '1px solid rgba(168, 85, 247, 0.6)'
+                                                                    : '1px solid rgba(255, 255, 255, 0.08)',
+                                                                transition: 'filter 0.2s ease'
+                                                            }}
+                                                        >
+                                                            <div style={{
+                                                                fontSize: '12px', fontWeight: 600, lineHeight: '16px',
+                                                                color: airing ? '#e9d5ff' : 'rgba(226, 232, 240, 0.9)',
+                                                                whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+                                                            }}>
+                                                                {program.title}
+                                                            </div>
+                                                            <div style={{
+                                                                fontSize: '10px', color: 'rgba(148, 163, 184, 0.9)',
+                                                                whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+                                                            }}>
+                                                                {(block.clippedStart ? '◂ ' : '') +
+                                                                    formatGuideTime(Date.parse(program.start)) + ' – ' +
+                                                                    formatGuideTime(Date.parse(program.end)) +
+                                                                    (block.clippedEnd ? ' ▸' : '')}
+                                                            </div>
+                                                        </div>
+                                                    );
+                                                });
+                                            })()}
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            {playingChannel && (
+                <AsyncVideoPlayer
+                    movie={playingChannel}
+                    buildStreamUrl={buildLiveStreamUrl}
+                    onClose={() => setPlayingChannel(null)}
+                    customTitle={playingChannel.name}
+                    contentId={playingChannel.stream_id.toString()}
+                    contentType="live"
+                />
+            )}
+        </div>
+    );
+}
+
+function ChannelLetterFallback({ name }: { name: string }) {
+    // Skip country/quality prefixes when picking the letter (e.g. "BR: Globo" → G)
+    const cleaned = name.replace(/^[a-z]{2,3}\s*[:|]\s*/i, '').trim();
+    const letter = (cleaned[0] || name[0] || '?').toUpperCase();
+    return (
+        <div style={{
+            width: '100%', height: '100%',
+            background: 'linear-gradient(135deg, #a855f7 0%, #ec4899 100%)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: '16px', fontWeight: 700, color: 'white'
+        }}>
+            {letter}
+        </div>
+    );
+}
+
+const pageWrapperStyle: React.CSSProperties = {
+    position: 'relative',
+    height: '100vh',
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column'
+};
+
+const backdropStyle: React.CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    background: 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%)',
+    zIndex: 0
+};
+
+const rowPlaceholderStyle: React.CSSProperties = {
+    position: 'absolute',
+    left: '12px',
+    top: '50%',
+    transform: 'translateY(-50%)',
+    fontSize: '12px',
+    fontStyle: 'italic',
+    color: 'rgba(100, 116, 139, 0.8)'
+};

--- a/src/services/epgService.ts
+++ b/src/services/epgService.ts
@@ -560,38 +560,38 @@ export const epgService = {
             .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code)));
     },
 
-    // Fetch from mi.tv
+    // Fetch from mi.tv via the main-process proxy (direct fetch is CORS-blocked
+    // in the renderer — webSecurity is on)
     async fetchFromMiTV(channelName: string): Promise<EPGProgram[]> {
         try {
             const slug = this.getMiTVSlug(channelName);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ipcRenderer = (window as any).ipcRenderer;
+            if (!ipcRenderer?.invoke) return [];
 
-            // Use -300 timezone offset for Brazil (UTC-3 = -180 minutes, but site uses -300)
-            const url = `https://mi.tv/br/async/channel/${slug}/-300`;
-            const response = await fetch(url);
+            const result = await ipcRenderer.invoke('epg:fetch-mitv', slug);
+            if (!result?.success || !result.html) return [];
 
-            if (!response.ok) return [];
-
-            const html = await response.text();
-            return this.parseHTML(html, channelName);
+            return this.parseHTML(result.html, channelName);
         } catch (error) {
             console.error('[EPG] mi.tv error:', error);
             return [];
         }
     },
 
-    // Fetch from meuguia.tv
+    // Fetch from meuguia.tv via the main-process proxy (same CORS situation)
     async fetchFromMeuGuia(channelName: string): Promise<EPGProgram[]> {
         try {
             const slug = this.getMeuGuiaSlug(channelName);
             if (!slug) return [];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ipcRenderer = (window as any).ipcRenderer;
+            if (!ipcRenderer?.invoke) return [];
 
-            const url = `https://meuguia.tv/programacao/canal/${slug}`;
-            const response = await fetch(url);
+            const result = await ipcRenderer.invoke('epg:fetch-meuguia', slug);
+            if (!result?.success || !result.html) return [];
 
-            if (!response.ok) return [];
-
-            const html = await response.text();
-            return this.parseMeuGuiaHTML(html, channelName);
+            return this.parseMeuGuiaHTML(result.html, channelName);
         } catch (error) {
             console.error('[EPG] meuguia.tv error:', error);
             return [];

--- a/src/utils/epgGuide.test.ts
+++ b/src/utils/epgGuide.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+    HALF_HOUR_MS,
+    PX_PER_HALF_HOUR,
+    WINDOW_HALF_HOURS,
+    getGuideWindow,
+    buildTimeTicks,
+    programToBlock,
+    nowOffsetPx,
+    isAiringNow
+} from './epgGuide';
+
+// Fixed reference: 2026-06-11T15:47:00Z
+const NOW = Date.UTC(2026, 5, 11, 15, 47, 0);
+// floor(15:47) = 15:30, minus one slot => 15:00
+const EXPECTED_START = Date.UTC(2026, 5, 11, 15, 0, 0);
+
+describe('getGuideWindow', () => {
+    it('floors now to 30min and backs up one slot', () => {
+        const win = getGuideWindow(NOW);
+        expect(win.start).toBe(EXPECTED_START);
+        expect(win.end - win.start).toBe(WINDOW_HALF_HOURS * HALF_HOUR_MS);
+    });
+
+    it('handles an exact 30-min boundary', () => {
+        const boundary = Date.UTC(2026, 5, 11, 16, 0, 0);
+        const win = getGuideWindow(boundary);
+        expect(win.start).toBe(boundary - HALF_HOUR_MS);
+    });
+});
+
+describe('buildTimeTicks', () => {
+    it('emits one tick per half-hour slot, starting at the window start', () => {
+        const win = getGuideWindow(NOW);
+        const ticks = buildTimeTicks(win);
+        expect(ticks).toHaveLength(WINDOW_HALF_HOURS);
+        expect(ticks[0]).toBe(win.start);
+        expect(ticks[ticks.length - 1]).toBe(win.end - HALF_HOUR_MS);
+    });
+});
+
+describe('programToBlock', () => {
+    const win = getGuideWindow(NOW);
+    const iso = (offsetMin: number) => new Date(win.start + offsetMin * 60000).toISOString();
+
+    it('positions a program fully inside the window', () => {
+        const block = programToBlock(iso(30), iso(90), win);
+        expect(block).not.toBeNull();
+        expect(block!.left).toBe(PX_PER_HALF_HOUR);
+        expect(block!.width).toBe(2 * PX_PER_HALF_HOUR);
+        expect(block!.clippedStart).toBe(false);
+        expect(block!.clippedEnd).toBe(false);
+    });
+
+    it('clips a program that started before the window', () => {
+        const block = programToBlock(iso(-60), iso(30), win);
+        expect(block).not.toBeNull();
+        expect(block!.left).toBe(0);
+        expect(block!.width).toBe(PX_PER_HALF_HOUR);
+        expect(block!.clippedStart).toBe(true);
+    });
+
+    it('clips a program that ends after the window', () => {
+        const totalMin = WINDOW_HALF_HOURS * 30;
+        const block = programToBlock(iso(totalMin - 30), iso(totalMin + 60), win);
+        expect(block).not.toBeNull();
+        expect(block!.width).toBe(PX_PER_HALF_HOUR);
+        expect(block!.clippedEnd).toBe(true);
+    });
+
+    it('returns null for programs fully outside the window', () => {
+        expect(programToBlock(iso(-120), iso(-60), win)).toBeNull();
+        const totalMin = WINDOW_HALF_HOURS * 30;
+        expect(programToBlock(iso(totalMin + 10), iso(totalMin + 70), win)).toBeNull();
+    });
+
+    it('returns null for invalid or inverted times', () => {
+        expect(programToBlock('not-a-date', iso(30), win)).toBeNull();
+        expect(programToBlock(iso(60), iso(30), win)).toBeNull();
+    });
+});
+
+describe('nowOffsetPx', () => {
+    const win = getGuideWindow(NOW);
+
+    it('maps now into pixels from the window start', () => {
+        // NOW is 47min after window start => 47/30 slots
+        expect(nowOffsetPx(NOW, win)).toBeCloseTo((47 / 30) * PX_PER_HALF_HOUR, 5);
+    });
+
+    it('returns null outside the window', () => {
+        expect(nowOffsetPx(win.start - 1, win)).toBeNull();
+        expect(nowOffsetPx(win.end, win)).toBeNull();
+    });
+});
+
+describe('isAiringNow', () => {
+    it('detects the current program', () => {
+        const start = new Date(NOW - 10 * 60000).toISOString();
+        const end = new Date(NOW + 10 * 60000).toISOString();
+        expect(isAiringNow(start, end, NOW)).toBe(true);
+    });
+
+    it('rejects past/future programs and invalid dates', () => {
+        const past = new Date(NOW - 60 * 60000).toISOString();
+        const pastEnd = new Date(NOW - 30 * 60000).toISOString();
+        expect(isAiringNow(past, pastEnd, NOW)).toBe(false);
+        expect(isAiringNow('bad', pastEnd, NOW)).toBe(false);
+    });
+});

--- a/src/utils/epgGuide.ts
+++ b/src/utils/epgGuide.ts
@@ -1,0 +1,99 @@
+// Pure time/layout helpers for the EPG guide grid (Guia de TV).
+// Kept dependency-free so they can be unit-tested in isolation.
+
+export const HALF_HOUR_MS = 30 * 60 * 1000;
+/** Horizontal pixels per 30-minute slot. */
+export const PX_PER_HALF_HOUR = 200;
+/** Total 30-min slots in the window: -30min .. +4h from "now floor 30min". */
+export const WINDOW_HALF_HOURS = 9;
+
+export interface GuideWindow {
+    /** Window start (ms since epoch) */
+    start: number;
+    /** Window end (ms since epoch, exclusive) */
+    end: number;
+}
+
+export interface ProgramBlock {
+    /** Offset from the timeline origin, px */
+    left: number;
+    /** Block width, px */
+    width: number;
+    /** True when the program started before the window (clipped at left edge) */
+    clippedStart: boolean;
+    /** True when the program ends after the window (clipped at right edge) */
+    clippedEnd: boolean;
+}
+
+/**
+ * Window bounds: floor "now" to the previous 30-min boundary, back up one
+ * extra slot (so the current program has context) and span 4.5 hours total.
+ */
+export function getGuideWindow(now: number = Date.now()): GuideWindow {
+    const floored = Math.floor(now / HALF_HOUR_MS) * HALF_HOUR_MS;
+    const start = floored - HALF_HOUR_MS;
+    return { start, end: start + WINDOW_HALF_HOURS * HALF_HOUR_MS };
+}
+
+/** Timestamps (ms) for every 30-min tick in the window, including the start. */
+export function buildTimeTicks(window: GuideWindow): number[] {
+    const ticks: number[] = [];
+    for (let t = window.start; t < window.end; t += HALF_HOUR_MS) {
+        ticks.push(t);
+    }
+    return ticks;
+}
+
+/**
+ * Maps a program (ISO start/end) to a positioned block inside the window.
+ * Returns null when the program is invalid or fully outside the window.
+ */
+export function programToBlock(
+    startIso: string,
+    endIso: string,
+    window: GuideWindow,
+    pxPerHalfHour: number = PX_PER_HALF_HOUR
+): ProgramBlock | null {
+    const start = Date.parse(startIso);
+    const end = Date.parse(endIso);
+    if (Number.isNaN(start) || Number.isNaN(end) || end <= start) return null;
+
+    const clampedStart = Math.max(start, window.start);
+    const clampedEnd = Math.min(end, window.end);
+    if (clampedEnd <= clampedStart) return null;
+
+    const pxPerMs = pxPerHalfHour / HALF_HOUR_MS;
+    return {
+        left: (clampedStart - window.start) * pxPerMs,
+        width: (clampedEnd - clampedStart) * pxPerMs,
+        clippedStart: start < window.start,
+        clippedEnd: end > window.end
+    };
+}
+
+/** Pixel offset of "now" inside the window, or null when outside it. */
+export function nowOffsetPx(
+    now: number,
+    window: GuideWindow,
+    pxPerHalfHour: number = PX_PER_HALF_HOUR
+): number | null {
+    if (now < window.start || now >= window.end) return null;
+    return ((now - window.start) / HALF_HOUR_MS) * pxPerHalfHour;
+}
+
+/** True when "now" falls within [start, end) of the program. */
+export function isAiringNow(startIso: string, endIso: string, now: number = Date.now()): boolean {
+    const start = Date.parse(startIso);
+    const end = Date.parse(endIso);
+    if (Number.isNaN(start) || Number.isNaN(end)) return false;
+    return now >= start && now < end;
+}
+
+/** HH:MM label for a tick / program time (local time, 24h). */
+export function formatGuideTime(ms: number): string {
+    return new Date(ms).toLocaleTimeString('pt-BR', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+    });
+}


### PR DESCRIPTION
## Guia de TV (grade de EPG)

Página nova em **/dashboard/guide** (ícone de calendário na sidebar, logo após Canais).

### Layout
- Grade clássica de guia de TV: coluna fixa de canais (logo + nome), header fixo com ticks de 30 min, janela de 4,5h
- Blocos de programa posicionados pelo horário real, cortados nas bordas da janela (com marcadores ◂/▸)
- Programa atual destacado em roxo + linha "Agora" com gradiente atualizando a cada minuto
- Tooltip com título + descrição

### Performance (1.700+ canais)
- Seletor de categoria — só a categoria escolhida renderiza linhas
- Linhas janeladas: 25 iniciais, +25 ao rolar
- EPG buscado preguiçosamente por canal visível, máx. 4 em paralelo, dedupe + cache de sessão

### Interação
- Clique no canal (ou no bloco do programa atual) reproduz inline com o mesmo player e gating kids/parental do LiveTV

### 🐛 Fix importante descoberto no gate visual
O epgService buscava **mi.tv e meuguia.tv direto do renderer** — bloqueado por CORS desde sempre (webSecurity ativo); só o caminho Open-EPG via IPC funcionava. Os dois fetchers agora usam os proxies do main process que já existiam (`epg:fetch-mitv` / `epg:fetch-meuguia`). Isso também **restaura essas fontes pro painel de detalhes do LiveTV**.

### Verificação
- ✅ tsc / eslint / vitest **65/65** (12 testes novos dos helpers puros) / vite build (chunk lazy)
- ✅ Visual no app rodando: categorias Globo/HBO preenchidas com programação real, linha "Agora" correta, blocos alinhados ao header — confirmado também pelo usuário