### PR TITLE
feat: temas — fundo (Padrão/AMOLED) + 6 cores de destaque

### DIFF
--- a/release/NeoStream-IPTV-Portable-3.9.3.exe
+++ b/release/NeoStream-IPTV-Portable-3.9.3.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:589252ea081e09b219c73044d3b9cc1ae02c040a0f98e05b7697bc3a54fb8ddf
-size 128785472

--- a/release/NeoStream-IPTV-Setup-3.9.3.exe
+++ b/release/NeoStream-IPTV-Setup-3.9.3.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08139db4203439d20cfd70da0320154a211fc010aa6bda083a60471dab15dedb
-size 129081526

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -511,11 +511,11 @@ const globalSearchStyles = `
     max-height: 70vh;
     display: flex;
     flex-direction: column;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     border-radius: 20px;
     overflow: hidden;
-    box-shadow: 0 25px 80px rgba(0, 0, 0, 0.6), 0 0 40px rgba(168, 85, 247, 0.1);
+    box-shadow: 0 25px 80px rgba(0, 0, 0, 0.6), 0 0 40px rgba(var(--ns-accent-rgb), 0.1);
     animation: gsearchSlide 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
@@ -567,7 +567,7 @@ const globalSearchStyles = `
     overflow-y: auto;
     padding: 8px;
     scrollbar-width: thin;
-    scrollbar-color: rgba(168, 85, 247, 0.4) transparent;
+    scrollbar-color: rgba(var(--ns-accent-rgb), 0.4) transparent;
 }
 
 .gsearch-results::-webkit-scrollbar {
@@ -575,7 +575,7 @@ const globalSearchStyles = `
 }
 
 .gsearch-results::-webkit-scrollbar-thumb {
-    background: rgba(168, 85, 247, 0.4);
+    background: rgba(var(--ns-accent-rgb), 0.4);
     border-radius: 3px;
 }
 
@@ -592,8 +592,8 @@ const globalSearchStyles = `
 .gsearch-spinner {
     width: 18px;
     height: 18px;
-    border: 2px solid rgba(168, 85, 247, 0.2);
-    border-top-color: #a855f7;
+    border: 2px solid rgba(var(--ns-accent-rgb), 0.2);
+    border-top-color: var(--ns-accent);
     border-radius: 50%;
     animation: gsearchSpin 0.8s linear infinite;
 }
@@ -631,7 +631,7 @@ const globalSearchStyles = `
 }
 
 .gsearch-item.selected {
-    background: rgba(168, 85, 247, 0.18);
+    background: rgba(var(--ns-accent-rgb), 0.18);
 }
 
 .gsearch-thumb {
@@ -649,7 +649,7 @@ const globalSearchStyles = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.35), rgba(236, 72, 153, 0.35));
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.35), rgba(var(--ns-accent-grad-to-rgb), 0.35));
     color: white;
     font-size: 18px;
     font-weight: 700;
@@ -674,9 +674,9 @@ const globalSearchStyles = `
 }
 
 .badge-live {
-    background: rgba(168, 85, 247, 0.15);
-    color: #c4b5fd;
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.15);
+    color: var(--ns-accent-light);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
 }
 
 .badge-vod {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -142,8 +142,8 @@ export function Sidebar() {
                         <svg className="logo-svg" width="44" height="44" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                             <defs>
                                 <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                                    <stop offset="0%" stopColor="#a855f7" />
-                                    <stop offset="100%" stopColor="#ec4899" />
+                                    <stop offset="0%" style={{ stopColor: 'var(--ns-accent)' }} />
+                                    <stop offset="100%" style={{ stopColor: 'var(--ns-accent-grad-to)' }} />
                                 </linearGradient>
                             </defs>
                             <path d="M 10,10 L 10,90 L 90,50 Z" fill="none" stroke="url(#logoGradient)" strokeWidth="6" strokeLinejoin="round" />
@@ -168,7 +168,7 @@ export function Sidebar() {
                         <div
                             className="item-glow"
                             style={{
-                                background: 'linear-gradient(135deg, #a855f7, #ec4899)',
+                                background: 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to))',
                                 opacity: hoveredItem === 'search' ? 0.15 : 0
                             }}
                         />
@@ -176,7 +176,7 @@ export function Sidebar() {
                             <Search
                                 className="item-icon"
                                 style={{
-                                    stroke: hoveredItem === 'search' ? '#c4b5fd' : 'rgba(255,255,255,0.7)'
+                                    stroke: hoveredItem === 'search' ? 'var(--ns-accent-light)' : 'rgba(255,255,255,0.7)'
                                 }}
                             />
                         </div>
@@ -214,7 +214,7 @@ export function Sidebar() {
                                     <item.icon
                                         className="item-icon"
                                         style={{
-                                            stroke: isActive ? '#fff' : isHovered ? '#c4b5fd' : 'rgba(255,255,255,0.7)'
+                                            stroke: isActive ? '#fff' : isHovered ? 'var(--ns-accent-light)' : 'rgba(255,255,255,0.7)'
                                         }}
                                     />
                                 </div>
@@ -265,8 +265,8 @@ export function Sidebar() {
                                 <svg width="26" height="26" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                                     <defs>
                                         <linearGradient id="profileGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-                                            <stop offset="0%" stopColor="#a855f7" />
-                                            <stop offset="100%" stopColor="#ec4899" />
+                                            <stop offset="0%" style={{ stopColor: 'var(--ns-accent)' }} />
+                                            <stop offset="100%" style={{ stopColor: 'var(--ns-accent-grad-to)' }} />
                                         </linearGradient>
                                     </defs>
                                     <circle cx="50" cy="35" r="14" fill="none" stroke="url(#profileGrad)" strokeWidth="6" />
@@ -453,7 +453,7 @@ const sidebarStyles = `
     overflow-x: hidden;
     overflow-y: auto;
     scrollbar-width: thin;
-    scrollbar-color: rgba(168, 85, 247, 0.4) transparent;
+    scrollbar-color: rgba(var(--ns-accent-rgb), 0.4) transparent;
 }
 
 .sidebar::-webkit-scrollbar {
@@ -465,7 +465,7 @@ const sidebarStyles = `
 }
 
 .sidebar::-webkit-scrollbar-thumb {
-    background: linear-gradient(180deg, #a855f7, #ec4899);
+    background: linear-gradient(180deg, var(--ns-accent), var(--ns-accent-grad-to));
     border-radius: 2px;
 }
 
@@ -479,7 +479,7 @@ const sidebarStyles = `
 .bg-gradient {
     position: absolute;
     inset: 0;
-    background: linear-gradient(180deg, #0f0f1a 0%, #1a1a2e 50%, #0f0f1a 100%);
+    background: linear-gradient(180deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-deep) 100%);
 }
 
 .bg-glow {
@@ -488,7 +488,7 @@ const sidebarStyles = `
     left: 0;
     right: 0;
     height: 200px;
-    background: radial-gradient(ellipse at center top, rgba(168, 85, 247, 0.15) 0%, transparent 70%);
+    background: radial-gradient(ellipse at center top, rgba(var(--ns-accent-rgb), 0.15) 0%, transparent 70%);
     pointer-events: none;
 }
 
@@ -515,24 +515,24 @@ const sidebarStyles = `
 .logo-svg {
     position: relative;
     z-index: 2;
-    filter: drop-shadow(0 0 8px rgba(168, 85, 247, 0.5));
+    filter: drop-shadow(0 0 8px rgba(var(--ns-accent-rgb), 0.5));
     transition: filter 0.3s ease;
 }
 
 .logo-wrapper:hover .logo-svg {
-    filter: drop-shadow(0 0 15px rgba(168, 85, 247, 0.8))
-            drop-shadow(0 0 30px rgba(168, 85, 247, 0.5));
+    filter: drop-shadow(0 0 15px rgba(var(--ns-accent-rgb), 0.8))
+            drop-shadow(0 0 30px rgba(var(--ns-accent-rgb), 0.5));
     animation: logoGlow 2s ease-in-out infinite;
 }
 
 @keyframes logoGlow {
     0%, 100% { 
-        filter: drop-shadow(0 0 15px rgba(168, 85, 247, 0.8))
-                drop-shadow(0 0 30px rgba(168, 85, 247, 0.5));
+        filter: drop-shadow(0 0 15px rgba(var(--ns-accent-rgb), 0.8))
+                drop-shadow(0 0 30px rgba(var(--ns-accent-rgb), 0.5));
     }
     50% { 
-        filter: drop-shadow(0 0 25px rgba(168, 85, 247, 1))
-                drop-shadow(0 0 50px rgba(168, 85, 247, 0.7));
+        filter: drop-shadow(0 0 25px rgba(var(--ns-accent-rgb), 1))
+                drop-shadow(0 0 50px rgba(var(--ns-accent-rgb), 0.7));
     }
 }
 
@@ -540,7 +540,7 @@ const sidebarStyles = `
     position: absolute;
     inset: -8px;
     border-radius: 50%;
-    border: 2px solid rgba(168, 85, 247, 0.3);
+    border: 2px solid rgba(var(--ns-accent-rgb), 0.3);
     opacity: 0;
     transition: all 0.3s ease;
 }
@@ -682,8 +682,8 @@ const sidebarStyles = `
     align-items: center;
     gap: 10px;
     padding: 10px 16px;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     border-radius: 12px;
     white-space: nowrap;
     opacity: 0;
@@ -748,7 +748,7 @@ const sidebarStyles = `
     position: absolute;
     inset: -3px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #a855f7, #ec4899);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
     opacity: 0.8;
     transition: all 0.3s ease;
 }
@@ -768,7 +768,7 @@ const sidebarStyles = `
     width: 42px;
     height: 42px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #1a1a2e, #0f0f1a);
+    background: linear-gradient(135deg, var(--ns-bg-panel), var(--ns-bg-deep));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -823,8 +823,8 @@ const sidebarStyles = `
     left: 92px;
     bottom: 80px;
     width: 220px;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     border-radius: 16px;
     padding: 12px;
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
@@ -880,14 +880,14 @@ const sidebarStyles = `
 }
 
 .profile-popup-item.active {
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.15));
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.15));
 }
 
 .profile-popup-avatar {
     width: 36px;
     height: 36px;
     border-radius: 50%;
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.3), rgba(236, 72, 153, 0.3));
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.3), rgba(var(--ns-accent-grad-to-rgb), 0.3));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -954,7 +954,7 @@ const sidebarStyles = `
     padding: 32px;
     max-width: 480px;
     width: 95%;
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     box-shadow: 0 25px 80px rgba(0, 0, 0, 0.5);
     animation: sidebarPinModalSlide 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
@@ -995,7 +995,7 @@ const sidebarStyles = `
 }
 
 .sidebar-pin-header strong {
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
 }
 
 .sidebar-pin-container {
@@ -1022,8 +1022,8 @@ const sidebarStyles = `
 }
 
 .sidebar-pin-digit.filled {
-    border-color: rgba(168, 85, 247, 0.7);
-    background: rgba(168, 85, 247, 0.15);
+    border-color: rgba(var(--ns-accent-rgb), 0.7);
+    background: rgba(var(--ns-accent-rgb), 0.15);
     animation: sidebarPinPop 0.2s ease;
 }
 
@@ -1103,13 +1103,13 @@ const sidebarStyles = `
 }
 
 .sidebar-pin-btn.submit {
-    background: linear-gradient(135deg, #a855f7, #7c3aed);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-dark));
     color: white;
 }
 
 .sidebar-pin-btn.submit:hover:not(:disabled) {
     transform: translateY(-2px);
-    box-shadow: 0 8px 24px rgba(168, 85, 247, 0.4);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .sidebar-pin-btn.submit:disabled {
@@ -1151,8 +1151,8 @@ const sidebarStyles = `
 .profile-transition-spinner {
     width: 48px;
     height: 48px;
-    border: 3px solid rgba(168, 85, 247, 0.2);
-    border-top-color: #a855f7;
+    border: 3px solid rgba(var(--ns-accent-rgb), 0.2);
+    border-top-color: var(--ns-accent);
     border-radius: 50%;
     animation: transitionSpin 0.8s linear infinite;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Theme variables (NeoStream appearance system).
+   Defaults mirror the classic palette exactly — themeService overrides them
+   at startup from localStorage ('neostream_theme'). */
+:root {
+    --ns-accent: #a855f7;
+    --ns-accent-dark: #7c3aed;
+    --ns-accent-light: #c4b5fd;
+    --ns-accent-grad-to: #ec4899;
+    --ns-accent-rgb: 168, 85, 247;
+    --ns-accent-grad-to-rgb: 236, 72, 153;
+    --ns-accent-soft: rgba(168, 85, 247, 0.15);
+    --ns-accent-glow: rgba(168, 85, 247, 0.4);
+    --ns-bg-deep: #0f0f1a;
+    --ns-bg-panel: #1a1a2e;
+    --ns-bg-tint: #16213e;
+}
+
 /* Basic debugging styles */
 * {
     margin: 0;
@@ -16,7 +33,7 @@ body {
 }
 
 body {
-    background: #0f0f23;
+    background: var(--ns-bg-deep);
     color: white;
     font-family: system-ui, -apple-system, sans-serif;
     padding-top: 36px;
@@ -38,17 +55,17 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-    background: rgba(59, 130, 246, 0.5);
+    background: rgba(var(--ns-accent-rgb), 0.5);
     border-radius: 6px;
     border: 2px solid rgba(0, 0, 0, 0.2);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: rgba(59, 130, 246, 0.7);
+    background: rgba(var(--ns-accent-rgb), 0.7);
 }
 
 /* Para Firefox */
 * {
     scrollbar-width: thin;
-    scrollbar-color: rgba(59, 130, 246, 0.5) rgba(0, 0, 0, 0.2);
+    scrollbar-color: rgba(var(--ns-accent-rgb), 0.5) rgba(0, 0, 0, 0.2);
 }

--- a/src/locales/ui/en.json
+++ b/src/locales/ui/en.json
@@ -3,6 +3,7 @@
     "updates": "Updates",
     "backup": "Backup",
     "playback": "Playback",
+    "appearance": "Appearance",
     "epg": "EPG",
     "stats": "Statistics",
     "parental": "Parental Control",
@@ -276,6 +277,23 @@
     "autoPlayNextDesc": "Automatically play the next episode",
     "clickThrough": "Click-Through Mode (PiP)",
     "clickThroughDesc": "Allows mouse to pass through PiP without interacting (F9 to toggle)"
+  },
+  "appearance": {
+    "title": "Appearance",
+    "description": "Customize the app colors",
+    "background": "Background",
+    "backgroundDesc": "Choose the app background style",
+    "backgroundDefault": "Default",
+    "backgroundAmoled": "AMOLED (pure black)",
+    "accent": "Accent color",
+    "accentDesc": "Color used on buttons, highlights and gradients",
+    "colorPurple": "Purple",
+    "colorBlue": "Blue",
+    "colorGreen": "Green",
+    "colorRed": "Red",
+    "colorOrange": "Orange",
+    "colorPink": "Pink",
+    "note": "Some screens still keep the classic palette for now."
   },
   "backup": {
     "title": "Backup & Restore",

--- a/src/locales/ui/es.json
+++ b/src/locales/ui/es.json
@@ -3,6 +3,7 @@
     "updates": "Actualizaciones",
     "backup": "Copia de seguridad",
     "playback": "Reproducción",
+    "appearance": "Apariencia",
     "epg": "EPG",
     "stats": "Estadísticas",
     "parental": "Control Parental",
@@ -276,6 +277,23 @@
     "autoPlayNextDesc": "Reproducir automáticamente el siguiente episodio",
     "clickThrough": "Modo Click-Through (PiP)",
     "clickThroughDesc": "Permite que el mouse pase por el PiP sin interactuar (F9 para alternar)"
+  },
+  "appearance": {
+    "title": "Apariencia",
+    "description": "Personaliza los colores de la aplicación",
+    "background": "Fondo",
+    "backgroundDesc": "Elige el estilo de fondo de la aplicación",
+    "backgroundDefault": "Predeterminado",
+    "backgroundAmoled": "AMOLED (negro puro)",
+    "accent": "Color de acento",
+    "accentDesc": "Color usado en botones, resaltados y degradados",
+    "colorPurple": "Morado",
+    "colorBlue": "Azul",
+    "colorGreen": "Verde",
+    "colorRed": "Rojo",
+    "colorOrange": "Naranja",
+    "colorPink": "Rosa",
+    "note": "Algunas pantallas aún mantienen la paleta clásica por ahora."
   },
   "backup": {
     "title": "Copia de Seguridad y Restauración",

--- a/src/locales/ui/pt.json
+++ b/src/locales/ui/pt.json
@@ -3,6 +3,7 @@
     "updates": "Atualizações",
     "backup": "Backup",
     "playback": "Reprodução",
+    "appearance": "Aparência",
     "epg": "EPG",
     "stats": "Estatísticas",
     "parental": "Controle Parental",
@@ -375,6 +376,23 @@
     "autoPlayNextDesc": "Reproduzir automaticamente o próximo episódio",
     "clickThrough": "Modo Click-Through (PiP)",
     "clickThroughDesc": "Permite que o mouse passe pelo PiP sem interagir (F9 para alternar)"
+  },
+  "appearance": {
+    "title": "Aparência",
+    "description": "Personalize as cores do aplicativo",
+    "background": "Fundo",
+    "backgroundDesc": "Escolha o estilo de fundo do aplicativo",
+    "backgroundDefault": "Padrão",
+    "backgroundAmoled": "AMOLED (preto puro)",
+    "accent": "Cor de destaque",
+    "accentDesc": "Cor usada em botões, realces e gradientes",
+    "colorPurple": "Roxo",
+    "colorBlue": "Azul",
+    "colorGreen": "Verde",
+    "colorRed": "Vermelho",
+    "colorOrange": "Laranja",
+    "colorPink": "Rosa",
+    "note": "Algumas telas ainda mantêm a paleta clássica por enquanto."
   },
   "dashboard": {
     "live": "TV Ao Vivo",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,11 @@
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { themeService } from './services/themeService'
+
+// Apply the persisted theme (CSS custom properties on <html>) before the
+// first render so themed surfaces never flash the default palette.
+themeService.apply()
 
 // Forward uncaught renderer errors to the main process so they land in
 // main.log — packaged-app bug reports were blind to the UI side.

--- a/src/pages/EpgGuide.tsx
+++ b/src/pages/EpgGuide.tsx
@@ -248,7 +248,7 @@ export function EpgGuide() {
                 <div style={{ position: 'relative', zIndex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: '16px' }}>
                     <div style={{
                         width: '48px', height: '48px', borderRadius: '50%',
-                        border: '3px solid rgba(168, 85, 247, 0.2)', borderTopColor: '#a855f7',
+                        border: '3px solid rgba(var(--ns-accent-rgb), 0.2)', borderTopColor: 'var(--ns-accent)',
                         animation: 'guideSpin 0.8s linear infinite'
                     }} />
                     <span style={{ color: 'rgba(255,255,255,0.7)', fontSize: '15px', fontWeight: 500 }}>
@@ -279,11 +279,11 @@ export function EpgGuide() {
                 .guide-scroll::-webkit-scrollbar { width: 6px; height: 6px; }
                 .guide-scroll::-webkit-scrollbar-track { background: transparent; }
                 .guide-scroll::-webkit-scrollbar-thumb {
-                    background: linear-gradient(180deg, #a855f7, #ec4899);
+                    background: linear-gradient(180deg, var(--ns-accent), var(--ns-accent-grad-to));
                     border-radius: 3px;
                 }
                 .guide-program:hover { filter: brightness(1.25); }
-                .guide-channel-cell:hover { background: rgba(168, 85, 247, 0.12) !important; }
+                .guide-channel-cell:hover { background: rgba(var(--ns-accent-rgb), 0.12) !important; }
             `}</style>
 
             {/* Header: title + category selector */}
@@ -306,7 +306,7 @@ export function EpgGuide() {
                     style={{
                         background: 'rgba(31, 41, 55, 0.9)',
                         color: 'white',
-                        border: '1px solid rgba(168, 85, 247, 0.4)',
+                        border: '1px solid rgba(var(--ns-accent-rgb), 0.4)',
                         borderRadius: '10px',
                         padding: '8px 14px',
                         fontSize: '14px',
@@ -352,14 +352,14 @@ export function EpgGuide() {
                         <div style={{
                             position: 'sticky', top: 0, zIndex: 30,
                             display: 'flex', height: HEADER_HEIGHT,
-                            background: 'linear-gradient(180deg, #1a1a2e 0%, #16162a 100%)',
-                            borderBottom: '1px solid rgba(168, 85, 247, 0.25)'
+                            background: 'linear-gradient(180deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%)',
+                            borderBottom: '1px solid rgba(var(--ns-accent-rgb), 0.25)'
                         }}>
                             <div style={{
                                 position: 'sticky', left: 0, zIndex: 31,
                                 width: CHANNEL_COL_WIDTH, minWidth: CHANNEL_COL_WIDTH,
                                 display: 'flex', alignItems: 'center', paddingLeft: '14px',
-                                background: 'linear-gradient(180deg, #1a1a2e 0%, #16162a 100%)',
+                                background: 'linear-gradient(180deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%)',
                                 borderRight: '1px solid rgba(255, 255, 255, 0.08)',
                                 fontSize: '11px', fontWeight: 700, letterSpacing: '1px',
                                 textTransform: 'uppercase', color: 'rgba(196, 181, 253, 0.9)'
@@ -386,14 +386,14 @@ export function EpgGuide() {
                                     position: 'absolute',
                                     left: CHANNEL_COL_WIDTH + nowLineLeft,
                                     top: 0, bottom: 0, width: '2px',
-                                    background: 'linear-gradient(180deg, #a855f7, #ec4899)',
-                                    boxShadow: '0 0 8px rgba(168, 85, 247, 0.7)',
+                                    background: 'linear-gradient(180deg, var(--ns-accent), var(--ns-accent-grad-to))',
+                                    boxShadow: '0 0 8px rgba(var(--ns-accent-rgb), 0.7)',
                                     zIndex: 20, pointerEvents: 'none'
                                 }}>
                                     <span style={{
                                         position: 'absolute', top: '2px', left: '4px',
                                         fontSize: '9px', fontWeight: 700, letterSpacing: '0.5px',
-                                        textTransform: 'uppercase', color: '#c4b5fd', whiteSpace: 'nowrap'
+                                        textTransform: 'uppercase', color: 'var(--ns-accent-light)', whiteSpace: 'nowrap'
                                     }}>
                                         {t('guide', 'now')}
                                     </span>
@@ -417,7 +417,7 @@ export function EpgGuide() {
                                                 width: CHANNEL_COL_WIDTH, minWidth: CHANNEL_COL_WIDTH,
                                                 display: 'flex', alignItems: 'center', gap: '10px',
                                                 padding: '0 12px',
-                                                background: 'linear-gradient(90deg, #14142299 0%, #14142299 100%), #0f0f1a',
+                                                background: 'linear-gradient(90deg, #14142299 0%, #14142299 100%), var(--ns-bg-deep)',
                                                 borderRight: '1px solid rgba(255, 255, 255, 0.08)',
                                                 cursor: 'pointer',
                                                 transition: 'background 0.2s ease'
@@ -485,10 +485,10 @@ export function EpgGuide() {
                                                                 overflow: 'hidden',
                                                                 cursor: airing ? 'pointer' : 'default',
                                                                 background: airing
-                                                                    ? 'linear-gradient(135deg, rgba(168, 85, 247, 0.35) 0%, rgba(236, 72, 153, 0.25) 100%)'
+                                                                    ? 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.35) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.25) 100%)'
                                                                     : 'rgba(255, 255, 255, 0.05)',
                                                                 border: airing
-                                                                    ? '1px solid rgba(168, 85, 247, 0.6)'
+                                                                    ? '1px solid rgba(var(--ns-accent-rgb), 0.6)'
                                                                     : '1px solid rgba(255, 255, 255, 0.08)',
                                                                 transition: 'filter 0.2s ease'
                                                             }}
@@ -543,7 +543,7 @@ function ChannelLetterFallback({ name }: { name: string }) {
     return (
         <div style={{
             width: '100%', height: '100%',
-            background: 'linear-gradient(135deg, #a855f7 0%, #ec4899 100%)',
+            background: 'linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%)',
             display: 'flex', alignItems: 'center', justifyContent: 'center',
             fontSize: '16px', fontWeight: 700, color: 'white'
         }}>
@@ -563,7 +563,7 @@ const pageWrapperStyle: React.CSSProperties = {
 const backdropStyle: React.CSSProperties = {
     position: 'fixed',
     inset: 0,
-    background: 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%)',
+    background: 'linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%)',
     zIndex: 0
 };
 

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -284,7 +284,7 @@ const historyStyles = `
     min-height: 100vh;
     padding: 32px;
     overflow-x: hidden;
-    background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%);
 }
 
 /* Animated Backdrop */
@@ -292,8 +292,8 @@ const historyStyles = `
     position: fixed;
     inset: 0;
     background:
-        radial-gradient(ellipse at 20% 20%, rgba(168, 85, 247, 0.15) 0%, transparent 50%),
-        radial-gradient(ellipse at 80% 80%, rgba(236, 72, 153, 0.1) 0%, transparent 50%),
+        radial-gradient(ellipse at 20% 20%, rgba(var(--ns-accent-rgb), 0.15) 0%, transparent 50%),
+        radial-gradient(ellipse at 80% 80%, rgba(var(--ns-accent-grad-to-rgb), 0.1) 0%, transparent 50%),
         radial-gradient(ellipse at 50% 50%, rgba(59, 130, 246, 0.05) 0%, transparent 70%);
     pointer-events: none;
     z-index: 0;
@@ -410,8 +410,8 @@ const historyStyles = `
 }
 
 .history-row:hover {
-    background: rgba(168, 85, 247, 0.1);
-    border-color: rgba(168, 85, 247, 0.4);
+    background: rgba(var(--ns-accent-rgb), 0.1);
+    border-color: rgba(var(--ns-accent-rgb), 0.4);
     transform: translateX(4px);
 }
 
@@ -422,7 +422,7 @@ const historyStyles = `
     flex-shrink: 0;
     border-radius: 8px;
     overflow: hidden;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
 }
 
 .history-poster-fallback {
@@ -431,7 +431,7 @@ const historyStyles = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.3), rgba(236, 72, 153, 0.3));
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.3), rgba(var(--ns-accent-grad-to-rgb), 0.3));
     color: white;
     font-size: 22px;
     font-weight: 700;
@@ -456,7 +456,7 @@ const historyStyles = `
 }
 
 .history-row:hover .history-row-title {
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
 }
 
 .history-row-meta {
@@ -480,7 +480,7 @@ const historyStyles = `
 }
 
 .history-kind-badge.episode {
-    background: linear-gradient(135deg, #a855f7 0%, #9333ea 100%);
+    background: linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-dark) 100%);
 }
 
 .history-progress-badge {
@@ -542,7 +542,7 @@ const historyStyles = `
     transform: translateX(-50%);
     width: 80px;
     height: 20px;
-    background: radial-gradient(ellipse, rgba(168, 85, 247, 0.4) 0%, transparent 70%);
+    background: radial-gradient(ellipse, rgba(var(--ns-accent-rgb), 0.4) 0%, transparent 70%);
     border-radius: 50%;
     animation: historyGlowPulse 3s ease-in-out infinite;
 }
@@ -577,8 +577,8 @@ const historyStyles = `
     align-items: center;
     gap: 10px;
     padding: 16px 28px;
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.15) 0%, rgba(236, 72, 153, 0.15) 100%);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.15) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.15) 100%);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     color: white;
     font-size: 15px;
     font-weight: 600;
@@ -588,10 +588,10 @@ const historyStyles = `
 }
 
 .history-suggestion-btn:hover {
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.25) 0%, rgba(236, 72, 153, 0.25) 100%);
-    border-color: rgba(168, 85, 247, 0.5);
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.25) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.25) 100%);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
     transform: translateY(-3px);
-    box-shadow: 0 10px 30px rgba(168, 85, 247, 0.2);
+    box-shadow: 0 10px 30px rgba(var(--ns-accent-rgb), 0.2);
 }
 
 .history-suggestion-btn span:first-child {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -754,13 +754,13 @@ export function Home() {
                                 width: 48,
                                 height: 48,
                                 borderRadius: '50%',
-                                background: 'linear-gradient(135deg, #a855f7, #ec4899)',
+                                background: 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to))',
                                 display: 'flex',
                                 alignItems: 'center',
                                 justifyContent: 'center',
                                 fontSize: 18,
                                 color: 'white',
-                                boxShadow: '0 4px 20px rgba(168, 85, 247, 0.5)',
+                                boxShadow: '0 4px 20px rgba(var(--ns-accent-rgb), 0.5)',
                                 cursor: 'pointer'
                             }}>▶</div>
 
@@ -787,7 +787,7 @@ export function Home() {
                                     display: 'inline-flex',
                                     padding: '3px 8px',
                                     background: type === 'series' || (isContinue && continueItem.type === 'series')
-                                        ? 'rgba(139, 92, 246, 0.8)'
+                                        ? 'rgba(var(--ns-accent-rgb), 0.8)'
                                         : 'rgba(59, 130, 246, 0.8)',
                                     borderRadius: 4,
                                     fontSize: 10,
@@ -825,7 +825,7 @@ export function Home() {
                                 <div style={{
                                     height: '100%',
                                     width: `${progress}%`,
-                                    background: 'linear-gradient(90deg, #a855f7, #ec4899)',
+                                    background: 'linear-gradient(90deg, var(--ns-accent), var(--ns-accent-grad-to))',
                                     borderRadius: 2
                                 }} />
                             </div>
@@ -979,7 +979,7 @@ export function Home() {
                                 fontSize: 16,
                                 transition: 'all 0.2s'
                             }}
-                            onMouseEnter={(e) => e.currentTarget.style.background = 'rgba(168, 85, 247, 0.4)'}
+                            onMouseEnter={(e) => e.currentTarget.style.background = 'rgba(var(--ns-accent-rgb), 0.4)'}
                             onMouseLeave={(e) => e.currentTarget.style.background = 'rgba(255, 255, 255, 0.1)'}
                         >
                             <span className="arrow-icon">←</span>
@@ -1001,7 +1001,7 @@ export function Home() {
                                 fontSize: 16,
                                 transition: 'all 0.2s'
                             }}
-                            onMouseEnter={(e) => e.currentTarget.style.background = 'rgba(168, 85, 247, 0.4)'}
+                            onMouseEnter={(e) => e.currentTarget.style.background = 'rgba(var(--ns-accent-rgb), 0.4)'}
                             onMouseLeave={(e) => e.currentTarget.style.background = 'rgba(255, 255, 255, 0.1)'}
                         >
                             <span className="arrow-icon">→</span>
@@ -1116,7 +1116,7 @@ export function Home() {
                     left: 50%;
                     width: 0;
                     height: 0;
-                    background: radial-gradient(circle, rgba(168, 85, 247, 0.6) 0%, transparent 70%);
+                    background: radial-gradient(circle, rgba(var(--ns-accent-rgb), 0.6) 0%, transparent 70%);
                     border-radius: 50%;
                     transform: translate(-50%, -50%);
                     transition: width 0.3s, height 0.3s;
@@ -1127,8 +1127,8 @@ export function Home() {
                 }
                 .nav-arrow:hover {
                     transform: scale(1.1);
-                    border-color: rgba(168, 85, 247, 0.5) !important;
-                    box-shadow: 0 0 15px rgba(168, 85, 247, 0.3);
+                    border-color: rgba(var(--ns-accent-rgb), 0.5) !important;
+                    box-shadow: 0 0 15px rgba(var(--ns-accent-rgb), 0.3);
                 }
                 .nav-arrow:active {
                     transform: scale(0.9);
@@ -1193,7 +1193,7 @@ export function Home() {
                 }
                 .content-card .play-btn:hover {
                     transform: translate(-50%, -50%) scale(1.15) !important;
-                    box-shadow: 0 8px 30px rgba(168, 85, 247, 0.7) !important;
+                    box-shadow: 0 8px 30px rgba(var(--ns-accent-rgb), 0.7) !important;
                 }
                 @keyframes bounceIn {
                     0% { transform: scale(0) rotate(-90deg); }
@@ -1241,7 +1241,7 @@ export function Home() {
                     background: transparent;
                 }
                 .home-scroll-container::-webkit-scrollbar-thumb {
-                    background: linear-gradient(180deg, #a855f7, #ec4899);
+                    background: linear-gradient(180deg, var(--ns-accent), var(--ns-accent-grad-to));
                     border-radius: 3px;
                 }
             `}</style>
@@ -1255,14 +1255,14 @@ export function Home() {
             )}
             <div className="home-scroll-container" style={{
                 height: '100%',
-                background: 'linear-gradient(135deg, #0f0f23 0%, #1a1a2e 50%, #16213e 100%)',
+                background: 'linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%)',
                 padding: '40px 40px 40px 40px',
                 position: 'relative',
                 overflowY: 'auto',
                 overflowX: 'hidden',
                 paddingRight: '8px',
                 scrollbarWidth: 'thin',
-                scrollbarColor: 'rgba(168, 85, 247, 0.4) transparent'
+                scrollbarColor: 'rgba(var(--ns-accent-rgb), 0.4) transparent'
             }}>
                 {/* Background decorations */}
                 <div style={{
@@ -1281,7 +1281,7 @@ export function Home() {
                     left: '-150px',
                     width: '400px',
                     height: '400px',
-                    background: 'radial-gradient(circle, rgba(139, 92, 246, 0.08) 0%, transparent 70%)',
+                    background: 'radial-gradient(circle, rgba(var(--ns-accent-rgb), 0.08) 0%, transparent 70%)',
                     borderRadius: '50%',
                     pointerEvents: 'none'
                 }} />
@@ -1394,17 +1394,17 @@ export function Home() {
 
                     {/* Series Card */}
                     < a href="#/dashboard/series" style={{
-                        background: 'linear-gradient(135deg, rgba(139, 92, 246, 0.15) 0%, rgba(139, 92, 246, 0.05) 100%)',
+                        background: 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.15) 0%, rgba(var(--ns-accent-rgb), 0.05) 100%)',
                         borderRadius: '16px',
                         padding: '20px',
-                        border: '1px solid rgba(139, 92, 246, 0.2)',
+                        border: '1px solid rgba(var(--ns-accent-rgb), 0.2)',
                         textDecoration: 'none',
                         transition: 'all 0.3s ease',
                         cursor: 'pointer'
                     }}
                         onMouseEnter={(e) => {
                             e.currentTarget.style.transform = 'translateY(-4px)';
-                            e.currentTarget.style.boxShadow = '0 20px 40px rgba(139, 92, 246, 0.2)';
+                            e.currentTarget.style.boxShadow = '0 20px 40px rgba(var(--ns-accent-rgb), 0.2)';
                         }}
                         onMouseLeave={(e) => {
                             e.currentTarget.style.transform = 'translateY(0)';
@@ -1414,7 +1414,7 @@ export function Home() {
                         <div style={{ fontSize: '24px', fontWeight: '700', color: 'white', marginBottom: '2px' }}>
                             {loading ? '...' : filteredCounts.series.toLocaleString()}
                         </div>
-                        <div style={{ fontSize: '12px', color: 'rgba(139, 92, 246, 0.9)', fontWeight: '600' }}>
+                        <div style={{ fontSize: '12px', color: 'rgba(var(--ns-accent-rgb), 0.9)', fontWeight: '600' }}>
                             {t('home', 'seriesCount')}
                         </div>
                     </a >

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { useLanguage } from '../services/languageService';
 import epgTestService from '../services/epgTestService';
 import { UpdatesSection } from './settings/UpdatesSection';
 import { PlaybackSection } from './settings/PlaybackSection';
+import { AppearanceSection } from './settings/AppearanceSection';
 import { NetworkSection } from './settings/NetworkSection';
 import { EpgSection, type EpgResultsFilter, type EpgCountryFilter } from './settings/EpgSection';
 import { StatsSection } from './settings/StatsSection';
@@ -34,6 +35,7 @@ export function Settings() {
     const sections = [
         { id: 'updates', icon: '🔄', label: t('nav', 'updates'), color: '#10b981' },
         { id: 'playback', icon: '⏯️', label: t('nav', 'playback') || 'Reprodução', color: '#3b82f6' },
+        { id: 'appearance', icon: '🎨', label: t('nav', 'appearance') || 'Aparência', color: 'var(--ns-accent)' },
         { id: 'network', icon: '🔐', label: 'Rede', color: '#14b8a6' },
         { id: 'epg', icon: '📡', label: 'EPG', color: '#06b6d4' },
         { id: 'stats', icon: '📊', label: t('nav', 'stats'), color: '#8b5cf6' },
@@ -86,6 +88,9 @@ export function Settings() {
                         {/* Playback Section */}
                         {activeSection === 'playback' && <PlaybackSection />}
 
+                        {/* Appearance Section */}
+                        {activeSection === 'appearance' && <AppearanceSection />}
+
                         {/* Network Section */}
                         {activeSection === 'network' && <NetworkSection />}
 
@@ -129,7 +134,7 @@ const settingsStyles = `
     min-height: 100vh;
     padding: 32px;
     overflow-x: hidden;
-    background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%);
 }
 
 /* Animated Backdrop */
@@ -137,7 +142,7 @@ const settingsStyles = `
     position: fixed;
     inset: 0;
     background:
-        radial-gradient(ellipse at 30% 30%, rgba(168, 85, 247, 0.1) 0%, transparent 50%),
+        radial-gradient(ellipse at 30% 30%, rgba(var(--ns-accent-rgb), 0.1) 0%, transparent 50%),
         radial-gradient(ellipse at 70% 70%, rgba(59, 130, 246, 0.1) 0%, transparent 50%);
     pointer-events: none;
     z-index: 0;
@@ -180,7 +185,7 @@ const settingsStyles = `
     font-weight: 800;
     color: white;
     letter-spacing: -0.02em;
-    background: linear-gradient(135deg, #fff 0%, #c4b5fd 100%);
+    background: linear-gradient(135deg, #fff 0%, var(--ns-accent-light) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -265,9 +270,9 @@ const settingsStyles = `
 }
 
 .nav-item.active {
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.25), rgba(236, 72, 153, 0.2));
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.25), rgba(var(--ns-accent-grad-to-rgb), 0.2));
     color: white;
-    box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.4);
+    box-shadow: inset 0 0 0 1px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .nav-icon {
@@ -380,7 +385,7 @@ const settingsStyles = `
     font-size: 14px;
     font-weight: 600;
     border-radius: 12px;
-    border: 2px solid rgba(168, 85, 247, 0.3);
+    border: 2px solid rgba(var(--ns-accent-rgb), 0.3);
     cursor: pointer;
     outline: none;
     min-width: 180px;
@@ -388,12 +393,12 @@ const settingsStyles = `
 }
 
 .setting-select:hover {
-    border-color: rgba(168, 85, 247, 0.5);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
 }
 
 .setting-select:focus {
-    border-color: #a855f7;
-    box-shadow: 0 0 0 3px rgba(168, 85, 247, 0.2);
+    border-color: var(--ns-accent);
+    box-shadow: 0 0 0 3px rgba(var(--ns-accent-rgb), 0.2);
 }
 
 /* Toggle Switch */
@@ -432,7 +437,7 @@ const settingsStyles = `
 }
 
 .toggle-switch input:checked + .toggle-slider {
-    background: linear-gradient(135deg, #a855f7, #ec4899);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
 }
 
 .toggle-switch input:checked + .toggle-slider:before {
@@ -462,7 +467,7 @@ const settingsStyles = `
     align-items: center;
     gap: 10px;
     padding: 16px 20px;
-    background: rgba(168, 85, 247, 0.1);
+    background: rgba(var(--ns-accent-rgb), 0.1);
     border-radius: 12px;
     color: rgba(255, 255, 255, 0.7);
     font-size: 14px;
@@ -498,7 +503,7 @@ const settingsStyles = `
     gap: 12px;
     width: 100%;
     padding: 18px 32px;
-    background: linear-gradient(135deg, #a855f7 0%, #ec4899 100%);
+    background: linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%);
     border: none;
     border-radius: 14px;
     color: white;
@@ -506,12 +511,12 @@ const settingsStyles = `
     font-weight: 700;
     cursor: pointer;
     transition: all 0.3s ease;
-    box-shadow: 0 8px 24px rgba(168, 85, 247, 0.3);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.3);
 }
 
 .check-btn:hover:not(:disabled) {
     transform: translateY(-3px);
-    box-shadow: 0 12px 32px rgba(168, 85, 247, 0.4);
+    box-shadow: 0 12px 32px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .check-btn:disabled {
@@ -520,7 +525,7 @@ const settingsStyles = `
 }
 
 .check-btn.checking {
-    background: rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.3);
 }
 
 .spinner {
@@ -560,7 +565,7 @@ const settingsStyles = `
     font-weight: 800;
     color: white;
     margin: 0 0 8px 0;
-    background: linear-gradient(135deg, #a855f7, #ec4899);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -569,9 +574,9 @@ const settingsStyles = `
 .app-version {
     display: inline-block;
     padding: 6px 16px;
-    background: rgba(168, 85, 247, 0.2);
+    background: rgba(var(--ns-accent-rgb), 0.2);
     border-radius: 20px;
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
     font-size: 14px;
     font-weight: 600;
     margin-bottom: 20px;
@@ -594,24 +599,24 @@ const settingsStyles = `
 
 .about-link {
     padding: 14px 24px;
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.15) 0%, rgba(236, 72, 153, 0.15) 100%);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.15) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.15) 100%);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     border-radius: 14px;
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
     text-decoration: none;
     font-size: 14px;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    box-shadow: 0 4px 15px rgba(168, 85, 247, 0.15);
+    box-shadow: 0 4px 15px rgba(var(--ns-accent-rgb), 0.15);
 }
 
 .about-link:hover {
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.25) 0%, rgba(236, 72, 153, 0.25) 100%);
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.25) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.25) 100%);
     color: white;
     transform: translateY(-4px) scale(1.02);
-    box-shadow: 0 8px 25px rgba(168, 85, 247, 0.3);
-    border-color: rgba(168, 85, 247, 0.5);
+    box-shadow: 0 8px 25px rgba(var(--ns-accent-rgb), 0.3);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
 }
 
 .about-link:active {

--- a/src/pages/settings/AppearanceSection.tsx
+++ b/src/pages/settings/AppearanceSection.tsx
@@ -1,0 +1,134 @@
+import { useLanguage } from '../../services/languageService';
+import {
+    ACCENT_PRESETS,
+    BACKGROUND_PRESETS,
+    useTheme
+} from '../../services/themeService';
+
+export function AppearanceSection() {
+    const { t } = useLanguage();
+    const { theme, setTheme } = useTheme();
+
+    return (
+        <div className="section-card">
+            <div className="section-header">
+                <div className="section-icon" style={{ background: 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to))' }}>🎨</div>
+                <div>
+                    <h2>{t('appearance', 'title')}</h2>
+                    <p>{t('appearance', 'description')}</p>
+                </div>
+            </div>
+
+            <div className="settings-group">
+                {/* Background variant */}
+                <div className="setting-item" style={{ flexDirection: 'column', alignItems: 'stretch', gap: '16px' }}>
+                    <div className="setting-info">
+                        <label>{t('appearance', 'background')}</label>
+                        <p>{t('appearance', 'backgroundDesc')}</p>
+                    </div>
+                    <div style={{ display: 'flex', gap: '12px' }}>
+                        {BACKGROUND_PRESETS.map(bg => {
+                            const selected = theme.background === bg.id;
+                            return (
+                                <button
+                                    key={bg.id}
+                                    onClick={() => setTheme({ background: bg.id })}
+                                    aria-pressed={selected}
+                                    style={{
+                                        flex: 1,
+                                        padding: '14px',
+                                        borderRadius: '14px',
+                                        border: selected
+                                            ? '2px solid var(--ns-accent)'
+                                            : '2px solid rgba(255, 255, 255, 0.12)',
+                                        background: 'rgba(255, 255, 255, 0.04)',
+                                        cursor: 'pointer',
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        alignItems: 'center',
+                                        gap: '10px',
+                                        transition: 'all 0.2s ease'
+                                    }}
+                                >
+                                    <div style={{
+                                        width: '100%',
+                                        height: '54px',
+                                        borderRadius: '10px',
+                                        border: '1px solid rgba(255, 255, 255, 0.1)',
+                                        background: `linear-gradient(135deg, ${bg.deep} 0%, ${bg.panel} 60%, ${bg.tint} 100%)`
+                                    }} />
+                                    <span style={{ color: 'white', fontSize: '13px', fontWeight: 600 }}>
+                                        {t('appearance', bg.nameKey)}
+                                        {selected && <span style={{ marginLeft: 6, color: 'var(--ns-accent-light)' }}>✓</span>}
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* Accent color */}
+                <div className="setting-item" style={{ flexDirection: 'column', alignItems: 'stretch', gap: '16px' }}>
+                    <div className="setting-info">
+                        <label>{t('appearance', 'accent')}</label>
+                        <p>{t('appearance', 'accentDesc')}</p>
+                    </div>
+                    <div style={{ display: 'flex', gap: '14px', flexWrap: 'wrap' }}>
+                        {ACCENT_PRESETS.map(preset => {
+                            const selected = theme.accent === preset.id;
+                            return (
+                                <button
+                                    key={preset.id}
+                                    onClick={() => setTheme({ accent: preset.id })}
+                                    title={t('appearance', preset.nameKey)}
+                                    aria-pressed={selected}
+                                    style={{
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        alignItems: 'center',
+                                        gap: '8px',
+                                        background: 'transparent',
+                                        border: 'none',
+                                        cursor: 'pointer',
+                                        padding: '4px'
+                                    }}
+                                >
+                                    <span style={{
+                                        width: '44px',
+                                        height: '44px',
+                                        borderRadius: '50%',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        background: `linear-gradient(135deg, ${preset.accent}, ${preset.gradTo})`,
+                                        border: selected ? '3px solid white' : '3px solid transparent',
+                                        boxShadow: selected ? `0 0 14px ${preset.accent}` : 'none',
+                                        color: 'white',
+                                        fontSize: '16px',
+                                        fontWeight: 700,
+                                        transition: 'all 0.2s ease'
+                                    }}>
+                                        {selected ? '✓' : ''}
+                                    </span>
+                                    <span style={{
+                                        fontSize: '12px',
+                                        fontWeight: 600,
+                                        color: selected ? 'white' : 'rgba(255, 255, 255, 0.6)'
+                                    }}>
+                                        {t('appearance', preset.nameKey)}
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* Partial theming note */}
+                <div className="last-check">
+                    <span className="check-icon">ℹ️</span>
+                    <span>{t('appearance', 'note')}</span>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/services/themeService.test.ts
+++ b/src/services/themeService.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+    ACCENT_PRESETS,
+    BACKGROUND_PRESETS,
+    DEFAULT_THEME,
+    cssVariablesFor,
+    parseStoredTheme,
+    themeService
+} from './themeService'
+import type { Theme } from './themeService'
+
+const HEX_RE = /^#[0-9a-f]{6}$/
+
+function hexToRgbString(hex: string): string {
+    const n = parseInt(hex.slice(1), 16)
+    return `${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}`
+}
+
+beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+    // reset singleton state back to defaults
+    themeService.setTheme({ ...DEFAULT_THEME })
+    localStorage.clear()
+})
+
+describe('accent preset table integrity', () => {
+    it('has exactly 6 presets with unique ids and colors', () => {
+        expect(ACCENT_PRESETS).toHaveLength(6)
+        const ids = ACCENT_PRESETS.map(p => p.id)
+        expect(new Set(ids).size).toBe(6)
+        const accents = ACCENT_PRESETS.map(p => p.accent)
+        expect(new Set(accents).size).toBe(6)
+    })
+
+    it('every preset has valid lowercase hex colors', () => {
+        for (const p of ACCENT_PRESETS) {
+            expect(p.accent).toMatch(HEX_RE)
+            expect(p.dark).toMatch(HEX_RE)
+            expect(p.light).toMatch(HEX_RE)
+            expect(p.gradTo).toMatch(HEX_RE)
+        }
+    })
+
+    it('rgb triplets match their hex counterparts', () => {
+        for (const p of ACCENT_PRESETS) {
+            expect(p.rgb).toBe(hexToRgbString(p.accent))
+            expect(p.gradToRgb).toBe(hexToRgbString(p.gradTo))
+        }
+    })
+
+    it('"roxo" mirrors the classic palette exactly', () => {
+        const roxo = ACCENT_PRESETS.find(p => p.id === 'roxo')!
+        expect(roxo.accent).toBe('#a855f7')
+        expect(roxo.gradTo).toBe('#ec4899')
+        expect(roxo.light).toBe('#c4b5fd')
+    })
+
+    it('background presets: default mirrors classic, amoled is pure black', () => {
+        expect(BACKGROUND_PRESETS.map(b => b.id)).toEqual(['default', 'amoled'])
+        const def = BACKGROUND_PRESETS[0]
+        expect(def.deep).toBe('#0f0f1a')
+        expect(def.panel).toBe('#1a1a2e')
+        const amoled = BACKGROUND_PRESETS[1]
+        expect(amoled.deep).toBe('#000000')
+        expect(amoled.panel).toBe('#0a0a0f')
+    })
+})
+
+describe('cssVariablesFor', () => {
+    it('default theme produces the classic values', () => {
+        const vars = cssVariablesFor(DEFAULT_THEME)
+        expect(vars['--ns-accent']).toBe('#a855f7')
+        expect(vars['--ns-accent-grad-to']).toBe('#ec4899')
+        expect(vars['--ns-accent-rgb']).toBe('168, 85, 247')
+        expect(vars['--ns-accent-soft']).toBe('rgba(168, 85, 247, 0.15)')
+        expect(vars['--ns-bg-deep']).toBe('#0f0f1a')
+        expect(vars['--ns-bg-panel']).toBe('#1a1a2e')
+    })
+
+    it('amoled + azul switches background and accent variables', () => {
+        const vars = cssVariablesFor({ background: 'amoled', accent: 'azul' })
+        expect(vars['--ns-bg-deep']).toBe('#000000')
+        expect(vars['--ns-bg-panel']).toBe('#0a0a0f')
+        expect(vars['--ns-accent']).toBe('#3b82f6')
+        expect(vars['--ns-accent-glow']).toBe('rgba(59, 130, 246, 0.4)')
+    })
+})
+
+describe('parseStoredTheme', () => {
+    it('returns the default theme for null/garbage input', () => {
+        expect(parseStoredTheme(null)).toEqual(DEFAULT_THEME)
+        expect(parseStoredTheme('not json {{{')).toEqual(DEFAULT_THEME)
+    })
+
+    it('falls back per-field on unknown values', () => {
+        expect(parseStoredTheme(JSON.stringify({ background: 'neon', accent: 'verde' })))
+            .toEqual({ background: 'default', accent: 'verde' })
+        expect(parseStoredTheme(JSON.stringify({ background: 'amoled', accent: 'cyan' })))
+            .toEqual({ background: 'amoled', accent: 'roxo' })
+    })
+})
+
+describe('persistence round-trip', () => {
+    it('setTheme persists to localStorage under neostream_theme', () => {
+        themeService.setTheme({ background: 'amoled', accent: 'rosa' })
+        const stored = JSON.parse(localStorage.getItem('neostream_theme')!) as Theme
+        expect(stored).toEqual({ background: 'amoled', accent: 'rosa' })
+        expect(parseStoredTheme(localStorage.getItem('neostream_theme'))).toEqual(stored)
+    })
+
+    it('partial setTheme keeps the other field', () => {
+        themeService.setTheme({ accent: 'laranja' })
+        expect(themeService.getTheme()).toEqual({ background: 'default', accent: 'laranja' })
+        themeService.setTheme({ background: 'amoled' })
+        expect(themeService.getTheme()).toEqual({ background: 'amoled', accent: 'laranja' })
+    })
+})
+
+describe('CSS variable application', () => {
+    it('apply() sets --ns-* variables and data-theme on <html>', () => {
+        themeService.setTheme({ background: 'amoled', accent: 'verde' })
+        const root = document.documentElement
+        expect(root.style.getPropertyValue('--ns-accent')).toBe('#22c55e')
+        expect(root.style.getPropertyValue('--ns-bg-deep')).toBe('#000000')
+        expect(root.getAttribute('data-theme')).toBe('amoled-verde')
+    })
+
+    it('switching back to default restores the classic values', () => {
+        themeService.setTheme({ background: 'amoled', accent: 'azul' })
+        themeService.setTheme({ ...DEFAULT_THEME })
+        const root = document.documentElement
+        expect(root.style.getPropertyValue('--ns-accent')).toBe('#a855f7')
+        expect(root.style.getPropertyValue('--ns-bg-deep')).toBe('#0f0f1a')
+        expect(root.getAttribute('data-theme')).toBe('default-roxo')
+    })
+
+    it('notifies subscribers on change', () => {
+        let calls = 0
+        const unsub = themeService.subscribe(() => { calls += 1 })
+        themeService.setTheme({ accent: 'vermelho' })
+        expect(calls).toBe(1)
+        unsub()
+        themeService.setTheme({ accent: 'roxo' })
+        expect(calls).toBe(1)
+    })
+})

--- a/src/services/themeService.ts
+++ b/src/services/themeService.ts
@@ -1,0 +1,171 @@
+// Theme Service - app appearance (background variant + accent color preset)
+//
+// The app is a hand-styled dark UI. Theming works by setting CSS custom
+// properties (--ns-*) on <html> that high-visibility surfaces consume via
+// var(). Surfaces not yet migrated keep the classic palette (documented
+// limitation shown in Settings > Aparência).
+
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'neostream_theme';
+
+export type BackgroundVariant = 'default' | 'amoled';
+export type AccentId = 'roxo' | 'azul' | 'verde' | 'vermelho' | 'laranja' | 'rosa';
+
+export interface Theme {
+    background: BackgroundVariant;
+    accent: AccentId;
+}
+
+export interface AccentPreset {
+    id: AccentId;
+    /** translation key under the "appearance" section */
+    nameKey: string;
+    /** main accent color */
+    accent: string;
+    /** darker variant (gradient ends, pressed states) */
+    dark: string;
+    /** lighter variant (hover text/icons) */
+    light: string;
+    /** companion second gradient stop (accent → gradTo gradients) */
+    gradTo: string;
+    /** "r, g, b" of accent, for rgba(var(--ns-accent-rgb), a) composition */
+    rgb: string;
+    /** "r, g, b" of gradTo */
+    gradToRgb: string;
+}
+
+// Hard-coded preset table. "roxo" mirrors the classic palette exactly
+// (#a855f7 → #ec4899 gradients) so the default theme is pixel-identical.
+export const ACCENT_PRESETS: readonly AccentPreset[] = [
+    { id: 'roxo', nameKey: 'colorPurple', accent: '#a855f7', dark: '#7c3aed', light: '#c4b5fd', gradTo: '#ec4899', rgb: '168, 85, 247', gradToRgb: '236, 72, 153' },
+    { id: 'azul', nameKey: 'colorBlue', accent: '#3b82f6', dark: '#1d4ed8', light: '#93c5fd', gradTo: '#06b6d4', rgb: '59, 130, 246', gradToRgb: '6, 182, 212' },
+    { id: 'verde', nameKey: 'colorGreen', accent: '#22c55e', dark: '#15803d', light: '#86efac', gradTo: '#14b8a6', rgb: '34, 197, 94', gradToRgb: '20, 184, 166' },
+    { id: 'vermelho', nameKey: 'colorRed', accent: '#ef4444', dark: '#b91c1c', light: '#fca5a5', gradTo: '#f97316', rgb: '239, 68, 68', gradToRgb: '249, 115, 22' },
+    { id: 'laranja', nameKey: 'colorOrange', accent: '#f97316', dark: '#c2410c', light: '#fdba74', gradTo: '#f59e0b', rgb: '249, 115, 22', gradToRgb: '245, 158, 11' },
+    { id: 'rosa', nameKey: 'colorPink', accent: '#ec4899', dark: '#be185d', light: '#f9a8d4', gradTo: '#f43f5e', rgb: '236, 72, 153', gradToRgb: '244, 63, 94' }
+];
+
+export interface BackgroundPreset {
+    id: BackgroundVariant;
+    nameKey: string;
+    /** deepest background (page gradients start, sidebar) */
+    deep: string;
+    /** panel/card background */
+    panel: string;
+    /** subtle blue-ish tint used as third gradient stop */
+    tint: string;
+}
+
+export const BACKGROUND_PRESETS: readonly BackgroundPreset[] = [
+    { id: 'default', nameKey: 'backgroundDefault', deep: '#0f0f1a', panel: '#1a1a2e', tint: '#16213e' },
+    { id: 'amoled', nameKey: 'backgroundAmoled', deep: '#000000', panel: '#0a0a0f', tint: '#05050a' }
+];
+
+export const DEFAULT_THEME: Theme = { background: 'default', accent: 'roxo' };
+
+export function getAccentPreset(id: AccentId): AccentPreset {
+    return ACCENT_PRESETS.find(p => p.id === id) ?? ACCENT_PRESETS[0];
+}
+
+export function getBackgroundPreset(id: BackgroundVariant): BackgroundPreset {
+    return BACKGROUND_PRESETS.find(p => p.id === id) ?? BACKGROUND_PRESETS[0];
+}
+
+/** Pure: theme → CSS custom property map (what gets set on <html>). */
+export function cssVariablesFor(theme: Theme): Record<string, string> {
+    const accent = getAccentPreset(theme.accent);
+    const bg = getBackgroundPreset(theme.background);
+    return {
+        '--ns-accent': accent.accent,
+        '--ns-accent-dark': accent.dark,
+        '--ns-accent-light': accent.light,
+        '--ns-accent-grad-to': accent.gradTo,
+        '--ns-accent-rgb': accent.rgb,
+        '--ns-accent-grad-to-rgb': accent.gradToRgb,
+        '--ns-accent-soft': `rgba(${accent.rgb}, 0.15)`,
+        '--ns-accent-glow': `rgba(${accent.rgb}, 0.4)`,
+        '--ns-bg-deep': bg.deep,
+        '--ns-bg-panel': bg.panel,
+        '--ns-bg-tint': bg.tint
+    };
+}
+
+/** Pure: parse a persisted JSON string back into a valid Theme (or default). */
+export function parseStoredTheme(raw: string | null): Theme {
+    if (!raw) return { ...DEFAULT_THEME };
+    try {
+        const parsed = JSON.parse(raw) as Partial<Theme>;
+        const background = BACKGROUND_PRESETS.some(b => b.id === parsed.background)
+            ? parsed.background as BackgroundVariant
+            : DEFAULT_THEME.background;
+        const accent = ACCENT_PRESETS.some(a => a.id === parsed.accent)
+            ? parsed.accent as AccentId
+            : DEFAULT_THEME.accent;
+        return { background, accent };
+    } catch {
+        return { ...DEFAULT_THEME };
+    }
+}
+
+class ThemeService {
+    private theme: Theme;
+    private listeners: Set<() => void> = new Set();
+
+    constructor() {
+        let raw: string | null = null;
+        try {
+            raw = localStorage.getItem(STORAGE_KEY);
+        } catch {
+            // localStorage unavailable (tests/SSR) — fall back to default
+        }
+        this.theme = parseStoredTheme(raw);
+    }
+
+    getTheme(): Theme {
+        return { ...this.theme };
+    }
+
+    setTheme(partial: Partial<Theme>): void {
+        this.theme = { ...this.theme, ...partial };
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this.theme));
+        } catch {
+            // best effort persistence
+        }
+        this.apply();
+        this.listeners.forEach(listener => listener());
+    }
+
+    /** Set the --ns-* variables + data-theme attribute on <html>. */
+    apply(): void {
+        if (typeof document === 'undefined') return;
+        const root = document.documentElement;
+        const vars = cssVariablesFor(this.theme);
+        for (const [name, value] of Object.entries(vars)) {
+            root.style.setProperty(name, value);
+        }
+        root.setAttribute('data-theme', `${this.theme.background}-${this.theme.accent}`);
+    }
+
+    subscribe(listener: () => void): () => void {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+}
+
+export const themeService = new ThemeService();
+
+/** React hook: current theme + setter, re-renders on any theme change. */
+export function useTheme() {
+    const [theme, setThemeState] = useState<Theme>(themeService.getTheme());
+
+    useEffect(() => {
+        return themeService.subscribe(() => setThemeState(themeService.getTheme()));
+    }, []);
+
+    return {
+        theme,
+        setTheme: (partial: Partial<Theme>) => themeService.setTheme(partial)
+    };
+}


### PR DESCRIPTION
## 🎨 Temas

Seção nova **Aparência** nas Configurações.

### O que tem
- **Fundo**: Padrão (atual) ou **AMOLED** (preto puro, ideal pra OLED)
- **Cor de destaque**: Roxo (atual), Azul, Verde, Vermelho, Laranja ou Rosa — aplicada em botões, realces, gradientes, linha "Agora" do guia, scrollbars etc.
- Aplicação **instantânea** ao clicar (preview ao vivo, sem botão salvar) e persistida entre sessões
- Aplicado antes do primeiro paint (sem flash de tema errado na inicialização)

### Como funciona
- `themeService` grava em localStorage e seta variáveis CSS `--ns-*` no `<html>`; o `:root` carrega a paleta clássica como default, então **o tema padrão é pixel-idêntico ao build anterior**
- Superfícies temáticas nesta v1: Sidebar, Home, busca global, Guia de TV, Histórico, Configurações e scrollbars. Player, modais e páginas de conteúdo mantêm a paleta clássica por enquanto (nota na própria UI)

### Extra
Remove dois instaladores fantasma de 0 bytes (v3.9.3) que estavam commitados em `release/` — o workflow de release estava anexando eles como assets falsos (já removidos da v3.12.0 também).

### Verificação
- ✅ tsc / eslint / vitest **79/79** (12 testes novos) / vite build
- ✅ Visual ao vivo: AMOLED + Azul aplicados na hora em Home/Sidebar/Configurações; padrão restaurado idêntico