### PR TITLE
feat: EPG do provedor (xmltv.php) como fonte primária com fallback

### DIFF
--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -2,6 +2,7 @@ import { ipcMain, BrowserWindow, dialog, screen } from 'electron'
 import { XtreamClient } from './xtreamClient'
 import store from './store'
 import { getCertificateSettings, getProviderHttpsAgent, registerApprovedProviderUrl, setAllowInvalidProviderCertificates } from './certificatePolicy'
+import { resetProviderEpgState, setupProviderEpgHandlers } from './providerEpg'
 
 import log from './logger'
 // Store for window state (for custom maximize)
@@ -80,6 +81,9 @@ export function setupIpcHandlers() {
             // Save to store
             store.set('auth', { url, username, password, userInfo: data.user_info })
 
+            // New provider may have a different (or no) EPG — re-probe lazily.
+            resetProviderEpgState()
+
             return { success: true, data }
         } catch (error: unknown) {
             return { success: false, error: getErrorMessage(error) }
@@ -104,6 +108,7 @@ export function setupIpcHandlers() {
 
     ipcMain.handle('auth:logout', () => {
         store.set('auth', {})
+        resetProviderEpgState()
         return { success: true }
     })
 
@@ -600,6 +605,9 @@ export function setupIpcHandlers() {
             return { success: false, error: getErrorMessage(error) }
         }
     })
+
+    // Provider EPG (xmltv.php / get_simple_data_table) handlers
+    setupProviderEpgHandlers()
 
     log.info('IPC Handlers initialized')
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -42,6 +42,8 @@ const invokeChannels = new Set([
     'epg:fetch-mitv',
     'epg:get-cache-info',
     'epg:get-cached',
+    'epg:provider-available',
+    'epg:provider-channel',
     'fetch-url',
     'mpv:available',
     'mpv:pause',

--- a/electron/providerEpg.ts
+++ b/electron/providerEpg.ts
@@ -1,0 +1,265 @@
+/**
+ * Xtream provider EPG — main process side.
+ *
+ * Downloads {server}/xmltv.php once per session (24h file cache, same
+ * mechanism/dir as 'epg:get-cached'), parses it ONCE into an in-memory
+ * Map<epg_channel_id, programs> and answers per-channel lookups instantly
+ * over IPC. When the provider has no xmltv.php (404/HTML/empty), it is
+ * marked unavailable for the session — no retry storms — and per-channel
+ * get_simple_data_table is tried as the secondary provider source.
+ *
+ * Pure parsing helpers live in providerEpgProtocol.ts (unit-tested).
+ */
+import { ipcMain } from 'electron'
+import store from './store'
+import log from './logger'
+import { getProviderHttpsAgent, registerApprovedProviderUrl } from './certificatePolicy'
+import {
+    buildSimpleDataTableUrl,
+    buildXmltvUrl,
+    looksLikeXmltv,
+    parseSimpleDataTable,
+    parseXmltvIndex,
+} from './providerEpgProtocol'
+import type { ProviderEpgProgram } from './providerEpgProtocol'
+
+const XMLTV_CACHE_KEY = 'provider-xmltv'
+const XMLTV_CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const SIMPLE_TABLE_TTL_MS = 60 * 60 * 1000
+const FETCH_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+    'Accept': 'application/xml, text/xml, application/json, */*'
+}
+
+type Availability = 'unknown' | 'ready' | 'unavailable'
+
+interface Credentials {
+    url: string
+    username: string
+    password: string
+}
+
+let xmltvAvailability: Availability = 'unknown'
+let xmltvIndex: Map<string, ProviderEpgProgram[]> | null = null
+let xmltvLoading: Promise<void> | null = null
+
+// get_simple_data_table fallback — disabled for the session on first hard failure.
+let simpleTableAvailable = true
+const simpleTableCache = new Map<number, { at: number; programs: ProviderEpgProgram[] }>()
+
+function getCredentials(): Credentials | null {
+    const auth = store.get('auth')
+    if (auth.url && auth.username && auth.password) {
+        return { url: auth.url, username: auth.username, password: auth.password }
+    }
+    return null
+}
+
+/** Reset all session state (e.g. after switching providers). Exported for tests/future use. */
+export function resetProviderEpgState() {
+    xmltvAvailability = 'unknown'
+    xmltvIndex = null
+    xmltvLoading = null
+    simpleTableAvailable = true
+    simpleTableCache.clear()
+}
+
+/**
+ * Download xmltv.php through the same 24h file cache used by 'epg:get-cached'
+ * (userData/epg_cache, cacheKey 'provider-xmltv'). Returns null on failure.
+ */
+async function fetchXmltvWithCache(url: string): Promise<string | null> {
+    const fs = await import('fs/promises')
+    const path = await import('path')
+    const { app } = await import('electron')
+
+    const cacheDir = path.join(app.getPath('userData'), 'epg_cache')
+    const cacheFile = path.join(cacheDir, `${XMLTV_CACHE_KEY}.xml`)
+    const metaFile = path.join(cacheDir, `${XMLTV_CACHE_KEY}.meta.json`)
+    await fs.mkdir(cacheDir, { recursive: true })
+
+    // Within TTL → reuse the cached file, never re-download.
+    try {
+        const meta = JSON.parse(await fs.readFile(metaFile, 'utf-8'))
+        if (Date.now() - meta.timestamp < XMLTV_CACHE_TTL_MS) {
+            const cached = await fs.readFile(cacheFile, 'utf-8')
+            log.info('[Provider EPG] Using cached xmltv, age:',
+                Math.round((Date.now() - meta.timestamp) / 3600000), 'h, length:', cached.length)
+            return cached
+        }
+        log.info('[Provider EPG] Cache expired, downloading fresh xmltv')
+    } catch {
+        log.info('[Provider EPG] No xmltv cache, downloading fresh')
+    }
+
+    try {
+        const fetch = (await import('node-fetch')).default
+        const response = await fetch(url, {
+            agent: getProviderHttpsAgent(url),
+            headers: FETCH_HEADERS
+        })
+
+        if (!response.ok) {
+            log.warn('[Provider EPG] xmltv download failed: HTTP', response.status)
+            return await readStaleCache(fs, cacheFile)
+        }
+
+        const data = await response.text()
+        registerApprovedProviderUrl(response.url || url)
+        log.info('[Provider EPG] Downloaded xmltv, length:', data.length)
+
+        // Only cache plausible XMLTV — caching an HTML error page for 24h
+        // would mask the provider coming back.
+        if (looksLikeXmltv(data)) {
+            await fs.writeFile(cacheFile, data, 'utf-8')
+            await fs.writeFile(metaFile, JSON.stringify({ timestamp: Date.now(), size: data.length }), 'utf-8')
+        }
+        return data
+    } catch (error) {
+        log.warn('[Provider EPG] xmltv download error:', error instanceof Error ? error.message : String(error))
+        return await readStaleCache(fs, cacheFile)
+    }
+}
+
+async function readStaleCache(fs: typeof import('fs/promises'), cacheFile: string): Promise<string | null> {
+    try {
+        const data = await fs.readFile(cacheFile, 'utf-8')
+        log.info('[Provider EPG] Using stale xmltv cache after download failure')
+        return data
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Availability probe + index build. Runs the download/parse at most once per
+ * session (single in-flight promise); a definitive failure marks the source
+ * unavailable for the rest of the session.
+ */
+function ensureXmltvIndex(): Promise<void> {
+    if (xmltvAvailability !== 'unknown') return Promise.resolve()
+    if (xmltvLoading) return xmltvLoading
+
+    xmltvLoading = (async () => {
+        const credentials = getCredentials()
+        if (!credentials) {
+            // Not logged in yet — stay 'unknown' so the next call (post-login) retries.
+            log.info('[Provider EPG] No credentials, skipping xmltv probe')
+            return
+        }
+
+        try {
+            const url = buildXmltvUrl(credentials.url, credentials.username, credentials.password)
+            const xml = await fetchXmltvWithCache(url)
+
+            if (!xml || !looksLikeXmltv(xml)) {
+                xmltvAvailability = 'unavailable'
+                log.info('[Provider EPG] Provider xmltv unavailable (empty/404/HTML), disabled for this session')
+                return
+            }
+
+            const parseStart = Date.now()
+            xmltvIndex = parseXmltvIndex(xml)
+            xmltvAvailability = 'ready'
+
+            let programCount = 0
+            for (const programs of xmltvIndex.values()) programCount += programs.length
+            log.info('[Provider EPG] Indexed', xmltvIndex.size, 'channels /', programCount,
+                'programs in', Date.now() - parseStart, 'ms')
+        } catch (error) {
+            xmltvAvailability = 'unavailable'
+            log.error('[Provider EPG] xmltv probe error:', error instanceof Error ? error.message : String(error))
+        }
+    })().finally(() => {
+        xmltvLoading = null
+    })
+
+    return xmltvLoading
+}
+
+/** Per-channel JSON EPG (secondary source when xmltv.php is unavailable). */
+async function fetchSimpleDataTable(streamId: number, channelId: string): Promise<ProviderEpgProgram[]> {
+    const cached = simpleTableCache.get(streamId)
+    if (cached && Date.now() - cached.at < SIMPLE_TABLE_TTL_MS) {
+        return cached.programs
+    }
+
+    const credentials = getCredentials()
+    if (!credentials) return []
+
+    try {
+        const url = buildSimpleDataTableUrl(credentials.url, credentials.username, credentials.password, streamId)
+        const fetch = (await import('node-fetch')).default
+        const response = await fetch(url, {
+            agent: getProviderHttpsAgent(url),
+            headers: FETCH_HEADERS
+        })
+
+        if (!response.ok) {
+            log.warn('[Provider EPG] get_simple_data_table failed: HTTP', response.status, '— disabled for this session')
+            simpleTableAvailable = false
+            return []
+        }
+
+        const text = await response.text()
+        let payload: unknown
+        try {
+            payload = JSON.parse(text)
+        } catch {
+            log.warn('[Provider EPG] get_simple_data_table returned non-JSON — disabled for this session')
+            simpleTableAvailable = false
+            return []
+        }
+
+        registerApprovedProviderUrl(response.url || url)
+        const programs = parseSimpleDataTable(payload, channelId || String(streamId))
+        simpleTableCache.set(streamId, { at: Date.now(), programs })
+        return programs
+    } catch (error) {
+        log.warn('[Provider EPG] get_simple_data_table error:', error instanceof Error ? error.message : String(error))
+        simpleTableAvailable = false
+        return []
+    }
+}
+
+export function setupProviderEpgHandlers() {
+    // Is the provider's own EPG usable this session? (Triggers the probe.)
+    ipcMain.handle('epg:provider-available', async () => {
+        try {
+            await ensureXmltvIndex()
+            return { success: true, available: xmltvAvailability === 'ready' }
+        } catch (error) {
+            return { success: false, error: error instanceof Error ? error.message : String(error) }
+        }
+    })
+
+    // Programs for one channel, straight from the in-memory index.
+    ipcMain.handle('epg:provider-channel', async (_, args: { channelId?: string; streamId?: number }) => {
+        try {
+            const channelId = typeof args?.channelId === 'string' ? args.channelId : ''
+            const streamId = typeof args?.streamId === 'number' && Number.isFinite(args.streamId)
+                ? args.streamId
+                : null
+
+            if (channelId) {
+                await ensureXmltvIndex()
+                if (xmltvAvailability === 'ready' && xmltvIndex) {
+                    // xmltv is THE provider EPG when present: a channel missing
+                    // from it means the provider has no EPG for it — let the
+                    // renderer fall back to its existing chain.
+                    return { success: true, programs: xmltvIndex.get(channelId) ?? [], source: 'xmltv' }
+                }
+            }
+
+            // xmltv unavailable (or channel has no epg id): try the per-channel endpoint.
+            if (streamId !== null && simpleTableAvailable) {
+                const programs = await fetchSimpleDataTable(streamId, channelId)
+                return { success: true, programs, source: 'simple-data-table' }
+            }
+
+            return { success: true, programs: [], source: 'none' }
+        } catch (error) {
+            return { success: false, error: error instanceof Error ? error.message : String(error) }
+        }
+    })
+}

--- a/electron/providerEpgProtocol.test.ts
+++ b/electron/providerEpgProtocol.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for the pure Xtream provider EPG helpers.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+    buildDefaultWindow,
+    buildSimpleDataTableUrl,
+    buildXmltvUrl,
+    decodeBase64Utf8,
+    decodeXmlText,
+    looksLikeXmltv,
+    normalizeServerUrl,
+    parseSimpleDataTable,
+    parseXmltvIndex,
+    parseXmltvTime,
+    PROVIDER_EPG_FUTURE_WINDOW_MS,
+    PROVIDER_EPG_PAST_WINDOW_MS,
+} from './providerEpgProtocol'
+
+describe('normalizeServerUrl / URL builders', () => {
+    it('strips trailing slashes from the server url', () => {
+        expect(normalizeServerUrl('http://host:8080/')).toBe('http://host:8080')
+        expect(normalizeServerUrl('http://host:8080///')).toBe('http://host:8080')
+    })
+
+    it('builds the xmltv.php url with encoded credentials', () => {
+        expect(buildXmltvUrl('http://host:8080/', 'user name', 'p&ss'))
+            .toBe('http://host:8080/xmltv.php?username=user%20name&password=p%26ss')
+    })
+
+    it('builds the get_simple_data_table url with the stream id', () => {
+        expect(buildSimpleDataTableUrl('http://host:8080', 'u', 'p', 42))
+            .toBe('http://host:8080/player_api.php?username=u&password=p&action=get_simple_data_table&stream_id=42')
+    })
+})
+
+describe('looksLikeXmltv', () => {
+    it('accepts a document containing programme entries', () => {
+        expect(looksLikeXmltv('<?xml version="1.0"?><tv><programme channel="x"></programme></tv>')).toBe(true)
+    })
+
+    it('rejects empty bodies, HTML error pages and programme-less documents', () => {
+        expect(looksLikeXmltv('')).toBe(false)
+        expect(looksLikeXmltv('<!DOCTYPE html><html><body>404 Not Found</body></html>')).toBe(false)
+        expect(looksLikeXmltv('<html><head><title>Error</title></head></html>')).toBe(false)
+        expect(looksLikeXmltv('<?xml version="1.0"?><tv></tv>')).toBe(false)
+    })
+})
+
+describe('parseXmltvTime', () => {
+    it('parses "YYYYMMDDHHMMSS +0000" into epoch ms (UTC)', () => {
+        expect(parseXmltvTime('20260612153000 +0000')).toBe(Date.UTC(2026, 5, 12, 15, 30, 0))
+    })
+
+    it('applies positive and negative timezone offsets', () => {
+        // 15:30 at -0300 == 18:30 UTC
+        expect(parseXmltvTime('20260612153000 -0300')).toBe(Date.UTC(2026, 5, 12, 18, 30, 0))
+        // 15:30 at +0200 == 13:30 UTC
+        expect(parseXmltvTime('20260612153000 +0200')).toBe(Date.UTC(2026, 5, 12, 13, 30, 0))
+    })
+
+    it('treats a missing offset as UTC and pads missing seconds', () => {
+        expect(parseXmltvTime('202606121530')).toBe(Date.UTC(2026, 5, 12, 15, 30, 0))
+    })
+
+    it('returns null for malformed values', () => {
+        expect(parseXmltvTime('')).toBeNull()
+        expect(parseXmltvTime('not-a-time')).toBeNull()
+        expect(parseXmltvTime('20261312000000 +0000')).toBeNull() // month 13
+    })
+})
+
+describe('decodeXmlText', () => {
+    it('unwraps CDATA sections', () => {
+        expect(decodeXmlText('<![CDATA[Jornal Nacional]]>')).toBe('Jornal Nacional')
+    })
+
+    it('decodes entities including numeric and hex references', () => {
+        expect(decodeXmlText('Tom &amp; Jerry &lt;ao vivo&gt; &quot;hoje&quot; &#233; &#xE0;s 20h'))
+            .toBe('Tom & Jerry <ao vivo> "hoje" é às 20h')
+    })
+
+    it('keeps accented characters untouched', () => {
+        expect(decodeXmlText('Sessão da Tarde: Ação e Emoção')).toBe('Sessão da Tarde: Ação e Emoção')
+    })
+})
+
+// A small fixture exercising CDATA, entities, accents, multiple channels and
+// programs outside the retention window.
+const NOW = Date.UTC(2026, 5, 12, 12, 0, 0) // 2026-06-12 12:00 UTC
+
+const XMLTV_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<tv generator-info-name="provider">
+  <channel id="globo.br"><display-name>Globo</display-name></channel>
+  <programme start="20260612110000 +0000" stop="20260612130000 +0000" channel="globo.br">
+    <title lang="pt"><![CDATA[Sessão da Tarde]]></title>
+    <desc lang="pt"><![CDATA[Filme: Ação & Aventura]]></desc>
+  </programme>
+  <programme start="20260612130000 +0000" stop="20260612140000 +0000" channel="globo.br">
+    <title lang="pt">Tom &amp; Jerry</title>
+    <desc lang="pt">Epis&#243;dio in&#233;dito</desc>
+  </programme>
+  <programme start="20260610000000 +0000" stop="20260610010000 +0000" channel="globo.br">
+    <title>Too old — outside the window</title>
+  </programme>
+  <programme start="20260620000000 +0000" stop="20260620010000 +0000" channel="globo.br">
+    <title>Too far in the future</title>
+  </programme>
+  <programme start="20260612090000 -0300" stop="20260612100000 -0300" channel="sbt.br">
+    <title>Programa Sílvio Santos</title>
+  </programme>
+  <programme start="bogus" stop="20260612140000 +0000" channel="sbt.br">
+    <title>Malformed start, skipped</title>
+  </programme>
+  <programme start="20260612140000 +0000" stop="20260612150000 +0000">
+    <title>No channel attribute, skipped</title>
+  </programme>
+</tv>`
+
+describe('parseXmltvIndex', () => {
+    it('indexes programmes per channel id', () => {
+        const index = parseXmltvIndex(XMLTV_FIXTURE, NOW)
+        expect([...index.keys()].sort()).toEqual(['globo.br', 'sbt.br'])
+        expect(index.get('globo.br')).toHaveLength(2)
+        expect(index.get('sbt.br')).toHaveLength(1)
+    })
+
+    it('decodes CDATA, entities and accents in titles/descriptions', () => {
+        const index = parseXmltvIndex(XMLTV_FIXTURE, NOW)
+        const globo = index.get('globo.br')!
+
+        expect(globo[0].title).toBe('Sessão da Tarde')
+        expect(globo[0].description).toBe('Filme: Ação & Aventura')
+        expect(globo[1].title).toBe('Tom & Jerry')
+        expect(globo[1].description).toBe('Episódio inédito')
+
+        expect(index.get('sbt.br')![0].title).toBe('Programa Sílvio Santos')
+    })
+
+    it('converts XMLTV times (with offsets) into ISO timestamps, sorted', () => {
+        const index = parseXmltvIndex(XMLTV_FIXTURE, NOW)
+        const globo = index.get('globo.br')!
+
+        expect(globo[0].start).toBe(new Date(Date.UTC(2026, 5, 12, 11, 0, 0)).toISOString())
+        expect(globo[0].end).toBe(new Date(Date.UTC(2026, 5, 12, 13, 0, 0)).toISOString())
+        expect(globo[0].start <= globo[1].start).toBe(true)
+
+        // -0300 offset: 09:00 local == 12:00 UTC
+        expect(index.get('sbt.br')![0].start).toBe(new Date(Date.UTC(2026, 5, 12, 12, 0, 0)).toISOString())
+    })
+
+    it('drops programmes outside the now-24h..now+48h window', () => {
+        const index = parseXmltvIndex(XMLTV_FIXTURE, NOW)
+        const titles = index.get('globo.br')!.map((p) => p.title)
+        expect(titles).not.toContain('Too old — outside the window')
+        expect(titles).not.toContain('Too far in the future')
+    })
+
+    it('returns an empty index for non-XMLTV input', () => {
+        expect(parseXmltvIndex('<html>404</html>', NOW).size).toBe(0)
+    })
+})
+
+describe('buildDefaultWindow', () => {
+    it('spans now-24h to now+48h', () => {
+        const window = buildDefaultWindow(NOW)
+        expect(window.minEndMs).toBe(NOW - PROVIDER_EPG_PAST_WINDOW_MS)
+        expect(window.maxStartMs).toBe(NOW + PROVIDER_EPG_FUTURE_WINDOW_MS)
+    })
+})
+
+describe('decodeBase64Utf8', () => {
+    it('decodes UTF-8 text with accents', () => {
+        const encoded = Buffer.from('Sessão da Tarde', 'utf-8').toString('base64')
+        expect(decodeBase64Utf8(encoded)).toBe('Sessão da Tarde')
+    })
+
+    it('returns the input on invalid base64 instead of throwing', () => {
+        expect(typeof decodeBase64Utf8('%%not-base64%%')).toBe('string')
+    })
+})
+
+describe('parseSimpleDataTable', () => {
+    const startSec = Math.floor(NOW / 1000)
+    const payload = {
+        epg_listings: [
+            {
+                id: '1',
+                title: Buffer.from('Jornal da Manhã', 'utf-8').toString('base64'),
+                description: Buffer.from('Notícias & esportes', 'utf-8').toString('base64'),
+                start: '2026-06-12 12:00:00',
+                end: '2026-06-12 13:00:00',
+                start_timestamp: String(startSec),
+                stop_timestamp: String(startSec + 3600),
+            },
+            {
+                id: '2',
+                title: Buffer.from('Muito antigo', 'utf-8').toString('base64'),
+                start_timestamp: String(startSec - 3 * 24 * 3600),
+                stop_timestamp: String(startSec - 3 * 24 * 3600 + 1800),
+            },
+        ],
+    }
+
+    it('maps listings to programs with decoded base64 fields', () => {
+        const programs = parseSimpleDataTable(payload, 'globo.br', NOW)
+        expect(programs).toHaveLength(1)
+        expect(programs[0].title).toBe('Jornal da Manhã')
+        expect(programs[0].description).toBe('Notícias & esportes')
+        expect(programs[0].channel_id).toBe('globo.br')
+        expect(programs[0].start).toBe(new Date(NOW).toISOString())
+        expect(programs[0].end).toBe(new Date(NOW + 3600 * 1000).toISOString())
+    })
+
+    it('applies the retention window', () => {
+        const programs = parseSimpleDataTable(payload, 'globo.br', NOW)
+        expect(programs.some((p) => p.title === 'Muito antigo')).toBe(false)
+    })
+
+    it('handles malformed payloads gracefully', () => {
+        expect(parseSimpleDataTable(null, 'x', NOW)).toEqual([])
+        expect(parseSimpleDataTable({}, 'x', NOW)).toEqual([])
+        expect(parseSimpleDataTable({ epg_listings: 'nope' }, 'x', NOW)).toEqual([])
+        expect(parseSimpleDataTable({ epg_listings: [{ title: 'a' }] }, 'x', NOW)).toEqual([])
+    })
+})

--- a/electron/providerEpgProtocol.ts
+++ b/electron/providerEpgProtocol.ts
@@ -1,0 +1,251 @@
+/**
+ * Pure helpers for the Xtream provider EPG integration — no Electron, no
+ * network, no state. Everything here is unit-testable; the side-effectful
+ * parts (download, file cache, ipcMain handlers) live in providerEpg.ts.
+ *
+ * Endpoints covered:
+ *   1. {server}/xmltv.php?username=..&password=..           — full XMLTV dump
+ *   2. {server}/player_api.php?..&action=get_simple_data_table&stream_id=..
+ *      — per-channel JSON EPG with base64-encoded title/description.
+ */
+
+export interface ProviderEpgProgram {
+    id: string
+    start: string
+    end: string
+    title: string
+    description?: string
+    channel_id: string
+}
+
+/** Keep only programs within now-24h .. now+48h to bound memory. */
+export const PROVIDER_EPG_PAST_WINDOW_MS = 24 * 60 * 60 * 1000
+export const PROVIDER_EPG_FUTURE_WINDOW_MS = 48 * 60 * 60 * 1000
+
+export function normalizeServerUrl(serverUrl: string): string {
+    return serverUrl.trim().replace(/\/+$/, '')
+}
+
+export function buildXmltvUrl(serverUrl: string, username: string, password: string): string {
+    const base = normalizeServerUrl(serverUrl)
+    return `${base}/xmltv.php?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`
+}
+
+export function buildSimpleDataTableUrl(serverUrl: string, username: string, password: string, streamId: number): string {
+    const base = normalizeServerUrl(serverUrl)
+    return `${base}/player_api.php?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`
+        + `&action=get_simple_data_table&stream_id=${encodeURIComponent(String(streamId))}`
+}
+
+/**
+ * Quick sanity check on a downloaded xmltv.php body. Providers without EPG
+ * typically answer 404, an HTML error page or an empty/minimal document —
+ * none of those contain <programme> entries.
+ */
+export function looksLikeXmltv(text: string): boolean {
+    if (!text) return false
+    const head = text.slice(0, 2000).toLowerCase()
+    if (head.includes('<html') || head.includes('<!doctype html')) return false
+    return text.toLowerCase().includes('<programme')
+}
+
+/**
+ * Parse the XMLTV time format "20260612153000 +0000" (offset optional,
+ * seconds optional) into epoch milliseconds. Returns null when malformed.
+ */
+export function parseXmltvTime(value: string): number | null {
+    const match = /^(\d{12,14})(?:\s*([+-]\d{4}))?$/.exec(value.trim())
+    if (!match) return null
+
+    const digits = match[1].padEnd(14, '0')
+    const year = parseInt(digits.substring(0, 4), 10)
+    const month = parseInt(digits.substring(4, 6), 10) - 1
+    const day = parseInt(digits.substring(6, 8), 10)
+    const hour = parseInt(digits.substring(8, 10), 10)
+    const minute = parseInt(digits.substring(10, 12), 10)
+    const second = parseInt(digits.substring(12, 14), 10)
+
+    if (month < 0 || month > 11 || day < 1 || day > 31 || hour > 23 || minute > 59 || second > 59) {
+        return null
+    }
+
+    let offsetMs = 0
+    if (match[2]) {
+        const sign = match[2].startsWith('-') ? -1 : 1
+        const offsetHours = parseInt(match[2].substring(1, 3), 10)
+        const offsetMinutes = parseInt(match[2].substring(3, 5), 10)
+        offsetMs = sign * (offsetHours * 60 + offsetMinutes) * 60 * 1000
+    }
+
+    return Date.UTC(year, month, day, hour, minute, second) - offsetMs
+}
+
+/** Strip a CDATA wrapper (if any) and decode the common XML entities. */
+export function decodeXmlText(text: string): string {
+    let value = text.trim()
+    const cdata = /^<!\[CDATA\[([\s\S]*?)\]\]>$/.exec(value)
+    if (cdata) value = cdata[1]
+
+    return value
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, code: string) => String.fromCodePoint(parseInt(code, 16)))
+        .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(parseInt(code, 10)))
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&amp;/g, '&')
+        .trim()
+}
+
+export interface XmltvWindow {
+    /** Drop programs that ended before this instant. */
+    minEndMs: number
+    /** Drop programs that start after this instant. */
+    maxStartMs: number
+}
+
+export function buildDefaultWindow(nowMs: number): XmltvWindow {
+    return {
+        minEndMs: nowMs - PROVIDER_EPG_PAST_WINDOW_MS,
+        maxStartMs: nowMs + PROVIDER_EPG_FUTURE_WINDOW_MS,
+    }
+}
+
+const PROGRAMME_RE = /<programme\b([^>]*)>([\s\S]*?)<\/programme>/gi
+const ATTR_RE: Record<string, RegExp> = {
+    start: /start="([^"]+)"/i,
+    stop: /stop="([^"]+)"/i,
+    channel: /channel="([^"]+)"/i,
+}
+const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i
+const DESC_RE = /<desc[^>]*>([\s\S]*?)<\/desc>/i
+
+/**
+ * Single-pass scan of an XMLTV document into a per-channel program index.
+ * Regex/string scanning on purpose (same approach as the renderer's Open-EPG
+ * parser) — a DOM parse of a multi-megabyte dump would be far more expensive.
+ */
+export function parseXmltvIndex(xml: string, nowMs: number = Date.now()): Map<string, ProviderEpgProgram[]> {
+    const index = new Map<string, ProviderEpgProgram[]>()
+    const window = buildDefaultWindow(nowMs)
+
+    PROGRAMME_RE.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = PROGRAMME_RE.exec(xml)) !== null) {
+        const attrs = match[1]
+        const body = match[2]
+
+        const channelMatch = ATTR_RE.channel.exec(attrs)
+        const startMatch = ATTR_RE.start.exec(attrs)
+        const stopMatch = ATTR_RE.stop.exec(attrs)
+        if (!channelMatch || !startMatch || !stopMatch) continue
+
+        const startMs = parseXmltvTime(decodeXmlText(startMatch[1]))
+        const endMs = parseXmltvTime(decodeXmlText(stopMatch[1]))
+        if (startMs === null || endMs === null) continue
+        if (endMs < window.minEndMs || startMs > window.maxStartMs) continue
+
+        const channelId = decodeXmlText(channelMatch[1])
+        if (!channelId) continue
+
+        const titleMatch = TITLE_RE.exec(body)
+        const descMatch = DESC_RE.exec(body)
+        const title = titleMatch ? decodeXmlText(titleMatch[1]) : ''
+
+        const program: ProviderEpgProgram = {
+            id: `provider-${channelId}-${startMs}`,
+            start: new Date(startMs).toISOString(),
+            end: new Date(endMs).toISOString(),
+            title: title || 'Sem título',
+            description: descMatch ? decodeXmlText(descMatch[1]) : '',
+            channel_id: channelId,
+        }
+
+        const list = index.get(channelId)
+        if (list) list.push(program)
+        else index.set(channelId, [program])
+    }
+
+    for (const programs of index.values()) {
+        programs.sort((a, b) => a.start.localeCompare(b.start))
+    }
+
+    return index
+}
+
+/** Decode a base64 string as UTF-8 text (Xtream get_simple_data_table fields). */
+export function decodeBase64Utf8(value: string): string {
+    try {
+        const nodeBuffer = (globalThis as {
+            Buffer?: { from(data: string, encoding: string): { toString(encoding: string): string } }
+        }).Buffer
+        if (nodeBuffer) {
+            return nodeBuffer.from(value, 'base64').toString('utf-8')
+        }
+        const binary = atob(value)
+        const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
+        return new TextDecoder().decode(bytes)
+    } catch {
+        return value
+    }
+}
+
+interface SimpleDataTableListing {
+    title?: string
+    description?: string
+    start?: string
+    end?: string
+    stop?: string
+    start_timestamp?: string | number
+    stop_timestamp?: string | number
+}
+
+function parseListingTime(timestamp: string | number | undefined, fallback: string | undefined): number | null {
+    const numeric = Number(timestamp)
+    if (Number.isFinite(numeric) && numeric > 0) return numeric * 1000
+
+    if (fallback) {
+        // "2026-06-12 15:30:00" — treated as local time, same as Date.parse
+        const parsed = Date.parse(fallback.replace(' ', 'T'))
+        if (!Number.isNaN(parsed)) return parsed
+    }
+
+    return null
+}
+
+/**
+ * Parse the get_simple_data_table JSON payload (per-channel EPG) into the
+ * common program shape, applying the same retention window as the XMLTV path.
+ */
+export function parseSimpleDataTable(payload: unknown, channelId: string, nowMs: number = Date.now()): ProviderEpgProgram[] {
+    const listings = (payload as { epg_listings?: unknown })?.epg_listings
+    if (!Array.isArray(listings)) return []
+
+    const window = buildDefaultWindow(nowMs)
+    const programs: ProviderEpgProgram[] = []
+
+    for (const raw of listings) {
+        if (!raw || typeof raw !== 'object') continue
+        const listing = raw as SimpleDataTableListing
+
+        const startMs = parseListingTime(listing.start_timestamp, listing.start)
+        const endMs = parseListingTime(listing.stop_timestamp, listing.end ?? listing.stop)
+        if (startMs === null || endMs === null) continue
+        if (endMs < window.minEndMs || startMs > window.maxStartMs) continue
+
+        const title = listing.title ? decodeBase64Utf8(listing.title).trim() : ''
+        const description = listing.description ? decodeBase64Utf8(listing.description).trim() : ''
+
+        programs.push({
+            id: `provider-sdt-${channelId}-${startMs}`,
+            start: new Date(startMs).toISOString(),
+            end: new Date(endMs).toISOString(),
+            title: title || 'Sem título',
+            description,
+            channel_id: channelId,
+        })
+    }
+
+    programs.sort((a, b) => a.start.localeCompare(b.start))
+    return programs
+}

--- a/src/pages/EpgGuide.tsx
+++ b/src/pages/EpgGuide.tsx
@@ -89,7 +89,7 @@ function loadChannelEpg(channel: LiveStream): Promise<EPGProgram[]> {
         pending = (async () => {
             await acquireEpgSlot();
             try {
-                const programs = await epgService.fetchChannelEPG(channel.epg_channel_id || '', channel.name);
+                const programs = await epgService.fetchChannelEPG(channel.epg_channel_id || '', channel.name, channel.stream_id);
                 epgCache.set(key, programs);
                 return programs;
             } catch {

--- a/src/pages/LiveTV.tsx
+++ b/src/pages/LiveTV.tsx
@@ -185,7 +185,7 @@ export function LiveTV() {
             try {
                 console.log('[EPG] Fetching EPG for channel:', selectedChannel.name, 'EPG ID:', selectedChannel.epg_channel_id);
                 // Pass both EPG ID and channel name (for Open-EPG Portugal and meuguia.tv fallback)
-                const programs = await epgService.fetchChannelEPG(selectedChannel.epg_channel_id || '', selectedChannel.name);
+                const programs = await epgService.fetchChannelEPG(selectedChannel.epg_channel_id || '', selectedChannel.name, selectedChannel.stream_id);
                 console.log('[EPG] Got programs:', programs.length);
                 setEpgData(programs);
 

--- a/src/services/epgService.ts
+++ b/src/services/epgService.ts
@@ -81,7 +81,18 @@ const openEpgBrazilMappings: Record<string, string> = openEpgBrazilMappingsJson;
 export const epgService = {
 
     // Main function to fetch EPG for a channel
-    async fetchChannelEPG(_epgChannelId: string, channelName?: string): Promise<EPGProgram[]> {
+    async fetchChannelEPG(epgChannelId: string, channelName?: string, streamId?: number): Promise<EPGProgram[]> {
+        // PRIMARY: the Xtream provider's own EPG (xmltv.php parsed once in the
+        // main process; get_simple_data_table as secondary). Falls back to the
+        // existing chain when the provider has nothing for this channel.
+        // Providers sometimes ship stale dumps (e.g. ending hours ago), so the
+        // provider only wins when it has at least one current/future program.
+        const providerPrograms = await this.fetchFromProvider(epgChannelId, streamId);
+        const now = Date.now();
+        if (providerPrograms.some(p => new Date(p.end).getTime() > now)) {
+            return providerPrograms;
+        }
+
         if (!channelName) return [];
 
         // Check if this is a Portuguese channel (has mapping in Open-EPG Portugal)
@@ -124,6 +135,29 @@ export const epgService = {
         }
 
         return [];
+    },
+
+    // Fetch from the Xtream provider's own EPG via the main process
+    // ('epg:provider-channel' answers from an in-memory index, so this is
+    // effectively instant when the provider has an EPG)
+    async fetchFromProvider(epgChannelId: string, streamId?: number): Promise<EPGProgram[]> {
+        try {
+            if (!epgChannelId && streamId === undefined) return [];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ipcRenderer = (window as any).ipcRenderer;
+            if (!ipcRenderer?.invoke) return [];
+
+            const result = await ipcRenderer.invoke('epg:provider-channel', {
+                channelId: epgChannelId || '',
+                streamId
+            });
+            if (!result?.success || !Array.isArray(result.programs)) return [];
+
+            return result.programs as EPGProgram[];
+        } catch (error) {
+            console.error('[EPG] Provider EPG error:', error);
+            return [];
+        }
     },
 
     // Get Open-EPG Portugal ID from channel name


### PR DESCRIPTION
## 📅 EPG do provedor

O guia e o painel de canais agora usam a programação **do próprio provedor Xtream** (`xmltv.php`) como fonte primária — no provedor real: 240 canais / 11.627 programas indexados em 54ms, com 1 download a cada 24h.

### Como funciona
- Baixado e parseado **uma vez** no main process → índice em memória → consultas por canal instantâneas (nada de XML de vários MB pelo IPC)
- Janela de memória limitada (agora-24h até +48h)
- Probe único por sessão: provedor sem xmltv → marcado indisponível, sem tempestade de retries (re-testa ao trocar de login)
- `get_simple_data_table` como secundária por canal

### Regra do fallback (pega real encontrada no teste ao vivo)
O dump do provedor tinha dados do Globo **terminando horas no passado** — se "ter dados" bastasse, mascararia o fallback que tem a programação atual. Então: **o provedor só ganha se tiver ao menos um programa atual/futuro**; senão a cadeia existente (Open-EPG → mi.tv → meuguia) roda intocada. Exatamente o combinado: "se não tiver EPG do provedor, usa o que já tem".

### Verificação
- tsc / eslint / vitest **118/118** (23 novos) / vite build ✅
- Ao vivo: guia preenchido com programação atual ("Bom Dia Praça/MG/DF" 04:00–06:30), linha AGORA correta ✅