### PR TITLE
fix: tema completo no fluxo de assistir (modais, player, páginas)

### DIFF
--- a/electron/autoUpdater.ts
+++ b/electron/autoUpdater.ts
@@ -106,7 +106,9 @@ export function initializeAutoUpdater(mainWindow: BrowserWindow) {
             // Give user 5 seconds before auto-installing
             setTimeout(() => {
                 log.info('Auto-installing update...');
-                autoUpdater.quitAndInstall(false, true);
+                // isSilent=true: never show the NSIS wizard — the in-app
+                // update UI is the only thing the user sees.
+                autoUpdater.quitAndInstall(true, true);
             }, 5000);
         }
     });
@@ -160,8 +162,8 @@ export function initializeAutoUpdater(mainWindow: BrowserWindow) {
 
     ipcMain.handle('update:install', () => {
         try {
-            // Quit and install immediately
-            autoUpdater.quitAndInstall(false, true);
+            // Quit and install immediately, silently (no NSIS wizard)
+            autoUpdater.quitAndInstall(true, true);
             return { success: true };
         } catch (error: unknown) {
             log.error('Error installing update:', error);

--- a/src/components/AnimatedSearchBar.tsx
+++ b/src/components/AnimatedSearchBar.tsx
@@ -60,14 +60,14 @@ export function AnimatedSearchBar({ value, onChange, placeholder = "Buscar..." }
             <style>{`
                 @keyframes pulseGlow {
                     0%, 100% { 
-                        box-shadow: 0 0 20px rgba(99, 102, 241, 0.4), 
-                                    0 0 40px rgba(99, 102, 241, 0.2),
-                                    inset 0 0 20px rgba(99, 102, 241, 0.1);
+                        box-shadow: 0 0 20px rgba(var(--ns-accent-rgb), 0.4), 
+                                    0 0 40px rgba(var(--ns-accent-rgb), 0.2),
+                                    inset 0 0 20px rgba(var(--ns-accent-rgb), 0.1);
                     }
                     50% { 
-                        box-shadow: 0 0 30px rgba(99, 102, 241, 0.6), 
-                                    0 0 60px rgba(99, 102, 241, 0.3),
-                                    inset 0 0 30px rgba(99, 102, 241, 0.15);
+                        box-shadow: 0 0 30px rgba(var(--ns-accent-rgb), 0.6), 
+                                    0 0 60px rgba(var(--ns-accent-rgb), 0.3),
+                                    inset 0 0 30px rgba(var(--ns-accent-rgb), 0.15);
                     }
                 }
                 
@@ -116,7 +116,7 @@ export function AnimatedSearchBar({ value, onChange, placeholder = "Buscar..." }
                     inset: 0;
                     border-radius: 50px;
                     padding: 2px;
-                    background: linear-gradient(135deg, #6366f1, #8b5cf6, #a855f7, #6366f1);
+                    background: linear-gradient(135deg, var(--ns-accent-dark), var(--ns-accent), var(--ns-accent-grad-to), var(--ns-accent-dark));
                     background-size: 300% 300%;
                     -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
                     mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
@@ -136,7 +136,7 @@ export function AnimatedSearchBar({ value, onChange, placeholder = "Buscar..." }
                     color: white;
                     font-size: 15px;
                     font-weight: 500;
-                    border: 1px solid rgba(99, 102, 241, 0.3);
+                    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
                     border-radius: 50px;
                     outline: none;
                     backdrop-filter: blur(20px);
@@ -150,21 +150,21 @@ export function AnimatedSearchBar({ value, onChange, placeholder = "Buscar..." }
                 }
                 
                 .search-input:focus {
-                    border-color: rgba(99, 102, 241, 0.6);
+                    border-color: rgba(var(--ns-accent-rgb), 0.6);
                 }
                 
                 .search-btn {
                     width: 52px;
                     height: 52px;
-                    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #a855f7 100%);
+                    background: linear-gradient(135deg, var(--ns-accent-dark) 0%, var(--ns-accent) 50%, var(--ns-accent-grad-to) 100%);
                     border: none;
                     border-radius: 50%;
                     cursor: pointer;
                     display: flex;
                     align-items: center;
                     justify-content: center;
-                    box-shadow: 0 4px 20px rgba(99, 102, 241, 0.4),
-                                0 0 40px rgba(99, 102, 241, 0.2);
+                    box-shadow: 0 4px 20px rgba(var(--ns-accent-rgb), 0.4),
+                                0 0 40px rgba(var(--ns-accent-rgb), 0.2);
                     transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
                     position: relative;
                     z-index: 10;
@@ -173,8 +173,8 @@ export function AnimatedSearchBar({ value, onChange, placeholder = "Buscar..." }
                 
                 .search-btn:hover {
                     transform: scale(1.1);
-                    box-shadow: 0 6px 30px rgba(99, 102, 241, 0.5),
-                                0 0 60px rgba(99, 102, 241, 0.3);
+                    box-shadow: 0 6px 30px rgba(var(--ns-accent-rgb), 0.5),
+                                0 0 60px rgba(var(--ns-accent-rgb), 0.3);
                 }
                 
                 .search-btn:active {

--- a/src/components/AsyncVideoPlayer.tsx
+++ b/src/components/AsyncVideoPlayer.tsx
@@ -217,8 +217,8 @@ function AsyncVideoPlayer<TMovie extends MediaItem, TVersion extends MediaItem =
         }
 
         @keyframes loadingGlow {
-            0%, 100% { box-shadow: 0 0 20px rgba(168, 85, 247, 0.3); }
-            50% { box-shadow: 0 0 40px rgba(168, 85, 247, 0.6), 0 0 60px rgba(236, 72, 153, 0.3); }
+            0%, 100% { box-shadow: 0 0 20px rgba(var(--ns-accent-rgb), 0.3); }
+            50% { box-shadow: 0 0 40px rgba(var(--ns-accent-rgb), 0.6), 0 0 60px rgba(var(--ns-accent-grad-to-rgb), 0.3); }
         }
 
         .player-backdrop {
@@ -255,7 +255,7 @@ function AsyncVideoPlayer<TMovie extends MediaItem, TVersion extends MediaItem =
             width: 80px;
             height: 80px;
             border-radius: 50%;
-            background: linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2));
+            background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.2));
             display: flex;
             align-items: center;
             justify-content: center;
@@ -275,7 +275,7 @@ function AsyncVideoPlayer<TMovie extends MediaItem, TVersion extends MediaItem =
             width: 10px;
             height: 10px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #a855f7, #ec4899);
+            background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
             animation: loadingDots 1.4s ease-in-out infinite;
         }
 
@@ -334,7 +334,7 @@ function AsyncVideoPlayer<TMovie extends MediaItem, TVersion extends MediaItem =
 
         .error-btn {
             padding: 12px 24px;
-            background: linear-gradient(135deg, #a855f7, #ec4899);
+            background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
             border: none;
             border-radius: 8px;
             color: white;

--- a/src/components/CastControls.tsx
+++ b/src/components/CastControls.tsx
@@ -144,13 +144,13 @@ export function CastControls({ deviceId, deviceName, onSessionEnded }: CastContr
             padding: '10px 16px',
             borderRadius: 14,
             background: 'rgba(15, 15, 35, 0.95)',
-            border: '1px solid rgba(139, 92, 246, 0.5)',
+            border: '1px solid rgba(var(--ns-accent-rgb), 0.5)',
             boxShadow: '0 8px 32px rgba(0, 0, 0, 0.6)',
             color: 'white',
             minWidth: 420,
             maxWidth: '90vw'
         }}>
-            <Tv size={18} color="#8b5cf6" style={{ flexShrink: 0 }} />
+            <Tv size={18} color="var(--ns-accent)" style={{ flexShrink: 0 }} />
             <div style={{ minWidth: 0, flexShrink: 1 }}>
                 <div style={{
                     fontSize: 12,
@@ -169,7 +169,7 @@ export function CastControls({ deviceId, deviceName, onSessionEnded }: CastContr
                 onClick={handleTogglePlay}
                 title={isPlaying ? 'Pausar' : 'Reproduzir'}
                 style={{
-                    background: 'rgba(139, 92, 246, 0.8)',
+                    background: 'rgba(var(--ns-accent-rgb), 0.8)',
                     border: 'none',
                     borderRadius: 8,
                     padding: 8,
@@ -192,7 +192,7 @@ export function CastControls({ deviceId, deviceName, onSessionEnded }: CastContr
                         max={Math.max(1, Math.floor(duration))}
                         value={Math.floor(position)}
                         onChange={handleSeek}
-                        style={{ flex: 1, height: 4, cursor: 'pointer', accentColor: '#8b5cf6' }}
+                        style={{ flex: 1, height: 4, cursor: 'pointer', accentColor: 'var(--ns-accent)' }}
                     />
                     <span style={{ fontSize: 10, color: '#9ca3af', flexShrink: 0 }}>{formatTime(duration)}</span>
                 </div>
@@ -211,7 +211,7 @@ export function CastControls({ deviceId, deviceName, onSessionEnded }: CastContr
                         max={100}
                         value={volume}
                         onChange={handleVolume}
-                        style={{ width: 64, height: 4, cursor: 'pointer', accentColor: '#8b5cf6' }}
+                        style={{ width: 64, height: 4, cursor: 'pointer', accentColor: 'var(--ns-accent)' }}
                     />
                 </div>
             )}

--- a/src/components/CastDeviceSelector.tsx
+++ b/src/components/CastDeviceSelector.tsx
@@ -320,8 +320,8 @@ const castStyles = `
     width: 90%;
     max-width: 480px;
     max-height: 85vh;
-    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-    border: 1px solid rgba(168, 85, 247, 0.2);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.2);
     border-radius: 24px;
     overflow: hidden;
     animation: modalSlide 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -350,7 +350,7 @@ const castStyles = `
 .orb-1 {
     width: 200px;
     height: 200px;
-    background: linear-gradient(135deg, #a855f7, #ec4899);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
     top: -50px;
     right: -50px;
     animation: orbFloat 8s ease-in-out infinite;
@@ -402,7 +402,7 @@ const castStyles = `
     font-weight: 700;
     color: white;
     margin: 0;
-    background: linear-gradient(135deg, #fff 0%, #c4b5fd 100%);
+    background: linear-gradient(135deg, #fff 0%, var(--ns-accent-light) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -559,8 +559,8 @@ const castStyles = `
 }
 
 .device-item:hover:not(.disabled) {
-    background: rgba(168, 85, 247, 0.1);
-    border-color: rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.1);
+    border-color: rgba(var(--ns-accent-rgb), 0.3);
     transform: translateX(4px);
 }
 
@@ -573,7 +573,7 @@ const castStyles = `
     width: 48px;
     height: 48px;
     border-radius: 12px;
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2));
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.2));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -644,9 +644,9 @@ const castStyles = `
 }
 
 .add-device-btn:hover {
-    border-color: rgba(168, 85, 247, 0.5);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
     color: white;
-    background: rgba(168, 85, 247, 0.1);
+    background: rgba(var(--ns-accent-rgb), 0.1);
 }
 
 /* Help */
@@ -719,8 +719,8 @@ const castStyles = `
 
 .form-input:focus {
     outline: none;
-    border-color: rgba(168, 85, 247, 0.5);
-    box-shadow: 0 0 0 3px rgba(168, 85, 247, 0.1);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
+    box-shadow: 0 0 0 3px rgba(var(--ns-accent-rgb), 0.1);
 }
 
 .form-input::placeholder {
@@ -731,7 +731,7 @@ const castStyles = `
 .submit-btn {
     width: 100%;
     padding: 14px 24px;
-    background: linear-gradient(135deg, #a855f7 0%, #ec4899 100%);
+    background: linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%);
     border: none;
     border-radius: 12px;
     color: white;
@@ -744,7 +744,7 @@ const castStyles = `
 
 .submit-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 10px 30px rgba(168, 85, 247, 0.3);
+    box-shadow: 0 10px 30px rgba(var(--ns-accent-rgb), 0.3);
 }
 
 .submit-btn:active {

--- a/src/components/CastDeviceSelector.tsx
+++ b/src/components/CastDeviceSelector.tsx
@@ -452,7 +452,7 @@ const castStyles = `
     justify-content: center;
     gap: 10px;
     padding: 14px 20px;
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(147, 51, 234, 0.2));
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(var(--ns-accent-rgb), 0.2));
     border: 1px solid rgba(59, 130, 246, 0.3);
     border-radius: 12px;
     color: white;

--- a/src/components/CategoryMenu.tsx
+++ b/src/components/CategoryMenu.tsx
@@ -295,11 +295,11 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                 @keyframes borderGlow {
                     0%, 100% { 
                         background-position: 0% 50%;
-                        box-shadow: 0 0 20px rgba(99, 102, 241, 0.3);
+                        box-shadow: 0 0 20px rgba(var(--ns-accent-rgb), 0.3);
                     }
                     50% { 
                         background-position: 100% 50%;
-                        box-shadow: 0 0 30px rgba(168, 85, 247, 0.4);
+                        box-shadow: 0 0 30px rgba(var(--ns-accent-rgb), 0.4);
                     }
                 }
                 
@@ -355,7 +355,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                     inset: 0;
                     border-radius: 14px;
                     padding: 2px;
-                    background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899, #6366f1);
+                    background: linear-gradient(135deg, var(--ns-accent-dark), var(--ns-accent), var(--ns-accent-grad-to), var(--ns-accent-dark));
                     background-size: 300% 300%;
                     -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
                     mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
@@ -372,7 +372,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                 
                 .category-item:hover {
                     transform: translateX(8px) scale(1.02);
-                    background: rgba(99, 102, 241, 0.1) !important;
+                    background: rgba(var(--ns-accent-rgb), 0.1) !important;
                 }
                 
                 .category-item.selected {
@@ -390,7 +390,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                 }
                 
                 .category-scroll::-webkit-scrollbar-thumb {
-                    background: linear-gradient(180deg, #6366f1, #a855f7);
+                    background: linear-gradient(180deg, var(--ns-accent-dark), var(--ns-accent));
                     border-radius: 4px;
                     border: 2px solid transparent;
                     background-clip: content-box;
@@ -408,7 +408,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                 
                 .toggle-btn:hover {
                     transform: scale(1.15);
-                    filter: drop-shadow(0 0 12px rgba(99, 102, 241, 0.6));
+                    filter: drop-shadow(0 0 12px rgba(var(--ns-accent-rgb), 0.6));
                 }
                 
                 .toggle-btn:active {
@@ -428,7 +428,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                     width: '48px',
                     height: '48px',
                     background: isOpen
-                        ? 'linear-gradient(135deg, rgba(99, 102, 241, 0.3) 0%, rgba(168, 85, 247, 0.3) 100%)'
+                        ? 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.3) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.3) 100%)'
                         : 'transparent',
                     border: 'none',
                     borderRadius: '12px',
@@ -446,7 +446,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                     style={{
                         width: '22px',
                         height: '2.5px',
-                        background: 'linear-gradient(90deg, #6366f1, #a855f7)',
+                        background: 'linear-gradient(90deg, var(--ns-accent-dark), var(--ns-accent))',
                         borderRadius: '2px',
                         display: 'block'
                     }}
@@ -456,7 +456,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                     style={{
                         width: '22px',
                         height: '2.5px',
-                        background: 'linear-gradient(90deg, #a855f7, #ec4899)',
+                        background: 'linear-gradient(90deg, var(--ns-accent), var(--ns-accent-grad-to))',
                         borderRadius: '2px',
                         display: 'block'
                     }}
@@ -466,7 +466,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                     style={{
                         width: '22px',
                         height: '2.5px',
-                        background: 'linear-gradient(90deg, #ec4899, #6366f1)',
+                        background: 'linear-gradient(90deg, var(--ns-accent-grad-to), var(--ns-accent-dark))',
                         borderRadius: '2px',
                         display: 'block'
                     }}
@@ -503,14 +503,14 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                     flexDirection: 'column',
                     backdropFilter: 'blur(24px)',
                     borderRight: '2px solid',
-                    borderImage: 'linear-gradient(180deg, rgba(99, 102, 241, 0.5), rgba(168, 85, 247, 0.5), rgba(236, 72, 153, 0.3)) 1',
-                    boxShadow: '8px 0 40px rgba(0, 0, 0, 0.5), 0 0 100px rgba(99, 102, 241, 0.15)'
+                    borderImage: 'linear-gradient(180deg, rgba(var(--ns-accent-rgb), 0.5), rgba(var(--ns-accent-rgb), 0.5), rgba(var(--ns-accent-grad-to-rgb), 0.3)) 1',
+                    boxShadow: '8px 0 40px rgba(0, 0, 0, 0.5), 0 0 100px rgba(var(--ns-accent-rgb), 0.15)'
                 }}
             >
                 {/* Header with gradient */}
                 <div style={{
                     padding: '32px 24px',
-                    background: 'linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(147, 51, 234, 0.15) 100%)',
+                    background: 'linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(var(--ns-accent-rgb), 0.15) 100%)',
                     borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
                     position: 'relative',
                     overflow: 'hidden'
@@ -567,7 +567,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                     <div style={{ position: 'relative', zIndex: 1 }}>
                         <h2 style={{
                             margin: 0,
-                            background: 'linear-gradient(135deg, #60a5fa 0%, #a78bfa 100%)',
+                            background: 'linear-gradient(135deg, #60a5fa 0%, var(--ns-accent-light) 100%)',
                             WebkitBackgroundClip: 'text',
                             WebkitTextFillColor: 'transparent',
                             fontSize: '28px',
@@ -596,7 +596,7 @@ export function CategoryMenu({ onSelectCategory, selectedCategory, type = 'serie
                         overflowY: 'auto',
                         padding: '16px',
                         scrollbarWidth: 'thin',
-                        scrollbarColor: 'rgba(99, 102, 241, 0.5) transparent'
+                        scrollbarColor: 'rgba(var(--ns-accent-rgb), 0.5) transparent'
                     }}
                 >
                     {loading && (

--- a/src/components/ContentDetailModal.tsx
+++ b/src/components/ContentDetailModal.tsx
@@ -365,13 +365,13 @@ export function ContentDetailModal({
                     width: '90%',
                     maxWidth: 900,
                     maxHeight: '90vh',
-                    background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)',
+                    background: 'linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%)',
                     borderRadius: 20,
                     overflow: 'hidden',
                     display: 'flex',
                     flexDirection: 'row',
                     boxShadow: '0 25px 80px rgba(0, 0, 0, 0.6)',
-                    border: '1px solid rgba(168, 85, 247, 0.3)',
+                    border: '1px solid rgba(var(--ns-accent-rgb), 0.3)',
                     animation: 'slideUp 0.3s ease'
                 }}
             >
@@ -421,7 +421,7 @@ export function ContentDetailModal({
                     <div style={{
                         position: 'absolute',
                         inset: 0,
-                        background: 'linear-gradient(90deg, transparent 60%, rgba(26, 26, 46, 1) 100%)'
+                        background: 'linear-gradient(90deg, transparent 60%, var(--ns-bg-panel) 100%)'
                     }} />
                 </div>
 
@@ -550,10 +550,10 @@ export function ContentDetailModal({
                                             padding: '8px 16px',
                                             borderRadius: 20,
                                             border: selectedSeason === Number(season)
-                                                ? '2px solid #a855f7'
+                                                ? '2px solid var(--ns-accent)'
                                                 : '2px solid rgba(255, 255, 255, 0.1)',
                                             background: selectedSeason === Number(season)
-                                                ? 'linear-gradient(135deg, rgba(168, 85, 247, 0.3), rgba(236, 72, 153, 0.2))'
+                                                ? 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.3), rgba(var(--ns-accent-grad-to-rgb), 0.2))'
                                                 : 'rgba(255, 255, 255, 0.05)',
                                             color: 'white',
                                             fontSize: 13,
@@ -593,9 +593,9 @@ export function ContentDetailModal({
                                                 borderRadius: 10,
                                                 cursor: 'pointer',
                                                 background: isSelected
-                                                    ? 'linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.15))'
+                                                    ? 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.15))'
                                                     : 'transparent',
-                                                border: isSelected ? '1px solid rgba(168, 85, 247, 0.4)' : '1px solid transparent',
+                                                border: isSelected ? '1px solid rgba(var(--ns-accent-rgb), 0.4)' : '1px solid transparent',
                                                 opacity: isWatched ? 0.6 : 1,
                                                 transition: 'all 0.2s'
                                             }}
@@ -606,7 +606,7 @@ export function ContentDetailModal({
                                                 borderRadius: 8,
                                                 background: isWatched
                                                     ? 'linear-gradient(135deg, #10b981, #059669)'
-                                                    : 'rgba(168, 85, 247, 0.3)',
+                                                    : 'rgba(var(--ns-accent-rgb), 0.3)',
                                                 display: 'flex',
                                                 alignItems: 'center',
                                                 justifyContent: 'center',
@@ -631,7 +631,7 @@ export function ContentDetailModal({
                                                     width: 24,
                                                     height: 24,
                                                     borderRadius: '50%',
-                                                    background: 'linear-gradient(135deg, #a855f7, #ec4899)',
+                                                    background: 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to))',
                                                     display: 'flex',
                                                     alignItems: 'center',
                                                     justifyContent: 'center',
@@ -676,8 +676,8 @@ export function ContentDetailModal({
                                 style={{
                                     padding: '8px 20px',
                                     borderRadius: 8,
-                                    border: '1px solid rgba(139, 92, 246, 0.6)',
-                                    background: 'rgba(139, 92, 246, 0.25)',
+                                    border: '1px solid rgba(var(--ns-accent-rgb), 0.6)',
+                                    background: 'rgba(var(--ns-accent-rgb), 0.25)',
                                     color: 'white',
                                     cursor: 'pointer',
                                     fontWeight: 600
@@ -718,7 +718,7 @@ export function ContentDetailModal({
                                 background: (contentType === 'movie' && downloadService.isDownloaded(contentData.name, 'movie')) ||
                                     (contentType === 'series' && downloadService.getOfflineEpisodePath(contentData.name, selectedSeason, selectedEpisode))
                                     ? 'linear-gradient(135deg, #06b6d4, #0891b2)'
-                                    : 'linear-gradient(135deg, #a855f7, #ec4899)',
+                                    : 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to))',
                                 color: 'white',
                                 fontSize: 15,
                                 fontWeight: 600,
@@ -730,7 +730,7 @@ export function ContentDetailModal({
                                 boxShadow: (contentType === 'movie' && downloadService.isDownloaded(contentData.name, 'movie')) ||
                                     (contentType === 'series' && downloadService.getOfflineEpisodePath(contentData.name, selectedSeason, selectedEpisode))
                                     ? '0 8px 24px rgba(6, 182, 212, 0.4)'
-                                    : '0 8px 24px rgba(168, 85, 247, 0.4)',
+                                    : '0 8px 24px rgba(var(--ns-accent-rgb), 0.4)',
                                 transition: 'all 0.3s'
                             }}
                             onMouseEnter={e => {
@@ -996,12 +996,12 @@ export function ContentDetailModal({
                 >
                     <div
                         style={{
-                            background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)',
+                            background: 'linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%)',
                             borderRadius: 20,
                             padding: 32,
                             maxWidth: 400,
                             textAlign: 'center',
-                            border: '1px solid rgba(168, 85, 247, 0.3)'
+                            border: '1px solid rgba(var(--ns-accent-rgb), 0.3)'
                         }}
                         onClick={e => e.stopPropagation()}
                     >
@@ -1069,9 +1069,9 @@ export function ContentDetailModal({
                                 <div style={{
                                     padding: '14px 24px',
                                     borderRadius: 12,
-                                    background: 'rgba(168, 85, 247, 0.2)',
-                                    border: '2px solid rgba(168, 85, 247, 0.4)',
-                                    color: '#c4b5fd',
+                                    background: 'rgba(var(--ns-accent-rgb), 0.2)',
+                                    border: '2px solid rgba(var(--ns-accent-rgb), 0.4)',
+                                    color: 'var(--ns-accent-light)',
                                     fontSize: 14,
                                     fontWeight: 600,
                                     textAlign: 'center'
@@ -1085,7 +1085,7 @@ export function ContentDetailModal({
                                         padding: '14px 24px',
                                         borderRadius: 12,
                                         border: 'none',
-                                        background: 'linear-gradient(135deg, #a855f7, #ec4899)',
+                                        background: 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to))',
                                         color: 'white',
                                         fontSize: 14,
                                         fontWeight: 600,

--- a/src/components/CustomTitleBar/CustomTitleBar.css
+++ b/src/components/CustomTitleBar/CustomTitleBar.css
@@ -4,13 +4,13 @@
     left: 0;
     right: 0;
     height: 36px;
-    background: linear-gradient(180deg, #1a1a2e 0%, #0f0f23 100%);
+    background: linear-gradient(180deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
     display: flex;
     align-items: center;
     justify-content: space-between;
     z-index: 99999;
     user-select: none;
-    border-bottom: 1px solid rgba(168, 85, 247, 0.2);
+    border-bottom: 1px solid rgba(var(--ns-accent-rgb), 0.2);
 }
 
 .title-bar-drag-region {
@@ -30,7 +30,7 @@
 }
 
 .title-bar-svg {
-    filter: drop-shadow(0 0 4px rgba(168, 85, 247, 0.4));
+    filter: drop-shadow(0 0 4px rgba(var(--ns-accent-rgb), 0.4));
 }
 
 /* Animated bars inside SVG */
@@ -67,7 +67,7 @@
     font-size: 13px;
     font-weight: 600;
     color: #fff;
-    background: linear-gradient(90deg, #a855f7, #ec4899, #a855f7);
+    background: linear-gradient(90deg, var(--ns-accent), var(--ns-accent-grad-to), var(--ns-accent));
     background-size: 200% 100%;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -132,7 +132,7 @@
 
 /* Minimize button */
 .window-control-btn.minimize:hover {
-    background: rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.3);
     color: #fff;
 }
 
@@ -200,7 +200,7 @@
 }
 
 .window-control-btn.minimize:active {
-    background: rgba(168, 85, 247, 0.5);
+    background: rgba(var(--ns-accent-rgb), 0.5);
 }
 
 .window-control-btn.maximize:active {

--- a/src/components/CustomTitleBar/CustomTitleBar.tsx
+++ b/src/components/CustomTitleBar/CustomTitleBar.tsx
@@ -76,8 +76,8 @@ export function CustomTitleBar() {
                     <svg className="title-bar-svg" width="22" height="22" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                         <defs>
                             <linearGradient id="titleBarGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                                <stop offset="0%" stopColor="#a855f7" />
-                                <stop offset="100%" stopColor="#ec4899" />
+                                <stop offset="0%" style={{ stopColor: 'var(--ns-accent)' }} />
+                                <stop offset="100%" style={{ stopColor: 'var(--ns-accent-grad-to)' }} />
                             </linearGradient>
                         </defs>
                         <path d="M 10,10 L 10,90 L 90,50 Z" fill="none" stroke="url(#titleBarGradient)" strokeWidth="6" strokeLinejoin="round" />

--- a/src/components/EpisodeToast.tsx
+++ b/src/components/EpisodeToast.tsx
@@ -86,10 +86,10 @@ export function EpisodeToast({ onNavigateToSeries }: EpisodeToastProps) {
                         display: 'flex',
                         gap: 12,
                         padding: 16,
-                        background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)',
+                        background: 'linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%)',
                         borderRadius: 16,
-                        boxShadow: '0 10px 40px rgba(0, 0, 0, 0.5), 0 0 30px rgba(168, 85, 247, 0.2)',
-                        border: '1px solid rgba(168, 85, 247, 0.4)',
+                        boxShadow: '0 10px 40px rgba(0, 0, 0, 0.5), 0 0 30px rgba(var(--ns-accent-rgb), 0.2)',
+                        border: '1px solid rgba(var(--ns-accent-rgb), 0.4)',
                         maxWidth: 380,
                         animation: 'slideInRight 0.3s ease',
                         pointerEvents: 'auto',
@@ -170,7 +170,7 @@ export function EpisodeToast({ onNavigateToSeries }: EpisodeToastProps) {
                             {toast.message}
                         </div>
                         <div style={{
-                            color: '#a855f7',
+                            color: 'var(--ns-accent)',
                             fontSize: 11,
                             marginTop: 6,
                             fontWeight: 500

--- a/src/components/HoverPreviewCard.css
+++ b/src/components/HoverPreviewCard.css
@@ -24,9 +24,9 @@
 /* Hover state - card expansion */
 .hover-preview-card:hover {
     transform: translateY(-8px) scale(1.03);
-    border-color: rgba(168, 85, 247, 0.4);
+    border-color: rgba(var(--ns-accent-rgb), 0.4);
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4),
-        0 0 40px rgba(168, 85, 247, 0.15);
+        0 0 40px rgba(var(--ns-accent-rgb), 0.15);
 }
 
 /* Poster container */
@@ -34,7 +34,7 @@
     position: relative;
     aspect-ratio: 2 / 3;
     overflow: hidden;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
 }
 
 .preview-poster img {
@@ -66,7 +66,7 @@
 }
 
 .hover-preview-card:hover .card-title {
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
 }
 
 /* Overlay for card */
@@ -91,7 +91,7 @@
 .play-icon {
     width: 60px;
     height: 60px;
-    background: rgba(168, 85, 247, 0.9);
+    background: rgba(var(--ns-accent-rgb), 0.9);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -100,7 +100,7 @@
     color: white;
     transform: scale(0);
     transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    box-shadow: 0 8px 24px rgba(168, 85, 247, 0.5);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.5);
 }
 
 .hover-preview-card:hover .play-icon {
@@ -114,6 +114,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
     font-size: 48px;
 }

--- a/src/components/NotificationsPanel.tsx
+++ b/src/components/NotificationsPanel.tsx
@@ -79,7 +79,7 @@ export function NotificationsPanel({ onNavigateToSeries, onNavigateToDownloads }
         switch (type) {
             case 'new_season':
             case 'new_episodes':
-                return <Tv size={16} color="#a855f7" />;
+                return <Tv size={16} color="var(--ns-accent)" />;
             case 'download_complete':
                 return <Download size={16} color="#10b981" />;
             case 'download_failed':
@@ -104,7 +104,7 @@ export function NotificationsPanel({ onNavigateToSeries, onNavigateToDownloads }
             case 'download_started':
                 return { bg: 'rgba(59, 130, 246, 0.3)', text: '#93c5fd' };
             default:
-                return { bg: 'rgba(168, 85, 247, 0.3)', text: '#c4b5fd' };
+                return { bg: 'rgba(var(--ns-accent-rgb), 0.3)', text: 'var(--ns-accent-light)' };
         }
     };
 
@@ -210,10 +210,10 @@ export function NotificationsPanel({ onNavigateToSeries, onNavigateToDownloads }
                             minWidth: 380,
                             minHeight: 200,
                             maxHeight: 520,
-                            background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)',
+                            background: 'linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%)',
                             borderRadius: 16,
                             boxShadow: '0 20px 60px rgba(0, 0, 0, 0.5)',
-                            border: '1px solid rgba(168, 85, 247, 0.3)',
+                            border: '1px solid rgba(var(--ns-accent-rgb), 0.3)',
                             overflow: 'hidden',
                             zIndex: 999,
                             animation: 'slideIn 0.2s ease'
@@ -240,7 +240,7 @@ export function NotificationsPanel({ onNavigateToSeries, onNavigateToDownloads }
                                 transition: all 0.2s ease;
                             }
                             .notif-action-btn:hover {
-                                background: rgba(168, 85, 247, 0.3);
+                                background: rgba(var(--ns-accent-rgb), 0.3);
                                 transform: scale(1.1);
                             }
                             .notif-action-btn:active {
@@ -257,7 +257,7 @@ export function NotificationsPanel({ onNavigateToSeries, onNavigateToDownloads }
                                 transition: all 0.2s ease;
                             }
                             .notif-header-btn:hover {
-                                background: rgba(168, 85, 247, 0.3);
+                                background: rgba(var(--ns-accent-rgb), 0.3);
                                 transform: scale(1.1);
                             }
                             .notif-header-btn:active {
@@ -274,14 +274,14 @@ export function NotificationsPanel({ onNavigateToSeries, onNavigateToDownloads }
                             justifyContent: 'space-between'
                         }}>
                             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                                <Bell size={18} color="#a855f7" />
+                                <Bell size={18} color="var(--ns-accent)" />
                                 <span style={{ color: 'white', fontWeight: 600, fontSize: 15 }}>
                                     {t('notifications', 'title')}
                                 </span>
                                 {unreadCount > 0 && (
                                     <span style={{
-                                        background: 'rgba(168, 85, 247, 0.3)',
-                                        color: '#c4b5fd',
+                                        background: 'rgba(var(--ns-accent-rgb), 0.3)',
+                                        color: 'var(--ns-accent-light)',
                                         fontSize: 11,
                                         fontWeight: 600,
                                         padding: '2px 8px',
@@ -345,13 +345,13 @@ export function NotificationsPanel({ onNavigateToSeries, onNavigateToDownloads }
                                                 gap: 12,
                                                 padding: '12px 16px',
                                                 borderBottom: '1px solid rgba(255,255,255,0.05)',
-                                                background: notification.read ? 'transparent' : 'rgba(168, 85, 247, 0.08)',
+                                                background: notification.read ? 'transparent' : 'rgba(var(--ns-accent-rgb), 0.08)',
                                                 cursor: 'pointer',
                                                 transition: 'background 0.2s'
                                             }}
                                             onClick={() => handleNotificationClick(notification)}
                                             onMouseEnter={e => e.currentTarget.style.background = 'rgba(255,255,255,0.05)'}
-                                            onMouseLeave={e => e.currentTarget.style.background = notification.read ? 'transparent' : 'rgba(168, 85, 247, 0.08)'}
+                                            onMouseLeave={e => e.currentTarget.style.background = notification.read ? 'transparent' : 'rgba(var(--ns-accent-rgb), 0.08)'}
                                         >
                                             {/* Icon or Poster */}
                                             <div style={{

--- a/src/components/ProfileManager.tsx
+++ b/src/components/ProfileManager.tsx
@@ -652,7 +652,7 @@ const profileManagerStyles = `
             .profile-manager-overlay {
                 position: fixed;
             inset: 0;
-            background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+            background: linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%);
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -687,7 +687,7 @@ const profileManagerStyles = `
             .pm-orb-1 {
                 width: 400px;
             height: 400px;
-            background: radial-gradient(circle, #a855f7 0%, transparent 70%);
+            background: radial-gradient(circle, var(--ns-accent) 0%, transparent 70%);
             top: -100px;
             left: -100px;
 }
@@ -695,7 +695,7 @@ const profileManagerStyles = `
             .pm-orb-2 {
                 width: 350px;
             height: 350px;
-            background: radial-gradient(circle, #ec4899 0%, transparent 70%);
+            background: radial-gradient(circle, var(--ns-accent-grad-to) 0%, transparent 70%);
             bottom: -50px;
             right: -50px;
             animation-delay: -5s;
@@ -814,7 +814,7 @@ const profileManagerStyles = `
             .pm-profile-card:hover {
                 transform: translateY(-8px);
             background: rgba(255, 255, 255, 0.08);
-            border-color: rgba(168, 85, 247, 0.4);
+            border-color: rgba(var(--ns-accent-rgb), 0.4);
             box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
 }
 
@@ -851,7 +851,7 @@ const profileManagerStyles = `
             height: 100px;
             border-radius: 50%;
             overflow: hidden;
-            background: linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2));
+            background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.2));
             border: 3px solid rgba(255, 255, 255, 0.2);
             display: flex;
             align-items: center;
@@ -860,7 +860,7 @@ const profileManagerStyles = `
 }
 
             .pm-profile-card:hover .pm-avatar {
-                border - color: rgba(168, 85, 247, 0.6);
+                border - color: rgba(var(--ns-accent-rgb), 0.6);
             transform: scale(1.05);
 }
 
@@ -980,15 +980,15 @@ const profileManagerStyles = `
             min-height: 280px;
             border-radius: 16px;
             background: rgba(255, 255, 255, 0.03);
-            border: 3px dashed rgba(168, 85, 247, 0.3);
+            border: 3px dashed rgba(var(--ns-accent-rgb), 0.3);
             cursor: pointer;
             transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
             animation: pmCardSlideUp 0.6s ease backwards;
 }
 
             .pm-add-card:hover {
-                background: rgba(168, 85, 247, 0.1);
-            border-color: #a855f7;
+                background: rgba(var(--ns-accent-rgb), 0.1);
+            border-color: var(--ns-accent);
             transform: translateY(-8px) scale(1.02);
 }
 
@@ -996,16 +996,16 @@ const profileManagerStyles = `
                 width: 80px;
             height: 80px;
             border-radius: 50%;
-            background: linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2));
+            background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.2));
             display: flex;
             align-items: center;
             justify-content: center;
-            color: rgba(168, 85, 247, 0.8);
+            color: rgba(var(--ns-accent-rgb), 0.8);
             transition: all 0.3s ease;
 }
 
             .pm-add-card:hover .pm-add-icon {
-                background: linear-gradient(135deg, #a855f7, #ec4899);
+                background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
             color: white;
             transform: rotate(90deg) scale(1.1);
 }
@@ -1030,10 +1030,10 @@ const profileManagerStyles = `
     width: 100%;
     padding: 12px 16px;
     margin-top: 16px;
-    background: rgba(168, 85, 247, 0.15);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.15);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     border-radius: 12px;
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
     font-size: 14px;
     font-weight: 600;
     cursor: pointer;
@@ -1041,8 +1041,8 @@ const profileManagerStyles = `
 }
 
 .pm-edit-pin-btn:hover {
-    background: rgba(168, 85, 247, 0.3);
-    border-color: rgba(168, 85, 247, 0.5);
+    background: rgba(var(--ns-accent-rgb), 0.3);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
     color: white;
     transform: translateY(-2px);
 }
@@ -1067,7 +1067,7 @@ const profileManagerStyles = `
             padding: 32px;
             max-width: 480px;
             width: 90%;
-            border: 1px solid rgba(168, 85, 247, 0.2);
+            border: 1px solid rgba(var(--ns-accent-rgb), 0.2);
             box-shadow: 0 25px 80px rgba(0, 0, 0, 0.5);
             animation: pmModalSlide 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
@@ -1133,8 +1133,8 @@ const profileManagerStyles = `
 }
 
             .pm-input:focus {
-                border - color: #a855f7;
-            background: rgba(168, 85, 247, 0.1);
+                border - color: var(--ns-accent);
+            background: rgba(var(--ns-accent-rgb), 0.1);
 }
 
             .pm-avatar-grid {
@@ -1158,14 +1158,14 @@ const profileManagerStyles = `
 }
 
             .pm-avatar-option:hover {
-                border - color: rgba(168, 85, 247, 0.5);
-            background: rgba(168, 85, 247, 0.1);
+                border - color: rgba(var(--ns-accent-rgb), 0.5);
+            background: rgba(var(--ns-accent-rgb), 0.1);
             transform: scale(1.1);
 }
 
             .pm-avatar-option.selected {
-                border - color: #a855f7;
-            background: rgba(168, 85, 247, 0.3);
+                border - color: var(--ns-accent);
+            background: rgba(var(--ns-accent-rgb), 0.3);
             transform: scale(1.1);
 }
 
@@ -1209,14 +1209,14 @@ const profileManagerStyles = `
 
             .pm-btn-save {
                 flex: 1;
-            background: linear-gradient(135deg, #a855f7, #ec4899);
+            background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
             color: white;
-            box-shadow: 0 8px 24px rgba(168, 85, 247, 0.3);
+            box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.3);
 }
 
             .pm-btn-save:hover:not(:disabled) {
                 transform: translateY(-2px);
-            box-shadow: 0 12px 32px rgba(168, 85, 247, 0.4);
+            box-shadow: 0 12px 32px rgba(var(--ns-accent-rgb), 0.4);
 }
 
             .pm-btn-save:disabled {
@@ -1260,7 +1260,7 @@ const profileManagerStyles = `
     padding: 32px;
     max-width: 480px;
     width: 95%;
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     box-shadow: 0 25px 80px rgba(0, 0, 0, 0.5);
     animation: pmPinModalSlide 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
@@ -1301,7 +1301,7 @@ const profileManagerStyles = `
 }
 
 .pm-pin-header strong {
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
 }
 
 .pm-pin-input-container {
@@ -1328,8 +1328,8 @@ const profileManagerStyles = `
 }
 
 .pm-pin-digit.filled {
-    border-color: rgba(168, 85, 247, 0.7);
-    background: rgba(168, 85, 247, 0.15);
+    border-color: rgba(var(--ns-accent-rgb), 0.7);
+    background: rgba(var(--ns-accent-rgb), 0.15);
     animation: pmPinPop 0.2s ease;
 }
 
@@ -1409,13 +1409,13 @@ const profileManagerStyles = `
 }
 
 .pm-pin-btn.submit {
-    background: linear-gradient(135deg, #a855f7, #7c3aed);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-dark));
     color: white;
 }
 
 .pm-pin-btn.submit:hover:not(:disabled) {
     transform: translateY(-2px);
-    box-shadow: 0 8px 24px rgba(168, 85, 247, 0.4);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .pm-pin-btn.submit:disabled {

--- a/src/components/ResumeModal.tsx
+++ b/src/components/ResumeModal.tsx
@@ -79,8 +79,8 @@ export function ResumeModal({
                     50% { transform: scale(1.1); }
                 }
                 @keyframes progressGlow {
-                    0%, 100% { box-shadow: 0 0 20px rgba(168, 85, 247, 0.4); }
-                    50% { box-shadow: 0 0 40px rgba(168, 85, 247, 0.8); }
+                    0%, 100% { box-shadow: 0 0 20px rgba(var(--ns-accent-rgb), 0.4); }
+                    50% { box-shadow: 0 0 40px rgba(var(--ns-accent-rgb), 0.8); }
                 }
                 @keyframes shimmer {
                     0% { background-position: -200% 0; }
@@ -105,8 +105,8 @@ export function ResumeModal({
                     padding: 0,
                     maxWidth: 420,
                     width: '92%',
-                    boxShadow: '0 40px 100px -20px rgba(0, 0, 0, 0.8), 0 0 80px rgba(168, 85, 247, 0.15)',
-                    border: '1px solid rgba(168, 85, 247, 0.25)',
+                    boxShadow: '0 40px 100px -20px rgba(0, 0, 0, 0.8), 0 0 80px rgba(var(--ns-accent-rgb), 0.15)',
+                    border: '1px solid rgba(var(--ns-accent-rgb), 0.25)',
                     overflow: 'hidden',
                     animation: isVisible ? 'modalSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards' : 'none'
                 }}
@@ -114,7 +114,7 @@ export function ResumeModal({
                 {/* Decorative gradient header */}
                 <div style={{
                     height: 6,
-                    background: 'linear-gradient(90deg, #a855f7, #ec4899, #f97316, #a855f7)',
+                    background: 'linear-gradient(90deg, var(--ns-accent), var(--ns-accent-grad-to), var(--ns-accent-light), var(--ns-accent))',
                     backgroundSize: '200% 100%',
                     animation: 'shimmer 3s linear infinite'
                 }} />
@@ -134,7 +134,7 @@ export function ResumeModal({
                             width: 100,
                             height: 100,
                             borderRadius: '50%',
-                            border: '2px solid rgba(168, 85, 247, 0.3)',
+                            border: '2px solid rgba(var(--ns-accent-rgb), 0.3)',
                             animation: 'ringPulse 2s ease-out infinite'
                         }} />
                         <div style={{
@@ -142,7 +142,7 @@ export function ResumeModal({
                             width: 100,
                             height: 100,
                             borderRadius: '50%',
-                            border: '2px solid rgba(236, 72, 153, 0.3)',
+                            border: '2px solid rgba(var(--ns-accent-grad-to-rgb), 0.3)',
                             animation: 'ringPulse 2s ease-out 0.5s infinite'
                         }} />
 
@@ -151,12 +151,12 @@ export function ResumeModal({
                             width: 80,
                             height: 80,
                             borderRadius: '50%',
-                            background: 'linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2))',
+                            background: 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.2))',
                             display: 'flex',
                             alignItems: 'center',
                             justifyContent: 'center',
                             animation: 'iconPulse 2s ease-in-out infinite',
-                            border: '2px solid rgba(168, 85, 247, 0.4)'
+                            border: '2px solid rgba(var(--ns-accent-rgb), 0.4)'
                         }}>
                             <span style={{ fontSize: 36 }}>⏯️</span>
                         </div>
@@ -190,7 +190,7 @@ export function ResumeModal({
                             {seriesName}
                         </p>
                         <p style={{
-                            color: 'rgba(168, 85, 247, 0.9)',
+                            color: 'rgba(var(--ns-accent-rgb), 0.9)',
                             fontSize: 13,
                             fontWeight: 500
                         }}>
@@ -218,7 +218,7 @@ export function ResumeModal({
                                 <div style={{ color: 'rgba(255, 255, 255, 0.5)', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 4 }}>
                                     Parou em
                                 </div>
-                                <div style={{ color: '#a855f7', fontSize: 18, fontWeight: 700 }}>
+                                <div style={{ color: 'var(--ns-accent)', fontSize: 18, fontWeight: 700 }}>
                                     {formatTime(currentTime)}
                                 </div>
                             </div>
@@ -226,13 +226,13 @@ export function ResumeModal({
                                 width: 40,
                                 height: 40,
                                 borderRadius: '50%',
-                                background: 'linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2))',
+                                background: 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.2))',
                                 display: 'flex',
                                 alignItems: 'center',
                                 justifyContent: 'center',
                                 fontSize: 14,
                                 fontWeight: 700,
-                                color: '#a855f7'
+                                color: 'var(--ns-accent)'
                             }}>
                                 {progress}%
                             </div>
@@ -261,10 +261,10 @@ export function ResumeModal({
                                 left: 0,
                                 width: `${progressAnimated}%`,
                                 height: '100%',
-                                background: 'linear-gradient(90deg, #a855f7, #ec4899)',
+                                background: 'linear-gradient(90deg, var(--ns-accent), var(--ns-accent-grad-to))',
                                 borderRadius: 5,
                                 transition: 'width 1s cubic-bezier(0.16, 1, 0.3, 1)',
-                                boxShadow: '0 0 20px rgba(168, 85, 247, 0.5)'
+                                boxShadow: '0 0 20px rgba(var(--ns-accent-rgb), 0.5)'
                             }}>
                                 {/* Shimmer effect */}
                                 <div style={{
@@ -288,7 +288,7 @@ export function ResumeModal({
                                 borderRadius: '50%',
                                 background: 'white',
                                 boxShadow: '0 2px 8px rgba(0, 0, 0, 0.3)',
-                                border: '3px solid #a855f7',
+                                border: '3px solid var(--ns-accent)',
                                 transition: 'left 1s cubic-bezier(0.16, 1, 0.3, 1)',
                                 animation: 'progressGlow 2s ease-in-out infinite'
                             }} />
@@ -307,14 +307,14 @@ export function ResumeModal({
                             onClick={onResume}
                             style={{
                                 padding: '16px 24px',
-                                background: 'linear-gradient(135deg, #a855f7, #ec4899)',
+                                background: 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to))',
                                 color: 'white',
                                 fontSize: 16,
                                 fontWeight: 700,
                                 borderRadius: 14,
                                 border: 'none',
                                 cursor: 'pointer',
-                                boxShadow: '0 8px 32px rgba(168, 85, 247, 0.4)',
+                                boxShadow: '0 8px 32px rgba(var(--ns-accent-rgb), 0.4)',
                                 transition: 'all 0.3s cubic-bezier(0.16, 1, 0.3, 1)',
                                 display: 'flex',
                                 alignItems: 'center',
@@ -325,11 +325,11 @@ export function ResumeModal({
                             }}
                             onMouseEnter={(e) => {
                                 e.currentTarget.style.transform = 'translateY(-2px) scale(1.02)';
-                                e.currentTarget.style.boxShadow = '0 12px 40px rgba(168, 85, 247, 0.6)';
+                                e.currentTarget.style.boxShadow = '0 12px 40px rgba(var(--ns-accent-rgb), 0.6)';
                             }}
                             onMouseLeave={(e) => {
                                 e.currentTarget.style.transform = 'translateY(0) scale(1)';
-                                e.currentTarget.style.boxShadow = '0 8px 32px rgba(168, 85, 247, 0.4)';
+                                e.currentTarget.style.boxShadow = '0 8px 32px rgba(var(--ns-accent-rgb), 0.4)';
                             }}
                         >
                             <span style={{ fontSize: 20 }}>▶️</span>

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -247,15 +247,15 @@ const notificationStyles = `
     transform: translate(-50%, -50%);
     width: 90%;
     max-width: 420px;
-    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     border-radius: 24px;
     padding: 24px;
     z-index: 9999;
     box-shadow: 
         0 25px 50px -12px rgba(0, 0, 0, 0.5),
         0 0 0 1px rgba(255, 255, 255, 0.05),
-        0 0 60px rgba(168, 85, 247, 0.2);
+        0 0 60px rgba(var(--ns-accent-rgb), 0.2);
     animation: slideUp 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
@@ -285,13 +285,13 @@ const notificationStyles = `
 .update-icon {
     width: 56px;
     height: 56px;
-    background: linear-gradient(135deg, #a855f7, #ec4899);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
     border-radius: 16px;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 28px;
-    box-shadow: 0 8px 24px rgba(168, 85, 247, 0.4);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .update-header h3 {
@@ -304,7 +304,7 @@ const notificationStyles = `
 .version-info {
     margin: 4px 0 0 0;
     font-size: 14px;
-    color: #a855f7;
+    color: var(--ns-accent);
     font-weight: 600;
 }
 
@@ -339,7 +339,7 @@ const notificationStyles = `
 
 .download-progress {
     padding: 16px;
-    background: rgba(168, 85, 247, 0.1);
+    background: rgba(var(--ns-accent-rgb), 0.1);
     border-radius: 12px;
 }
 
@@ -361,7 +361,7 @@ const notificationStyles = `
 
 .progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #a855f7, #ec4899);
+    background: linear-gradient(90deg, var(--ns-accent), var(--ns-accent-grad-to));
     border-radius: 4px;
     transition: width 0.3s ease;
 }
@@ -421,7 +421,7 @@ const notificationStyles = `
     gap: 10px;
     width: 100%;
     padding: 14px 24px;
-    background: linear-gradient(135deg, #a855f7, #ec4899);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
     border: none;
     border-radius: 12px;
     color: white;
@@ -429,12 +429,12 @@ const notificationStyles = `
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s;
-    box-shadow: 0 8px 24px rgba(168, 85, 247, 0.3);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.3);
 }
 
 .btn-primary:hover {
     transform: translateY(-2px);
-    box-shadow: 0 12px 32px rgba(168, 85, 247, 0.4);
+    box-shadow: 0 12px 32px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .btn-secondary {

--- a/src/components/VideoPlayer/ForcedSubtitlesMenu.tsx
+++ b/src/components/VideoPlayer/ForcedSubtitlesMenu.tsx
@@ -20,7 +20,7 @@ export function ForcedSubtitlesMenu({
                 className="control-btn"
                 onClick={() => setShowSettingsMenu(!showSettingsMenu)}
                 title={t('player', 'forcedSubtitles')}
-                style={{ color: showSettingsMenu ? '#a855f7' : (!forcedEnabledForSession ? 'rgba(255,255,255,0.4)' : 'white') }}
+                style={{ color: showSettingsMenu ? 'var(--ns-accent)' : (!forcedEnabledForSession ? 'rgba(255,255,255,0.4)' : 'white') }}
             >
                 <span style={{ fontSize: 14, fontWeight: 600 }}>F</span>
             </button>
@@ -76,7 +76,7 @@ export function ForcedSubtitlesMenu({
                                 width: 36,
                                 height: 20,
                                 borderRadius: 10,
-                                background: forcedEnabledForSession ? 'linear-gradient(135deg, #a855f7, #ec4899)' : 'rgba(255, 255, 255, 0.2)',
+                                background: forcedEnabledForSession ? 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to))' : 'rgba(255, 255, 255, 0.2)',
                                 position: 'relative',
                                 transition: 'background 0.3s'
                             }}

--- a/src/components/VideoPlayer/PlayerSettingsMenu.tsx
+++ b/src/components/VideoPlayer/PlayerSettingsMenu.tsx
@@ -66,7 +66,7 @@ export function PlayerSettingsMenu<TSwitchContent extends SwitchableContent = Sw
                                             ? 'linear-gradient(135deg, #10b981, #059669)'
                                             : currentVersion.label === 'SD'
                                                 ? 'linear-gradient(135deg, #6b7280, #4b5563)'
-                                                : 'linear-gradient(135deg, #8b5cf6, #7c3aed)',
+                                                : 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-dark))',
                                     color: 'white',
                                     textTransform: 'uppercase',
                                     letterSpacing: '0.5px',
@@ -87,7 +87,7 @@ export function PlayerSettingsMenu<TSwitchContent extends SwitchableContent = Sw
                                 borderRadius: '4px',
                                 background: currentVersion.quality === '4k'
                                     ? 'linear-gradient(135deg, #f59e0b, #d97706)'
-                                    : 'linear-gradient(135deg, #8b5cf6, #7c3aed)',
+                                    : 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-dark))',
                                 color: 'white',
                                 textTransform: 'uppercase',
                                 letterSpacing: '0.5px',

--- a/src/components/VideoPlayer/VideoPlayer.css
+++ b/src/components/VideoPlayer/VideoPlayer.css
@@ -91,7 +91,7 @@
 }
 
 .spinner-ring:nth-child(1) {
-    border-top-color: #a855f7;
+    border-top-color: var(--ns-accent);
     animation: spinRing 1.2s linear infinite;
 }
 
@@ -100,7 +100,7 @@
     height: 70%;
     top: 15%;
     left: 15%;
-    border-right-color: #ec4899;
+    border-right-color: var(--ns-accent-grad-to);
     animation: spinRing 1s linear infinite reverse;
 }
 
@@ -109,7 +109,7 @@
     height: 40%;
     top: 30%;
     left: 30%;
-    border-bottom-color: #6366f1;
+    border-bottom-color: var(--ns-accent-dark);
     animation: spinRing 0.8s linear infinite;
 }
 
@@ -155,7 +155,7 @@
 .central-play-icon {
     width: 100px;
     height: 100px;
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.9), rgba(236, 72, 153, 0.9));
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.9), rgba(var(--ns-accent-grad-to-rgb), 0.9));
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -163,25 +163,25 @@
     font-size: 40px;
     color: white;
     padding-left: 8px;
-    box-shadow: 0 8px 40px rgba(168, 85, 247, 0.5);
+    box-shadow: 0 8px 40px rgba(var(--ns-accent-rgb), 0.5);
     transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
     animation: centralPlayPulse 2s ease-in-out infinite;
 }
 
 .central-play-icon:hover {
     transform: scale(1.15);
-    box-shadow: 0 12px 50px rgba(168, 85, 247, 0.7);
+    box-shadow: 0 12px 50px rgba(var(--ns-accent-rgb), 0.7);
 }
 
 @keyframes centralPlayPulse {
 
     0%,
     100% {
-        box-shadow: 0 8px 40px rgba(168, 85, 247, 0.5);
+        box-shadow: 0 8px 40px rgba(var(--ns-accent-rgb), 0.5);
     }
 
     50% {
-        box-shadow: 0 8px 60px rgba(168, 85, 247, 0.8), 0 0 100px rgba(236, 72, 153, 0.3);
+        box-shadow: 0 8px 60px rgba(var(--ns-accent-rgb), 0.8), 0 0 100px rgba(var(--ns-accent-grad-to-rgb), 0.3);
     }
 }
 
@@ -308,7 +308,7 @@
     top: 0;
     left: 0;
     height: 100%;
-    background: linear-gradient(90deg, #a855f7, #ec4899);
+    background: linear-gradient(90deg, var(--ns-accent), var(--ns-accent-grad-to));
     border-radius: 3px;
     transition: width 0.1s ease;
 }
@@ -470,7 +470,7 @@
 }
 
 .settings-option.active {
-    background: linear-gradient(135deg, #a855f7, #ec4899);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
 }
 
 /* Fullscreen styles */

--- a/src/pages/LiveTV.tsx
+++ b/src/pages/LiveTV.tsx
@@ -475,7 +475,7 @@ export function LiveTV() {
                 <div style={{
                     position: 'fixed',
                     inset: 0,
-                    background: 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%)',
+                    background: 'linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%)',
                     zIndex: 0
                 }} />
                 <div style={{
@@ -483,7 +483,7 @@ export function LiveTV() {
                     inset: 0,
                     background: `
                         radial-gradient(ellipse at 20% 20%, rgba(59, 130, 246, 0.15) 0%, transparent 50%),
-                        radial-gradient(ellipse at 80% 80%, rgba(147, 51, 234, 0.1) 0%, transparent 50%)
+                        radial-gradient(ellipse at 80% 80%, rgba(var(--ns-accent-rgb), 0.1) 0%, transparent 50%)
                     `,
                     pointerEvents: 'none',
                     zIndex: 0
@@ -539,7 +539,7 @@ export function LiveTV() {
                         width: '100px',
                         height: '100px',
                         borderRadius: '24px',
-                        background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                        background: 'linear-gradient(135deg, #3b82f6 0%, var(--ns-accent) 100%)',
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
@@ -758,7 +758,7 @@ export function LiveTV() {
             <div style={{
                 position: 'fixed',
                 inset: 0,
-                background: 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%)',
+                background: 'linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%)',
                 zIndex: 0
             }} />
             <div style={{
@@ -766,7 +766,7 @@ export function LiveTV() {
                 inset: 0,
                 background: `
                     radial-gradient(ellipse at 20% 20%, rgba(59, 130, 246, 0.15) 0%, transparent 50%),
-                    radial-gradient(ellipse at 80% 80%, rgba(147, 51, 234, 0.1) 0%, transparent 50%),
+                    radial-gradient(ellipse at 80% 80%, rgba(var(--ns-accent-rgb), 0.1) 0%, transparent 50%),
                     radial-gradient(ellipse at 50% 50%, rgba(59, 130, 246, 0.05) 0%, transparent 70%)
                 `,
                 pointerEvents: 'none',
@@ -1035,7 +1035,7 @@ export function LiveTV() {
                                     gap: '10px'
                                 }}>
                                     <span style={{
-                                        background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                                        background: 'linear-gradient(135deg, #3b82f6 0%, var(--ns-accent) 100%)',
                                         padding: '8px',
                                         borderRadius: '10px',
                                         display: 'flex',
@@ -1050,7 +1050,7 @@ export function LiveTV() {
                                         <div style={{
                                             marginBottom: '20px',
                                             padding: 'clamp(14px, 2vw, 20px)',
-                                            background: 'linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(139, 92, 246, 0.1) 100%)',
+                                            background: 'linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(var(--ns-accent-rgb), 0.1) 100%)',
                                             borderRadius: '14px',
                                             border: '1px solid rgba(59, 130, 246, 0.25)',
                                             position: 'relative',
@@ -1093,7 +1093,7 @@ export function LiveTV() {
                                                 <div style={{
                                                     width: `${epgService.getProgramProgress(currentProgram)}%`,
                                                     height: '100%',
-                                                    background: 'linear-gradient(90deg, #3b82f6 0%, #8b5cf6 100%)',
+                                                    background: 'linear-gradient(90deg, #3b82f6 0%, var(--ns-accent) 100%)',
                                                     borderRadius: '3px',
                                                     transition: 'width 1s ease',
                                                     animation: 'progressGlow 2s ease-in-out infinite'
@@ -1144,7 +1144,7 @@ export function LiveTV() {
                     </div>
                 )}
 
-                <div ref={scrollContainerRef} className="livetv-scroll-container p-8" style={{ paddingLeft: '60px', position: 'relative', zIndex: 1, height: 'calc(100vh - 120px)', overflowY: 'auto', paddingRight: '8px', scrollbarWidth: 'thin', scrollbarColor: 'rgba(168, 85, 247, 0.4) transparent' }}>
+                <div ref={scrollContainerRef} className="livetv-scroll-container p-8" style={{ paddingLeft: '60px', position: 'relative', zIndex: 1, height: 'calc(100vh - 120px)', overflowY: 'auto', paddingRight: '8px', scrollbarWidth: 'thin', scrollbarColor: 'rgba(var(--ns-accent-rgb), 0.4) transparent' }}>
                     <style>{`
                         .channel-card {
                             transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -1188,7 +1188,7 @@ export function LiveTV() {
                             background: transparent;
                         }
                         .livetv-scroll-container::-webkit-scrollbar-thumb {
-                            background: linear-gradient(180deg, #a855f7, #ec4899);
+                            background: linear-gradient(180deg, var(--ns-accent), var(--ns-accent-grad-to));
                             border-radius: 3px;
                         }
                     `}</style>
@@ -1248,7 +1248,7 @@ export function LiveTV() {
                                                     <div style={{
                                                         width: '100%',
                                                         height: '100%',
-                                                        background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                                                        background: 'linear-gradient(135deg, #3b82f6 0%, var(--ns-accent) 100%)',
                                                         display: 'flex',
                                                         alignItems: 'center',
                                                         justifyContent: 'center',
@@ -1260,7 +1260,7 @@ export function LiveTV() {
                                             <div style={{
                                                 width: '100%',
                                                 height: '100%',
-                                                background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                                                background: 'linear-gradient(135deg, #3b82f6 0%, var(--ns-accent) 100%)',
                                                 display: 'flex',
                                                 alignItems: 'center',
                                                 justifyContent: 'center',

--- a/src/pages/PipWindow.tsx
+++ b/src/pages/PipWindow.tsx
@@ -430,7 +430,7 @@ export function PipWindow() {
                 overflow: 'hidden',
                 position: 'relative',
                 boxShadow: '0 10px 40px rgba(0, 0, 0, 0.6)',
-                border: '1px solid rgba(139, 92, 246, 0.4)',
+                border: '1px solid rgba(var(--ns-accent-rgb), 0.4)',
             }}
             onMouseMove={resetHideTimeout}
             onMouseEnter={() => setShowControls(true)}
@@ -532,7 +532,7 @@ export function PipWindow() {
                     onClick={handleTogglePlay}
                     className="pip-btn pip-btn-play"
                     style={{
-                        background: 'rgba(139, 92, 246, 0.8)',
+                        background: 'rgba(var(--ns-accent-rgb), 0.8)',
                         border: 'none',
                         borderRadius: 6,
                         padding: 8,
@@ -563,7 +563,7 @@ export function PipWindow() {
                     <div style={{
                         width: `${(currentTime / duration) * 100 || 0}%`,
                         height: '100%',
-                        background: 'linear-gradient(90deg, #8b5cf6, #a855f7)',
+                        background: 'linear-gradient(90deg, var(--ns-accent), var(--ns-accent))',
                         borderRadius: 2
                     }} />
                 </div>
@@ -622,7 +622,7 @@ export function PipWindow() {
                                 width: 55,
                                 height: 4,
                                 cursor: 'pointer',
-                                accentColor: '#8b5cf6'
+                                accentColor: 'var(--ns-accent)'
                             }}
                         />
                     </div>
@@ -634,8 +634,8 @@ export function PipWindow() {
                     className="pip-btn"
                     title={clickThrough ? 'Click-Through: ON (F9)' : 'Click-Through: OFF (F9)'}
                     style={{
-                        background: clickThrough ? 'rgba(139, 92, 246, 0.8)' : 'transparent',
-                        border: clickThrough ? '1px solid #8b5cf6' : '1px solid rgba(255,255,255,0.3)',
+                        background: clickThrough ? 'rgba(var(--ns-accent-rgb), 0.8)' : 'transparent',
+                        border: clickThrough ? '1px solid var(--ns-accent)' : '1px solid rgba(255,255,255,0.3)',
                         padding: '2px 6px',
                         cursor: 'pointer',
                         borderRadius: 4,
@@ -663,7 +663,7 @@ export function PipWindow() {
                         width: 24,
                         height: 24,
                         border: '2px solid rgba(255,255,255,0.3)',
-                        borderTopColor: '#8b5cf6',
+                        borderTopColor: 'var(--ns-accent)',
                         borderRadius: '50%',
                         animation: 'spin 1s linear infinite'
                     }} />
@@ -691,7 +691,7 @@ export function PipWindow() {
                     background: rgba(255,255,255,0.35) !important;
                 }
                 .pip-btn-play:hover {
-                    background: rgba(139, 92, 246, 1) !important;
+                    background: rgba(var(--ns-accent-rgb), 1) !important;
                 }
                 .pip-title-bar {
                     -webkit-app-region: drag;

--- a/src/pages/ProfileSelector.tsx
+++ b/src/pages/ProfileSelector.tsx
@@ -119,8 +119,8 @@ export function ProfileSelector({ onProfileSelected }: ProfileSelectorProps) {
                     <svg width="60" height="60" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                         <defs>
                             <linearGradient id="profileLogoGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-                                <stop offset="0%" stopColor="#a855f7" />
-                                <stop offset="100%" stopColor="#ec4899" />
+                                <stop offset="0%" style={{ stopColor: 'var(--ns-accent)' }} />
+                                <stop offset="100%" style={{ stopColor: 'var(--ns-accent-grad-to)' }} />
                             </linearGradient>
                         </defs>
                         <path d="M 10,10 L 10,90 L 90,50 Z" fill="none" stroke="url(#profileLogoGrad)" strokeWidth="6" strokeLinejoin="round" />
@@ -372,7 +372,7 @@ const profileSelectorStyles = `
     padding: 40px;
     position: relative;
     overflow: hidden;
-    background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%);
 }
 
 /* Animated Background */
@@ -394,7 +394,7 @@ const profileSelectorStyles = `
 .orb-1 {
     width: 400px;
     height: 400px;
-    background: radial-gradient(circle, #a855f7 0%, transparent 70%);
+    background: radial-gradient(circle, var(--ns-accent) 0%, transparent 70%);
     top: -100px;
     left: -100px;
     animation-delay: 0s;
@@ -403,7 +403,7 @@ const profileSelectorStyles = `
 .orb-2 {
     width: 350px;
     height: 350px;
-    background: radial-gradient(circle, #ec4899 0%, transparent 70%);
+    background: radial-gradient(circle, var(--ns-accent-grad-to) 0%, transparent 70%);
     bottom: -50px;
     right: -50px;
     animation-delay: -5s;
@@ -567,29 +567,29 @@ const profileSelectorStyles = `
     width: 150px;
     height: 150px;
     border-radius: 16px;
-    border: 3px dashed rgba(168, 85, 247, 0.4);
+    border: 3px dashed rgba(var(--ns-accent-rgb), 0.4);
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(168, 85, 247, 0.05);
+    background: rgba(var(--ns-accent-rgb), 0.05);
     transition: all 0.3s ease;
 }
 
 .add-profile-card:hover .add-icon-container {
-    border-color: rgba(168, 85, 247, 0.7);
-    background: rgba(168, 85, 247, 0.1);
+    border-color: rgba(var(--ns-accent-rgb), 0.7);
+    background: rgba(var(--ns-accent-rgb), 0.1);
     border-style: solid;
 }
 
 .add-icon {
     font-size: 60px;
-    color: rgba(168, 85, 247, 0.5);
+    color: rgba(var(--ns-accent-rgb), 0.5);
     font-weight: 300;
     transition: all 0.3s ease;
 }
 
 .add-profile-card:hover .add-icon {
-    color: #a855f7;
+    color: var(--ns-accent);
     transform: rotate(90deg) scale(1.1);
 }
 
@@ -597,7 +597,7 @@ const profileSelectorStyles = `
     position: absolute;
     inset: -10px;
     border-radius: 20px;
-    background: radial-gradient(circle, rgba(168, 85, 247, 0.2) 0%, transparent 70%);
+    background: radial-gradient(circle, rgba(var(--ns-accent-rgb), 0.2) 0%, transparent 70%);
     opacity: 0;
     transition: opacity 0.3s ease;
 }
@@ -641,7 +641,7 @@ const profileSelectorStyles = `
 
 .manage-btn:hover {
     background: rgba(255, 255, 255, 0.1);
-    border-color: rgba(168, 85, 247, 0.5);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
     color: white;
     transform: translateY(-2px);
 }
@@ -665,7 +665,7 @@ const profileSelectorStyles = `
     padding: 40px;
     max-width: 420px;
     width: 90%;
-    border: 1px solid rgba(168, 85, 247, 0.2);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.2);
     box-shadow: 0 25px 80px rgba(0, 0, 0, 0.5);
     animation: modalSlideIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
@@ -711,7 +711,7 @@ const profileSelectorStyles = `
 }
 
 .pin-modal-header strong {
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
 }
 
 /* PIN Input */
@@ -738,8 +738,8 @@ const profileSelectorStyles = `
 }
 
 .pin-digit.filled {
-    border-color: #a855f7;
-    background: rgba(168, 85, 247, 0.1);
+    border-color: var(--ns-accent);
+    background: rgba(var(--ns-accent-rgb), 0.1);
     animation: digitFill 0.2s ease;
 }
 
@@ -818,15 +818,15 @@ const profileSelectorStyles = `
 }
 
 .btn-submit {
-    background: linear-gradient(135deg, #a855f7 0%, #ec4899 100%);
+    background: linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%);
     border: none;
     color: white;
-    box-shadow: 0 8px 24px rgba(168, 85, 247, 0.3);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.3);
 }
 
 .btn-submit:hover:not(:disabled) {
     transform: translateY(-2px);
-    box-shadow: 0 12px 32px rgba(168, 85, 247, 0.4);
+    box-shadow: 0 12px 32px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .btn-submit:disabled {
@@ -866,7 +866,7 @@ const profileSelectorStyles = `
     position: absolute;
     top: 8px;
     left: 8px;
-    background: rgba(168, 85, 247, 0.9);
+    background: rgba(var(--ns-accent-rgb), 0.9);
     border-radius: 50%;
     width: 32px;
     height: 32px;
@@ -951,8 +951,8 @@ const profileSelectorStyles = `
 }
 
 .edit-profile-input:focus {
-    border-color: #a855f7;
-    background: rgba(168, 85, 247, 0.1);
+    border-color: var(--ns-accent);
+    background: rgba(var(--ns-accent-rgb), 0.1);
 }
 
 .avatar-selector {
@@ -976,13 +976,13 @@ const profileSelectorStyles = `
 }
 
 .avatar-option:hover {
-    border-color: rgba(168, 85, 247, 0.5);
-    background: rgba(168, 85, 247, 0.1);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
+    background: rgba(var(--ns-accent-rgb), 0.1);
     transform: scale(1.1);
 }
 
 .avatar-option.selected {
-    border-color: #a855f7;
-    background: rgba(168, 85, 247, 0.2);
+    border-color: var(--ns-accent);
+    background: rgba(var(--ns-accent-rgb), 0.2);
 }
 `;

--- a/src/pages/Series.tsx
+++ b/src/pages/Series.tsx
@@ -500,7 +500,7 @@ export function Series() {
                                                         position: 'absolute',
                                                         top: 10,
                                                         left: 10,
-                                                        background: 'linear-gradient(135deg, #a855f7 0%, #ec4899 100%)',
+                                                        background: 'linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%)',
                                                         borderRadius: 8,
                                                         padding: '4px 8px',
                                                         fontSize: 14,
@@ -520,7 +520,7 @@ export function Series() {
                                                         padding: '5px 8px',
                                                         fontSize: 11,
                                                         fontWeight: 600,
-                                                        color: '#c4b5fd',
+                                                        color: 'var(--ns-accent-light)',
                                                         textAlign: 'center',
                                                         zIndex: 5
                                                     }}>
@@ -693,7 +693,7 @@ const seriesStyles = `
     position: relative;
     height: 100vh;
     overflow: hidden;
-    background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%);
 }
 
 /* Dynamic Backdrop */
@@ -727,7 +727,7 @@ const seriesStyles = `
     background: linear-gradient(135deg, rgba(15, 15, 26, 0.9) 0%, rgba(26, 26, 46, 0.85) 100%);
     backdrop-filter: blur(24px);
     border-radius: 24px;
-    border: 1px solid rgba(168, 85, 247, 0.2);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.2);
     padding: 32px;
     animation: slideDown 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4), 
@@ -767,7 +767,7 @@ const seriesStyles = `
 }
 
 .badge.shimmer {
-    background: linear-gradient(90deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2), rgba(168, 85, 247, 0.2));
+    background: linear-gradient(90deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.2), rgba(var(--ns-accent-rgb), 0.2));
     background-size: 200% 100%;
     animation: shimmerBadge 1.5s ease infinite;
     color: rgba(255, 255, 255, 0.6);
@@ -779,9 +779,9 @@ const seriesStyles = `
 }
 
 .date-badge {
-    background: rgba(168, 85, 247, 0.2);
-    color: #c4b5fd;
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.2);
+    color: var(--ns-accent-light);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
 }
 
 .rating-badge {
@@ -854,8 +854,8 @@ const seriesStyles = `
 }
 
 .genre-tag:hover {
-    background: rgba(168, 85, 247, 0.2);
-    border-color: rgba(168, 85, 247, 0.4);
+    background: rgba(var(--ns-accent-rgb), 0.2);
+    border-color: rgba(var(--ns-accent-rgb), 0.4);
 }
 
 /* Overview */
@@ -904,8 +904,8 @@ const seriesStyles = `
 }
 
 .season-nav-btn:hover {
-    background: rgba(168, 85, 247, 0.3);
-    border-color: rgba(168, 85, 247, 0.5);
+    background: rgba(var(--ns-accent-rgb), 0.3);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
     opacity: 1;
     transform: scale(1.1);
 }
@@ -969,16 +969,16 @@ const seriesStyles = `
 }
 
 .season-tab:hover {
-    background: rgba(168, 85, 247, 0.15);
-    border-color: rgba(168, 85, 247, 0.4);
+    background: rgba(var(--ns-accent-rgb), 0.15);
+    border-color: rgba(var(--ns-accent-rgb), 0.4);
     color: white;
 }
 
 .season-tab.active {
-    background: linear-gradient(135deg, #a855f7 0%, #ec4899 100%);
+    background: linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%);
     border-color: transparent;
     color: white;
-    box-shadow: 0 4px 15px rgba(168, 85, 247, 0.4);
+    box-shadow: 0 4px 15px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .season-tab-number {
@@ -998,7 +998,7 @@ const seriesStyles = `
     background: rgba(0, 0, 0, 0.2);
     padding: 8px;
     scrollbar-width: thin;
-    scrollbar-color: rgba(168, 85, 247, 0.4) transparent;
+    scrollbar-color: rgba(var(--ns-accent-rgb), 0.4) transparent;
 }
 
 .episode-list-container::-webkit-scrollbar {
@@ -1010,7 +1010,7 @@ const seriesStyles = `
 }
 
 .episode-list-container::-webkit-scrollbar-thumb {
-    background: linear-gradient(180deg, #a855f7, #ec4899);
+    background: linear-gradient(180deg, var(--ns-accent), var(--ns-accent-grad-to));
     border-radius: 3px;
 }
 
@@ -1045,15 +1045,15 @@ const seriesStyles = `
 }
 
 .episode-card:hover {
-    background: rgba(168, 85, 247, 0.1);
-    border-color: rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.1);
+    border-color: rgba(var(--ns-accent-rgb), 0.3);
     transform: translateX(4px);
 }
 
 .episode-card.selected {
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.2) 0%, rgba(236, 72, 153, 0.15) 100%);
-    border-color: rgba(168, 85, 247, 0.5);
-    box-shadow: 0 4px 20px rgba(168, 85, 247, 0.2);
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.15) 100%);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
+    box-shadow: 0 4px 20px rgba(var(--ns-accent-rgb), 0.2);
 }
 
 .episode-card.watched {
@@ -1070,7 +1070,7 @@ const seriesStyles = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.3);
     border-radius: 10px;
     font-size: 14px;
     font-weight: 700;
@@ -1116,7 +1116,7 @@ const seriesStyles = `
 
 .episode-progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #a855f7, #ec4899);
+    background: linear-gradient(90deg, var(--ns-accent), var(--ns-accent-grad-to));
     border-radius: 3px;
     transition: width 0.3s ease;
 }
@@ -1127,7 +1127,7 @@ const seriesStyles = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, #a855f7, #ec4899);
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
     border-radius: 50%;
     font-size: 12px;
     color: white;
@@ -1155,7 +1155,7 @@ const seriesStyles = `
     font-size: 15px;
     font-weight: 600;
     border-radius: 12px;
-    border: 2px solid rgba(168, 85, 247, 0.4);
+    border: 2px solid rgba(var(--ns-accent-rgb), 0.4);
     cursor: pointer;
     outline: none;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
@@ -1164,13 +1164,13 @@ const seriesStyles = `
 }
 
 .episode-select:hover {
-    border-color: rgba(168, 85, 247, 0.7);
+    border-color: rgba(var(--ns-accent-rgb), 0.7);
     background: rgba(40, 40, 60, 0.9);
 }
 
 .episode-select:focus {
-    border-color: #a855f7;
-    box-shadow: 0 0 0 3px rgba(168, 85, 247, 0.2);
+    border-color: var(--ns-accent);
+    box-shadow: 0 0 0 3px rgba(var(--ns-accent-rgb), 0.2);
 }
 
 .episode-dropdown {
@@ -1204,14 +1204,14 @@ const seriesStyles = `
 }
 
 .btn-primary {
-    background: linear-gradient(135deg, #a855f7 0%, #ec4899 100%);
+    background: linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%);
     color: white;
-    box-shadow: 0 8px 24px rgba(168, 85, 247, 0.4);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .btn-primary:hover {
     transform: translateY(-3px) scale(1.02);
-    box-shadow: 0 12px 32px rgba(168, 85, 247, 0.5);
+    box-shadow: 0 12px 32px rgba(var(--ns-accent-rgb), 0.5);
 }
 
 .btn-primary:active {
@@ -1305,7 +1305,7 @@ const seriesStyles = `
     overflow-x: hidden;
     padding-right: 8px;
     scrollbar-width: thin;
-    scrollbar-color: rgba(168, 85, 247, 0.4) transparent;
+    scrollbar-color: rgba(var(--ns-accent-rgb), 0.4) transparent;
 }
 
 .series-scroll-container::-webkit-scrollbar {
@@ -1317,7 +1317,7 @@ const seriesStyles = `
 }
 
 .series-scroll-container::-webkit-scrollbar-thumb {
-    background: linear-gradient(180deg, #a855f7, #ec4899);
+    background: linear-gradient(180deg, var(--ns-accent), var(--ns-accent-grad-to));
     border-radius: 3px;
 }
 
@@ -1369,14 +1369,14 @@ const seriesStyles = `
 
 .series-card:hover {
     transform: translateY(-8px) scale(1.03);
-    border-color: rgba(168, 85, 247, 0.4);
+    border-color: rgba(var(--ns-accent-rgb), 0.4);
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4),
-                0 0 40px rgba(168, 85, 247, 0.15);
+                0 0 40px rgba(var(--ns-accent-rgb), 0.15);
 }
 
 .series-card.selected {
-    border-color: #a855f7;
-    box-shadow: 0 0 0 3px rgba(168, 85, 247, 0.3),
+    border-color: var(--ns-accent);
+    box-shadow: 0 0 0 3px rgba(var(--ns-accent-rgb), 0.3),
                 0 20px 40px rgba(0, 0, 0, 0.4);
 }
 
@@ -1385,7 +1385,7 @@ const seriesStyles = `
     position: relative;
     aspect-ratio: 2 / 3;
     overflow: hidden;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
 }
 
 .card-poster img {
@@ -1405,7 +1405,7 @@ const seriesStyles = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, #1e1e3f 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, #1e1e3f 0%, var(--ns-bg-deep) 100%);
     font-size: 48px;
 }
 
@@ -1433,7 +1433,7 @@ const seriesStyles = `
 .play-icon {
     width: 60px;
     height: 60px;
-    background: rgba(168, 85, 247, 0.9);
+    background: rgba(var(--ns-accent-rgb), 0.9);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -1442,7 +1442,7 @@ const seriesStyles = `
     color: white;
     transform: scale(0);
     transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    box-shadow: 0 8px 24px rgba(168, 85, 247, 0.5);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.5);
 }
 
 .series-card:hover .play-icon {
@@ -1473,7 +1473,7 @@ const seriesStyles = `
     left: 10px;
     width: 32px;
     height: 32px;
-    background: linear-gradient(135deg, #a855f7 0%, #ec4899 100%);
+    background: linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%);
     border-radius: 8px;
     display: flex;
     align-items: center;
@@ -1481,7 +1481,7 @@ const seriesStyles = `
     font-size: 18px;
     color: white;
     font-weight: bold;
-    box-shadow: 0 4px 12px rgba(168, 85, 247, 0.4);
+    box-shadow: 0 4px 12px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 /* Episode Badge */
@@ -1522,7 +1522,7 @@ const seriesStyles = `
 }
 
 .series-card:hover .card-title {
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
 }
 
 /* Empty State */
@@ -1574,13 +1574,13 @@ const seriesStyles = `
 
 .skeleton-poster {
     aspect-ratio: 2 / 3;
-    background: linear-gradient(135deg, #2a2a4a 0%, #1a1a2e 100%);
+    background: linear-gradient(135deg, #2a2a4a 0%, var(--ns-bg-panel) 100%);
     border-radius: 16px 16px 0 0;
 }
 
 .skeleton-title {
     height: 50px;
-    background: linear-gradient(135deg, #1a1a2e 0%, #2a2a4a 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, #2a2a4a 100%);
     border-radius: 0 0 16px 16px;
 }
 

--- a/src/pages/VOD.tsx
+++ b/src/pages/VOD.tsx
@@ -495,7 +495,7 @@ export function VOD() {
                                                         <div style={{
                                                             width: `${progress}%`,
                                                             height: '100%',
-                                                            background: 'linear-gradient(90deg, #6366f1, #a855f7)'
+                                                            background: 'linear-gradient(90deg, var(--ns-accent-dark), var(--ns-accent))'
                                                         }} />
                                                     </div>
                                                 )}
@@ -601,7 +601,7 @@ const vodStyles = `
     position: relative;
     height: 100vh;
     overflow: hidden;
-    background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%);
 }
 
 /* Dynamic Backdrop */
@@ -635,7 +635,7 @@ const vodStyles = `
     background: linear-gradient(135deg, rgba(15, 15, 26, 0.9) 0%, rgba(26, 26, 46, 0.85) 100%);
     backdrop-filter: blur(24px);
     border-radius: 24px;
-    border: 1px solid rgba(99, 102, 241, 0.2);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.2);
     padding: 32px;
     animation: slideDown 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4), 
@@ -675,7 +675,7 @@ const vodStyles = `
 }
 
 .badge.shimmer {
-    background: linear-gradient(90deg, rgba(99, 102, 241, 0.2), rgba(168, 85, 247, 0.2), rgba(99, 102, 241, 0.2));
+    background: linear-gradient(90deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.2), rgba(var(--ns-accent-rgb), 0.2));
     background-size: 200% 100%;
     animation: shimmerBadge 1.5s ease infinite;
     color: rgba(255, 255, 255, 0.6);
@@ -762,8 +762,8 @@ const vodStyles = `
 }
 
 .genre-tag:hover {
-    background: rgba(99, 102, 241, 0.2);
-    border-color: rgba(99, 102, 241, 0.4);
+    background: rgba(var(--ns-accent-rgb), 0.2);
+    border-color: rgba(var(--ns-accent-rgb), 0.4);
 }
 
 /* Overview */
@@ -805,14 +805,14 @@ const vodStyles = `
 }
 
 .btn-primary {
-    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+    background: linear-gradient(135deg, var(--ns-accent-dark) 0%, var(--ns-accent) 100%);
     color: white;
-    box-shadow: 0 8px 24px rgba(99, 102, 241, 0.4);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.4);
 }
 
 .btn-primary:hover {
     transform: translateY(-3px) scale(1.02);
-    box-shadow: 0 12px 32px rgba(99, 102, 241, 0.5);
+    box-shadow: 0 12px 32px rgba(var(--ns-accent-rgb), 0.5);
 }
 
 .btn-primary:active {
@@ -895,7 +895,7 @@ const vodStyles = `
     overflow-x: hidden;
     padding-right: 8px;
     scrollbar-width: thin;
-    scrollbar-color: rgba(99, 102, 241, 0.4) transparent;
+    scrollbar-color: rgba(var(--ns-accent-rgb), 0.4) transparent;
 }
 
 .movies-scroll-container::-webkit-scrollbar {
@@ -907,7 +907,7 @@ const vodStyles = `
 }
 
 .movies-scroll-container::-webkit-scrollbar-thumb {
-    background: linear-gradient(180deg, #6366f1, #a855f7);
+    background: linear-gradient(180deg, var(--ns-accent-dark), var(--ns-accent));
     border-radius: 3px;
 }
 
@@ -959,14 +959,14 @@ const vodStyles = `
 
 .movie-card:hover {
     transform: translateY(-8px) scale(1.03);
-    border-color: rgba(99, 102, 241, 0.4);
+    border-color: rgba(var(--ns-accent-rgb), 0.4);
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4),
-                0 0 40px rgba(99, 102, 241, 0.15);
+                0 0 40px rgba(var(--ns-accent-rgb), 0.15);
 }
 
 .movie-card.selected {
-    border-color: #6366f1;
-    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.3),
+    border-color: var(--ns-accent);
+    box-shadow: 0 0 0 3px rgba(var(--ns-accent-rgb), 0.3),
                 0 20px 40px rgba(0, 0, 0, 0.4);
 }
 
@@ -975,7 +975,7 @@ const vodStyles = `
     position: relative;
     aspect-ratio: 2 / 3;
     overflow: hidden;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
 }
 
 .card-poster img {
@@ -995,7 +995,7 @@ const vodStyles = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, #1e1e3f 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, #1e1e3f 0%, var(--ns-bg-deep) 100%);
     font-size: 48px;
 }
 
@@ -1023,7 +1023,7 @@ const vodStyles = `
 .play-icon {
     width: 60px;
     height: 60px;
-    background: rgba(99, 102, 241, 0.9);
+    background: rgba(var(--ns-accent-rgb), 0.9);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -1032,7 +1032,7 @@ const vodStyles = `
     color: white;
     transform: scale(0);
     transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    box-shadow: 0 8px 24px rgba(99, 102, 241, 0.5);
+    box-shadow: 0 8px 24px rgba(var(--ns-accent-rgb), 0.5);
 }
 
 .movie-card:hover .play-icon {
@@ -1090,7 +1090,7 @@ const vodStyles = `
 
 .card-progress-bar {
     height: 100%;
-    background: linear-gradient(90deg, #6366f1, #a855f7);
+    background: linear-gradient(90deg, var(--ns-accent-dark), var(--ns-accent));
     transition: width 0.3s ease;
 }
 
@@ -1189,13 +1189,13 @@ const vodStyles = `
 
 .skeleton-poster {
     aspect-ratio: 2 / 3;
-    background: linear-gradient(135deg, #2a2a4a 0%, #1a1a2e 100%);
+    background: linear-gradient(135deg, #2a2a4a 0%, var(--ns-bg-panel) 100%);
     border-radius: 16px 16px 0 0;
 }
 
 .skeleton-title {
     height: 50px;
-    background: linear-gradient(135deg, #1a1a2e 0%, #2a2a4a 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, #2a2a4a 100%);
     border-radius: 0 0 16px 16px;
 }
 

--- a/src/pages/settings/AboutSection.tsx
+++ b/src/pages/settings/AboutSection.tsx
@@ -102,8 +102,8 @@ export function AboutSection() {
                         width: '100%',
                         maxHeight: '80vh',
                         overflow: 'auto',
-                        border: '1px solid rgba(168, 85, 247, 0.3)',
-                        boxShadow: '0 25px 80px rgba(0, 0, 0, 0.5), 0 0 40px rgba(168, 85, 247, 0.1)',
+                        border: '1px solid rgba(var(--ns-accent-rgb), 0.3)',
+                        boxShadow: '0 25px 80px rgba(0, 0, 0, 0.5), 0 0 40px rgba(var(--ns-accent-rgb), 0.1)',
                         animation: 'modalSlideIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1)'
                     }}>
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
@@ -118,7 +118,7 @@ export function AboutSection() {
                             }}>
                                 <span style={{ fontSize: '32px', animation: 'iconPulse 2s ease infinite' }}>📄</span>
                                 <span style={{
-                                    background: 'linear-gradient(135deg, #a855f7 0%, #ec4899 100%)',
+                                    background: 'linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%)',
                                     WebkitBackgroundClip: 'text',
                                     WebkitTextFillColor: 'transparent',
                                     backgroundClip: 'text'
@@ -127,22 +127,22 @@ export function AboutSection() {
                             <button
                                 onClick={() => setShowTermsModal(false)}
                                 style={{
-                                    background: 'rgba(168, 85, 247, 0.15)',
-                                    border: '1px solid rgba(168, 85, 247, 0.3)',
+                                    background: 'rgba(var(--ns-accent-rgb), 0.15)',
+                                    border: '1px solid rgba(var(--ns-accent-rgb), 0.3)',
                                     borderRadius: '12px',
                                     padding: '10px 16px',
-                                    color: '#a855f7',
+                                    color: 'var(--ns-accent)',
                                     cursor: 'pointer',
                                     fontSize: '14px',
                                     fontWeight: 600,
                                     transition: 'all 0.2s ease'
                                 }}
                                 onMouseEnter={(e) => {
-                                    e.currentTarget.style.background = 'rgba(168, 85, 247, 0.25)';
+                                    e.currentTarget.style.background = 'rgba(var(--ns-accent-rgb), 0.25)';
                                     e.currentTarget.style.transform = 'scale(1.05)';
                                 }}
                                 onMouseLeave={(e) => {
-                                    e.currentTarget.style.background = 'rgba(168, 85, 247, 0.15)';
+                                    e.currentTarget.style.background = 'rgba(var(--ns-accent-rgb), 0.15)';
                                     e.currentTarget.style.transform = 'scale(1)';
                                 }}
                             >
@@ -150,17 +150,17 @@ export function AboutSection() {
                             </button>
                         </div>
                         <div style={{ color: '#9ca3af', fontSize: '14px', lineHeight: 1.8, animation: 'fadeInUp 0.5s ease 0.2s both' }}>
-                            <p style={{ marginBottom: '16px', padding: '12px 16px', background: 'rgba(168, 85, 247, 0.1)', borderRadius: '12px', border: '1px solid rgba(168, 85, 247, 0.2)' }}>
-                                <strong style={{ color: '#a855f7' }}>📅 Última atualização:</strong> <span style={{ color: 'white' }}>09 de Dezembro de 2025</span>
+                            <p style={{ marginBottom: '16px', padding: '12px 16px', background: 'rgba(var(--ns-accent-rgb), 0.1)', borderRadius: '12px', border: '1px solid rgba(var(--ns-accent-rgb), 0.2)' }}>
+                                <strong style={{ color: 'var(--ns-accent)' }}>📅 Última atualização:</strong> <span style={{ color: 'white' }}>09 de Dezembro de 2025</span>
                             </p>
 
-                            <h3 style={{ color: '#a855f7', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>1. Aceitação dos Termos</h3>
+                            <h3 style={{ color: 'var(--ns-accent)', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>1. Aceitação dos Termos</h3>
                             <p>Ao utilizar o NeoStream, você concorda com estes Termos de Uso. O aplicativo é destinado exclusivamente para uso pessoal e não comercial.</p>
 
-                            <h3 style={{ color: '#a855f7', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>2. Descrição do Serviço</h3>
+                            <h3 style={{ color: 'var(--ns-accent)', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>2. Descrição do Serviço</h3>
                             <p>O NeoStream é um player de mídia que permite visualizar conteúdo IPTV através de listas M3U fornecidas pelo usuário. Não fornecemos, hospedamos ou distribuímos qualquer conteúdo de mídia.</p>
 
-                            <h3 style={{ color: '#a855f7', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>3. Responsabilidade do Usuário</h3>
+                            <h3 style={{ color: 'var(--ns-accent)', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>3. Responsabilidade do Usuário</h3>
                             <p>Você é responsável por:</p>
                             <ul style={{ marginLeft: '20px', marginTop: '8px' }}>
                                 <li>Garantir que possui direitos legais sobre o conteúdo acessado</li>
@@ -169,10 +169,10 @@ export function AboutSection() {
                                 <li>Usar o aplicativo de forma ética e responsável</li>
                             </ul>
 
-                            <h3 style={{ color: '#a855f7', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>4. Uso do Controle Parental</h3>
+                            <h3 style={{ color: 'var(--ns-accent)', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>4. Uso do Controle Parental</h3>
                             <p>O recurso de controle parental é fornecido como ferramenta auxiliar. Os pais/responsáveis devem supervisionar o uso do aplicativo por menores.</p>
 
-                            <h3 style={{ color: '#a855f7', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>5. Limitação de Responsabilidade</h3>
+                            <h3 style={{ color: 'var(--ns-accent)', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>5. Limitação de Responsabilidade</h3>
                             <p>O NeoStream é fornecido "como está", sem garantias. Não nos responsabilizamos por:</p>
                             <ul style={{ marginLeft: '20px', marginTop: '8px' }}>
                                 <li>Conteúdo de terceiros acessado através do aplicativo</li>
@@ -180,7 +180,7 @@ export function AboutSection() {
                                 <li>Perdas de dados ou problemas técnicos</li>
                             </ul>
 
-                            <h3 style={{ color: '#a855f7', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>6. Modificações</h3>
+                            <h3 style={{ color: 'var(--ns-accent)', fontSize: '16px', marginTop: '24px', marginBottom: '12px' }}>6. Modificações</h3>
                             <p>Reservamo-nos o direito de modificar estes termos a qualquer momento. Alterações significativas serão comunicadas através do aplicativo.</p>
                         </div>
                     </div>

--- a/src/pages/settings/BackupSection.tsx
+++ b/src/pages/settings/BackupSection.tsx
@@ -167,7 +167,7 @@ export function BackupSection() {
                             padding: 32,
                             maxWidth: 480,
                             width: '90%',
-                            border: '1px solid rgba(168, 85, 247, 0.2)',
+                            border: '1px solid rgba(var(--ns-accent-rgb), 0.2)',
                             boxShadow: '0 25px 80px rgba(0, 0, 0, 0.5)'
                         }}
                         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## 🎨 Fix — cores do tema no fluxo de assistir

Bug reportado: trocar a cor na Aparência não mudava os modais de filme/série nem o player.

### Causa raiz
O commit que tematizava os modais ficou **fora do squash merge** do PR #27 (foi pushado minutos antes do merge e o GitHub não o incluiu). Recuperado via cherry-pick.

### E fomos além — fluxo de assistir 100% temático agora
- **Modais**: detalhes de filme/série, continuar assistindo, preview, cast, perfis
- **Player**: tela de loading, spinner, botão central, barra de progresso, menus internos, PiP
- **Páginas**: Filmes/Séries/Canais (heroes, abas de temporada, lista de episódios, cards, scrollbars), menu de categorias, barra de busca animada
- **Shell**: barra de título (logo inclusive), seletor de perfis, notificações, toast de episódios, popup de atualização

Cores semânticas preservadas (vermelho live/perigo, verde sucesso, azul cast, badges de identidade).

### Verificação
- tsc / eslint / vitest **95/95** / vite build ✅
- Visual ao vivo com o tema Azul do usuário: grade de filmes, modal, loading e controles do player todos azuis ✅