### PR TITLE
feat: recomendações personalizadas na Home (Porque você assistiu X)

### DIFF
--- a/src/locales/ui/en.json
+++ b/src/locales/ui/en.json
@@ -524,6 +524,7 @@
     "goodEvening": "Good evening",
     "continueWatching": "Continue Watching",
     "nextEpisodes": "Next Episodes",
+    "becauseYouWatched": "Because you watched {name}",
     "recommendations": "Recommended For You",
     "recentSeries": "Recent Series",
     "recentMovies": "Recent Movies",

--- a/src/locales/ui/es.json
+++ b/src/locales/ui/es.json
@@ -524,6 +524,7 @@
     "goodEvening": "Buenas noches",
     "continueWatching": "Seguir Viendo",
     "nextEpisodes": "Próximos Episodios",
+    "becauseYouWatched": "Porque viste {name}",
     "recommendations": "Recomendados Para Ti",
     "recentSeries": "Series Recientes",
     "recentMovies": "Películas Recientes",

--- a/src/locales/ui/pt.json
+++ b/src/locales/ui/pt.json
@@ -524,6 +524,7 @@
     "goodEvening": "Boa noite",
     "continueWatching": "Continue Assistindo",
     "nextEpisodes": "Próximos Episódios",
+    "becauseYouWatched": "Porque você assistiu {name}",
     "recommendations": "Recomendados Para Você",
     "recentSeries": "Séries Recentes",
     "recentMovies": "Filmes Recentes",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import { ResumeModal } from '../components/ResumeModal';
 import { profileService } from '../services/profileService';
 import { indexedDBCache } from '../services/indexedDBCache';
 import { searchMovieByName, searchSeriesByName, isKidsFriendly } from '../services/tmdb';
+import { getHomeRecommendations, type RecommendationGroup } from '../services/recommendationService';
 import { useLanguage } from '../services/languageService';
 
 interface ContentCounts {
@@ -73,7 +74,7 @@ export function Home() {
     const [recentMovies, setRecentMovies] = useState<MovieData[]>([]);
     const [allSeries, setAllSeries] = useState<SeriesData[]>([]);
     const [allMovies, setAllMovies] = useState<MovieData[]>([]);
-    const [recommendations, setRecommendations] = useState<(SeriesData | MovieData)[]>([]);
+    const [recommendationGroups, setRecommendationGroups] = useState<RecommendationGroup[]>([]);
     const [isVisible, setIsVisible] = useState(false);
     const [refreshTrigger, setRefreshTrigger] = useState(0);
 
@@ -324,66 +325,26 @@ export function Home() {
         setContinueWatching(items.slice(0, 30));
     }, [allSeries, allMovies, refreshTrigger]);
 
-    // Build recommendations based on watched categories (only once when data is ready)
+    // Build personalized recommendations ("Porque você assistiu X") from local
+    // watch history + genre/category/franchise scoring (recommendationService).
     useEffect(() => {
-        if (continueWatching.length === 0 || (allSeries.length === 0 && allMovies.length === 0)) return;
+        if (allSeries.length === 0 && allMovies.length === 0) return;
 
         // Only run once when we have data
-        if (recommendations.length > 0) return;
+        if (recommendationGroups.length > 0) return;
 
-        // Get categories from what user is watching
-        const watchedCategoryIds = new Set<string>();
-        const watchedIds = new Set<string>();
+        let cancelled = false;
+        getHomeRecommendations(allMovies, allSeries)
+            .then(groups => {
+                if (!cancelled && groups.length > 0) setRecommendationGroups(groups);
+            })
+            .catch(error => console.error('Failed to build recommendations:', error));
 
-        continueWatching.forEach(item => {
-            watchedIds.add(item.id);
-            if (item.type === 'series') {
-                const series = allSeries.find(s => s.series_id.toString() === item.id);
-                if (series?.category_id) watchedCategoryIds.add(series.category_id);
-            } else {
-                const movie = allMovies.find(m => m.stream_id.toString() === item.id);
-                if (movie?.category_id) watchedCategoryIds.add(movie.category_id);
-            }
-        });
-
-        // Find recommendations from same categories (not already watched/in progress)
-        const recs: (SeriesData | MovieData)[] = [];
-
-        // Add series from watched categories
-        allSeries.forEach(series => {
-            if (series.category_id &&
-                watchedCategoryIds.has(series.category_id) &&
-                !watchedIds.has(series.series_id.toString())) {
-                recs.push(series);
-            }
-        });
-
-        // Add movies from watched categories
-        allMovies.forEach(movie => {
-            if (movie.category_id &&
-                watchedCategoryIds.has(movie.category_id) &&
-                !watchedIds.has(movie.stream_id.toString())) {
-                recs.push(movie);
-            }
-        });
-
-        // Stable shuffle using Fisher-Yates with seed
-        const seed = continueWatching.length + allSeries.length;
-        let currentIndex = recs.length;
-        let randomIndex;
-        const seededRandom = (max: number) => Math.floor((seed * 9301 + 49297) % 233280 / 233280 * max);
-
-        while (currentIndex > 0) {
-            randomIndex = seededRandom(currentIndex);
-            currentIndex--;
-            [recs[currentIndex], recs[randomIndex]] = [recs[randomIndex], recs[currentIndex]];
-        }
-
-        setRecommendations(recs.slice(0, 30));
+        return () => { cancelled = true; };
     // This intentionally depends on list sizes only to avoid rebuilding recommendations
     // every time array identities change during the Home page refresh cycle.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [continueWatching.length, allSeries.length, allMovies.length]);
+    }, [allSeries.length, allMovies.length]);
 
     const formatTime = (date: Date) => {
         return date.toLocaleTimeString(t('home', 'locale'), { hour: '2-digit', minute: '2-digit' });
@@ -402,6 +363,12 @@ export function Home() {
         if (hour < 12) return t('home', 'goodMorning');
         if (hour < 18) return t('home', 'goodAfternoon');
         return t('home', 'goodEvening');
+    };
+
+    // Row title: "Porque você assistiu {seed}" (seed truncated to keep rows tidy)
+    const becauseYouWatchedTitle = (seedName: string) => {
+        const truncated = seedName.length > 28 ? `${seedName.slice(0, 27).trimEnd()}…` : seedName;
+        return t('home', 'becauseYouWatched').replace('{name}', truncated);
     };
 
     const formatProgress = (currentTime: number, duration: number) => {
@@ -1432,13 +1399,16 @@ export function Home() {
                 {/* Next Episodes Section */}
                 <NextEpisodes allSeries={allSeries} />
 
-                {/* Recommendations Section */}
-                < ContentSection
-                    title={`💡 ${t('home', 'recommendations')}`}
-                    items={recommendations}
-                    type="recommendations"
-                    sectionIndex={1}
-                />
+                {/* Personalized Recommendations ("Porque você assistiu X") */}
+                {recommendationGroups.map((group, index) => (
+                    <ContentSection
+                        key={`rec-${group.seedName}`}
+                        title={`💡 ${becauseYouWatchedTitle(group.seedName)}`}
+                        items={group.items.map(rec => rec.item)}
+                        type="recommendations"
+                        sectionIndex={1 + index}
+                    />
+                ))}
 
                 {/* Recently Added Series */}
                 < ContentSection

--- a/src/services/recommendationService.test.ts
+++ b/src/services/recommendationService.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest';
+import {
+    normalizeTitle,
+    sharesFranchisePrefix,
+    splitGenres,
+    genreOverlapCount,
+    seedWeight,
+    scoreCandidate,
+    bandedShuffle,
+    buildRecommendations,
+    groupBySeed,
+    type RecSeed,
+    type Recommendation,
+    type RecMovie,
+    type RecSeries
+} from './recommendationService';
+
+const seed = (overrides: Partial<RecSeed> & { name: string }): RecSeed => ({
+    kind: 'vod',
+    recencyRank: 0,
+    genres: [],
+    ...overrides
+});
+
+const movie = (overrides: Partial<RecMovie> & { stream_id: number; name: string }): RecMovie => ({
+    stream_icon: 'icon.png',
+    ...overrides
+});
+
+const series = (overrides: Partial<RecSeries> & { series_id: number; name: string }): RecSeries => ({
+    cover: 'cover.png',
+    ...overrides
+});
+
+describe('normalizeTitle', () => {
+    it('lowercases, strips accents and punctuation', () => {
+        expect(normalizeTitle('Ação & Reação!')).toBe('acao reacao');
+    });
+
+    it('strips year, bracket tags and quality markers', () => {
+        expect(normalizeTitle('Matrix (1999) [4K] Dublado')).toBe('matrix');
+        expect(normalizeTitle('Homem-Aranha: Sem Volta Para Casa HD')).toBe('homem aranha sem volta para casa');
+    });
+});
+
+describe('sharesFranchisePrefix', () => {
+    it('matches multi-word franchise prefixes', () => {
+        expect(sharesFranchisePrefix('Homem-Aranha', 'Homem-Aranha: Sem Volta Para Casa')).toBe(true);
+        expect(sharesFranchisePrefix('John Wick', 'John Wick 4: Baba Yaga')).toBe(true);
+    });
+
+    it('matches single-word franchises only when one title is exactly that word', () => {
+        expect(sharesFranchisePrefix('Matrix', 'Matrix Reloaded')).toBe(true);
+        // Conservative: a single shared word between two multi-word titles is
+        // not enough ("American Pie" vs "American Sniper").
+        expect(sharesFranchisePrefix('Matrix Reloaded', 'Matrix Revolutions')).toBe(false);
+    });
+
+    it('does not match unrelated titles or generic articles', () => {
+        expect(sharesFranchisePrefix('O Poderoso Chefão', 'O Senhor dos Anéis')).toBe(false);
+        expect(sharesFranchisePrefix('Lost', 'Lucifer')).toBe(false);
+    });
+});
+
+describe('splitGenres / genreOverlapCount', () => {
+    it('splits provider genre strings on common separators', () => {
+        expect(splitGenres('Ação / Aventura, Sci-Fi & Fantasia')).toEqual(['acao', 'aventura', 'sci-fi', 'fantasia']);
+        expect(splitGenres(undefined)).toEqual([]);
+    });
+
+    it('counts overlap with fuzzy containment matching', () => {
+        expect(genreOverlapCount(['acao', 'aventura'], ['Ação e Aventura'])).toBe(2);
+        expect(genreOverlapCount(['comedia'], ['Drama', 'Comédia'])).toBe(1);
+        expect(genreOverlapCount(['terror'], ['Romance'])).toBe(0);
+    });
+});
+
+describe('scoreCandidate', () => {
+    const seeds: RecSeed[] = [
+        seed({ name: 'Vingadores', recencyRank: 0, genres: ['Ação', 'Aventura'], categoryId: '10' }),
+        seed({ name: 'Friends', kind: 'series', recencyRank: 1, genres: ['Comédia'] })
+    ];
+
+    it('scores genre overlap higher than no overlap', () => {
+        const action = scoreCandidate({ name: 'Thor', genre: 'Ação, Aventura' }, seeds);
+        const romance = scoreCandidate({ name: 'Diário de uma Paixão', genre: 'Romance' }, seeds);
+        expect(action).not.toBeNull();
+        expect(romance).toBeNull();
+        expect(action!.becauseOf).toBe('Vingadores');
+    });
+
+    it('weights recent seeds higher than older ones', () => {
+        const recentMatch = scoreCandidate({ name: 'Thor', genre: 'Ação' }, seeds)!;
+        const olderMatch = scoreCandidate({ name: 'Seinfeld', genre: 'Comédia' }, seeds)!;
+        expect(recentMatch.score).toBeGreaterThan(olderMatch.score);
+        expect(olderMatch.becauseOf).toBe('Friends');
+        expect(seedWeight(0)).toBeGreaterThan(seedWeight(1));
+    });
+
+    it('boosts franchise title prefixes even without genre data', () => {
+        const franchise = scoreCandidate({ name: 'Vingadores: Ultimato' }, seeds);
+        expect(franchise).not.toBeNull();
+        expect(franchise!.becauseOf).toBe('Vingadores');
+    });
+
+    it('boosts same provider category as a fallback signal', () => {
+        const sameCategory = scoreCandidate({ name: 'Homem de Ferro', category_id: '10' }, seeds);
+        expect(sameCategory).not.toBeNull();
+        expect(sameCategory!.becauseOf).toBe('Vingadores');
+    });
+
+    it('returns null when nothing matches', () => {
+        expect(scoreCandidate({ name: 'Documentário Aleatório' }, seeds)).toBeNull();
+        expect(scoreCandidate({ name: 'Qualquer' }, [])).toBeNull();
+    });
+});
+
+describe('bandedShuffle', () => {
+    it('keeps higher score bands ahead of lower ones', () => {
+        const items = [
+            { id: 'low', score: 1 },
+            { id: 'high-a', score: 5 },
+            { id: 'high-b', score: 5.1 },
+            { id: 'mid', score: 3 }
+        ];
+        const result = bandedShuffle(items, () => 0.99);
+        expect(result.map(i => i.id).indexOf('low')).toBe(3);
+        expect(result.map(i => i.id).indexOf('mid')).toBe(2);
+        // both high items (same 5.0 band after rounding) stay in the first band
+        expect(result.slice(0, 2).map(i => i.id).sort()).toEqual(['high-a', 'high-b']);
+    });
+
+    it('varies order within a band depending on rng (diversity)', () => {
+        const items = [
+            { id: 'a', score: 5 },
+            { id: 'b', score: 5 },
+            { id: 'c', score: 5 }
+        ];
+        const orderA = bandedShuffle(items, () => 0).map(i => i.id);
+        const orderB = bandedShuffle(items, () => 0.99).map(i => i.id);
+        expect(orderA).not.toEqual(orderB);
+        expect([...orderA].sort()).toEqual(['a', 'b', 'c']);
+    });
+});
+
+describe('buildRecommendations', () => {
+    const seeds: RecSeed[] = [
+        seed({ name: 'Vingadores', recencyRank: 0, genres: ['Ação'], categoryId: '10' })
+    ];
+
+    const movies: RecMovie[] = [
+        movie({ stream_id: 1, name: 'Vingadores', genre: 'Ação' }),            // is the seed itself
+        movie({ stream_id: 2, name: 'Thor', genre: 'Ação' }),
+        movie({ stream_id: 3, name: 'Homem de Ferro', category_id: '10' }),
+        movie({ stream_id: 4, name: 'Romance Total', genre: 'Romance' }),       // no signal
+        movie({ stream_id: 5, name: 'Filme Já Visto', genre: 'Ação' })          // excluded by id
+    ];
+
+    const seriesList: RecSeries[] = [
+        series({ series_id: 7, name: 'Vingadores Unidos', genre: 'Animação' }), // franchise prefix
+        series({ series_id: 8, name: 'Série Assistida', genre: 'Ação' })        // excluded by title
+    ];
+
+    const run = () => buildRecommendations({
+        seeds,
+        movies,
+        series: seriesList,
+        excludeTitles: new Set([normalizeTitle('Série Assistida')]),
+        excludeMovieIds: new Set(['5']),
+        excludeSeriesIds: new Set(),
+        rng: () => 0.5
+    });
+
+    it('excludes seeds, watched ids and watched titles', () => {
+        const names = run().map(r => r.item.name);
+        expect(names).not.toContain('Vingadores');
+        expect(names).not.toContain('Filme Já Visto');
+        expect(names).not.toContain('Série Assistida');
+        expect(names).not.toContain('Romance Total');
+    });
+
+    it('includes scored matches from both kinds with becauseOf set', () => {
+        const recs = run();
+        const names = recs.map(r => r.item.name);
+        expect(names).toContain('Thor');
+        expect(names).toContain('Homem de Ferro');
+        expect(names).toContain('Vingadores Unidos');
+        expect(recs.every(r => r.becauseOf === 'Vingadores')).toBe(true);
+        expect(recs.find(r => r.item.name === 'Vingadores Unidos')!.kind).toBe('series');
+    });
+
+    it('caps results at maxItems', () => {
+        const manyMovies = Array.from({ length: 50 }, (_, i) =>
+            movie({ stream_id: 100 + i, name: `Ação ${i}`, genre: 'Ação' }));
+        const recs = buildRecommendations({
+            seeds,
+            movies: manyMovies,
+            series: [],
+            excludeTitles: new Set(),
+            excludeMovieIds: new Set(),
+            excludeSeriesIds: new Set(),
+            maxItems: 20,
+            rng: () => 0.5
+        });
+        expect(recs.length).toBe(20);
+    });
+
+    it('returns empty for empty seeds', () => {
+        expect(buildRecommendations({
+            seeds: [],
+            movies,
+            series: seriesList,
+            excludeTitles: new Set(),
+            excludeMovieIds: new Set(),
+            excludeSeriesIds: new Set()
+        })).toEqual([]);
+    });
+});
+
+describe('groupBySeed', () => {
+    const rec = (name: string, becauseOf: string, score = 1): Recommendation => ({
+        kind: 'vod',
+        item: movie({ stream_id: name.length, name }),
+        becauseOf,
+        score
+    });
+
+    it('groups by dominant seed, largest groups first, max 2 groups', () => {
+        const recs = [
+            rec('a1', 'Seed A'), rec('a2', 'Seed A'), rec('a3', 'Seed A'),
+            rec('b1', 'Seed B'), rec('b2', 'Seed B'), rec('b3', 'Seed B'), rec('b4', 'Seed B'),
+            rec('c1', 'Seed C'), rec('c2', 'Seed C'), rec('c3', 'Seed C')
+        ];
+        const groups = groupBySeed(recs, 2, 3);
+        expect(groups.length).toBe(2);
+        expect(groups[0].seedName).toBe('Seed B');
+        expect(groups[0].items.length).toBe(4);
+    });
+
+    it('drops groups below the minimum size', () => {
+        const recs = [rec('a1', 'Seed A'), rec('b1', 'Seed B'), rec('b2', 'Seed B'), rec('b3', 'Seed B')];
+        const groups = groupBySeed(recs, 2, 3);
+        expect(groups.length).toBe(1);
+        expect(groups[0].seedName).toBe('Seed B');
+    });
+
+    it('preserves the incoming item order within a group', () => {
+        const recs = [rec('b1', 'Seed B'), rec('b2', 'Seed B'), rec('b3', 'Seed B')];
+        const groups = groupBySeed(recs, 2, 3);
+        expect(groups[0].items.map(r => r.item.name)).toEqual(['b1', 'b2', 'b3']);
+    });
+});

--- a/src/services/recommendationService.ts
+++ b/src/services/recommendationService.ts
@@ -1,0 +1,423 @@
+/**
+ * Personalized Home recommendations — "Porque você assistiu X".
+ *
+ * Local-first and cheap:
+ * - Seeds come from the local watch history (movies + series, most recent first).
+ * - Seed genres are resolved from the local IndexedDB TMDB cache; at most 3
+ *   TMDB searches are made for the most recent seeds without cached genres
+ *   (results are cached fire-and-forget for next time).
+ * - Candidates are scored with pure functions (genre overlap weighted by seed
+ *   recency, provider category match, franchise title-prefix boost) so the
+ *   core logic is unit-testable without any network.
+ */
+
+import { movieProgressService } from './movieProgressService';
+import { watchProgressService } from './watchProgressService';
+import { indexedDBCache } from './indexedDBCache';
+import { searchMovieByName, searchSeriesByName } from './tmdb';
+
+// ==================== Types ====================
+
+export interface RecMovie {
+    stream_id: number;
+    name: string;
+    stream_icon: string;
+    cover?: string;
+    rating?: string;
+    category_id?: string;
+    genre?: string; // provider metadata, sometimes present
+    added?: number;
+}
+
+export interface RecSeries {
+    series_id: number;
+    name: string;
+    cover: string;
+    rating?: string;
+    category_id?: string;
+    genre?: string; // provider metadata, sometimes present
+    added?: number;
+}
+
+export interface RecSeed {
+    kind: 'vod' | 'series';
+    name: string;
+    /** 0 = most recently watched */
+    recencyRank: number;
+    genres: string[];
+    categoryId?: string;
+}
+
+export interface Recommendation {
+    kind: 'vod' | 'series';
+    item: RecMovie | RecSeries;
+    becauseOf: string; // seed name that contributed the most score
+    score: number;
+}
+
+export interface RecommendationGroup {
+    seedName: string;
+    items: Recommendation[];
+}
+
+// ==================== Pure helpers (unit-tested) ====================
+
+/** Lowercase, strip accents/tags/quality markers, collapse whitespace. */
+export function normalizeTitle(name: string): string {
+    return name
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .replace(/\s*\[.*?\]\s*/g, ' ')
+        .replace(/\s*\(\d{4}\)\s*/g, ' ')
+        .replace(/\b(4k|uhd|fhd|hd|sd|h265|h264|dual|dublado|legendado|leg|dub)\b/g, ' ')
+        .replace(/[^a-z0-9\s]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+const GENERIC_TOKENS = new Set([
+    'o', 'a', 'os', 'as', 'um', 'uma', 'de', 'do', 'da', 'dos', 'das', 'e',
+    'the', 'an', 'of', 'el', 'la', 'los', 'las', 'y', 'and'
+]);
+
+function titleTokens(name: string): string[] {
+    return normalizeTitle(name).split(' ').filter(tk => tk.length > 0 && !GENERIC_TOKENS.has(tk));
+}
+
+/**
+ * True when two titles look like the same franchise via a shared leading
+ * prefix — e.g. "Homem-Aranha" / "Homem-Aranha: Sem Volta Para Casa", or
+ * "Matrix" / "Matrix Reloaded".
+ */
+export function sharesFranchisePrefix(a: string, b: string): boolean {
+    const ta = titleTokens(a);
+    const tb = titleTokens(b);
+    if (ta.length === 0 || tb.length === 0) return false;
+
+    let shared = 0;
+    const min = Math.min(ta.length, tb.length);
+    while (shared < min && ta[shared] === tb[shared]) shared++;
+
+    if (shared >= 2) return true;
+    // Single-word franchises ("Matrix") only count when one title IS that word
+    // and it is distinctive enough.
+    return shared === 1 && (ta.length === 1 || tb.length === 1) && ta[0].length >= 4;
+}
+
+function normalizeGenre(genre: string): string {
+    return genre
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .trim();
+}
+
+/** Split a provider genre string ("Ação / Aventura, Sci-Fi") into tokens. */
+export function splitGenres(genre: string | undefined | null): string[] {
+    if (!genre) return [];
+    return genre
+        .split(/[,;|/&]/)
+        .map(normalizeGenre)
+        .filter(g => g.length > 1);
+}
+
+function genresMatch(a: string, b: string): boolean {
+    if (a === b) return true;
+    // "acao e aventura" should match "acao"
+    return (a.length >= 4 && b.includes(a)) || (b.length >= 4 && a.includes(b));
+}
+
+export function genreOverlapCount(candidateGenres: string[], seedGenres: string[]): number {
+    if (candidateGenres.length === 0 || seedGenres.length === 0) return 0;
+    const normalizedSeeds = seedGenres.map(normalizeGenre);
+    let count = 0;
+    for (const cg of candidateGenres) {
+        if (normalizedSeeds.some(sg => genresMatch(cg, sg))) count++;
+    }
+    return count;
+}
+
+/** Recency weight: most recent seed counts the most. */
+export function seedWeight(recencyRank: number): number {
+    return 1 / (1 + 0.35 * recencyRank);
+}
+
+export interface ScoredCandidate {
+    score: number;
+    becauseOf: string;
+}
+
+/**
+ * Score one candidate against all seeds.
+ * score = Σ per-seed [ 2*genreOverlap + 1*categoryMatch + 2.5*franchise ] * weight(recency)
+ */
+export function scoreCandidate(
+    candidate: { name: string; category_id?: string; genre?: string },
+    seeds: RecSeed[]
+): ScoredCandidate | null {
+    const candidateGenres = splitGenres(candidate.genre);
+    let total = 0;
+    let best = 0;
+    let becauseOf = '';
+
+    for (const seed of seeds) {
+        const w = seedWeight(seed.recencyRank);
+        let contribution = 0;
+
+        contribution += 2 * genreOverlapCount(candidateGenres, seed.genres) * w;
+        if (seed.categoryId && candidate.category_id && seed.categoryId === candidate.category_id) {
+            contribution += 1 * w;
+        }
+        if (sharesFranchisePrefix(candidate.name, seed.name)) {
+            contribution += 2.5 * w;
+        }
+
+        total += contribution;
+        if (contribution > best) {
+            best = contribution;
+            becauseOf = seed.name;
+        }
+    }
+
+    if (total <= 0 || !becauseOf) return null;
+    return { score: total, becauseOf };
+}
+
+/**
+ * Light shuffle inside score bands so the row varies between visits without
+ * letting weak matches jump ahead of strong ones. Bands are score rounded to
+ * the nearest 0.5. `rng` is injectable for deterministic tests.
+ */
+export function bandedShuffle<T extends { score: number }>(items: T[], rng: () => number = Math.random): T[] {
+    const bands = new Map<number, T[]>();
+    const order: number[] = [];
+    const sorted = [...items].sort((a, b) => b.score - a.score);
+
+    for (const item of sorted) {
+        const band = Math.round(item.score * 2) / 2;
+        if (!bands.has(band)) {
+            bands.set(band, []);
+            order.push(band);
+        }
+        bands.get(band)!.push(item);
+    }
+
+    const result: T[] = [];
+    for (const band of order) {
+        const group = bands.get(band)!;
+        // Fisher-Yates within the band
+        for (let i = group.length - 1; i > 0; i--) {
+            const j = Math.floor(rng() * (i + 1));
+            [group[i], group[j]] = [group[j], group[i]];
+        }
+        result.push(...group);
+    }
+    return result;
+}
+
+export interface BuildInput {
+    seeds: RecSeed[];
+    movies: RecMovie[];
+    series: RecSeries[];
+    /** normalized titles already watched / in history (excluded) */
+    excludeTitles: Set<string>;
+    /** raw ids already watched (movie stream_ids / series_ids as strings) */
+    excludeMovieIds: Set<string>;
+    excludeSeriesIds: Set<string>;
+    maxItems?: number;
+    rng?: () => number;
+}
+
+/** Score all candidates, exclude watched, return top N lightly shuffled. */
+export function buildRecommendations(input: BuildInput): Recommendation[] {
+    const {
+        seeds, movies, series, excludeTitles,
+        excludeMovieIds, excludeSeriesIds,
+        maxItems = 20, rng = Math.random
+    } = input;
+
+    if (seeds.length === 0) return [];
+
+    const seedTitles = new Set(seeds.map(s => normalizeTitle(s.name)));
+    const scored: Recommendation[] = [];
+
+    const consider = (kind: 'vod' | 'series', item: RecMovie | RecSeries, id: string, excludedIds: Set<string>) => {
+        if (excludedIds.has(id)) return;
+        const normalized = normalizeTitle(item.name);
+        if (normalized.length === 0 || excludeTitles.has(normalized) || seedTitles.has(normalized)) return;
+        const result = scoreCandidate(item, seeds);
+        if (result) {
+            scored.push({ kind, item, becauseOf: result.becauseOf, score: result.score });
+        }
+    };
+
+    for (const movie of movies) consider('vod', movie, String(movie.stream_id), excludeMovieIds);
+    for (const s of series) consider('series', s, String(s.series_id), excludeSeriesIds);
+
+    // Keep a generous pool, shuffle within bands, then cut to maxItems.
+    const pool = scored.sort((a, b) => b.score - a.score).slice(0, maxItems * 3);
+    return bandedShuffle(pool, rng).slice(0, maxItems);
+}
+
+/**
+ * Group recommendations by their dominant seed for row titles.
+ * Returns up to `maxGroups` groups (largest first), each preserving the
+ * incoming (band-shuffled) item order. Groups with fewer than `minGroupSize`
+ * items are dropped.
+ */
+export function groupBySeed(
+    recommendations: Recommendation[],
+    maxGroups: number = 2,
+    minGroupSize: number = 3
+): RecommendationGroup[] {
+    const bySeed = new Map<string, Recommendation[]>();
+    for (const rec of recommendations) {
+        if (!bySeed.has(rec.becauseOf)) bySeed.set(rec.becauseOf, []);
+        bySeed.get(rec.becauseOf)!.push(rec);
+    }
+
+    return [...bySeed.entries()]
+        .filter(([, items]) => items.length >= minGroupSize)
+        .sort((a, b) => b[1].length - a[1].length)
+        .slice(0, maxGroups)
+        .map(([seedName, items]) => ({ seedName, items }));
+}
+
+// ==================== History → seeds (local reads) ====================
+
+interface RawSeed {
+    kind: 'vod' | 'series';
+    name: string;
+    watchedAt: number;
+    categoryId?: string;
+}
+
+const MAX_SEEDS = 10;
+const MAX_TMDB_LOOKUPS = 3;
+
+function collectRawSeeds(movies: RecMovie[], series: RecSeries[]): {
+    seeds: RawSeed[];
+    watchedTitles: Set<string>;
+    watchedMovieIds: Set<string>;
+    watchedSeriesIds: Set<string>;
+} {
+    const watchedTitles = new Set<string>();
+    const watchedMovieIds = new Set<string>();
+    const watchedSeriesIds = new Set<string>();
+    const raw: RawSeed[] = [];
+
+    const movieById = new Map(movies.map(m => [String(m.stream_id), m]));
+    const seriesById = new Map(series.map(s => [String(s.series_id), s]));
+
+    for (const entry of movieProgressService.getHistory()) {
+        watchedMovieIds.add(entry.movieId);
+        const item = movieById.get(entry.movieId);
+        const name = item?.name || entry.movieName;
+        if (!name) continue;
+        watchedTitles.add(normalizeTitle(name));
+        raw.push({ kind: 'vod', name, watchedAt: entry.watchedAt, categoryId: item?.category_id });
+    }
+
+    // Episode history: keep the most recent timestamp per series.
+    const latestBySeries = new Map<string, number>();
+    for (const ep of watchProgressService.getEpisodeHistory()) {
+        const prev = latestBySeries.get(ep.seriesId) || 0;
+        if (ep.watchedAt > prev) latestBySeries.set(ep.seriesId, ep.watchedAt);
+    }
+    latestBySeries.forEach((watchedAt, seriesId) => {
+        watchedSeriesIds.add(seriesId);
+        const item = seriesById.get(seriesId);
+        if (!item) return;
+        watchedTitles.add(normalizeTitle(item.name));
+        raw.push({ kind: 'series', name: item.name, watchedAt, categoryId: item.category_id });
+    });
+
+    // Most recent first, dedupe by normalized title, cap.
+    raw.sort((a, b) => b.watchedAt - a.watchedAt);
+    const seen = new Set<string>();
+    const seeds: RawSeed[] = [];
+    for (const seed of raw) {
+        const key = normalizeTitle(seed.name);
+        if (key.length === 0 || seen.has(key)) continue;
+        seen.add(key);
+        seeds.push(seed);
+        if (seeds.length >= MAX_SEEDS) break;
+    }
+
+    return { seeds, watchedTitles, watchedMovieIds, watchedSeriesIds };
+}
+
+async function resolveSeedGenres(rawSeeds: RawSeed[]): Promise<RecSeed[]> {
+    // 1) Local IndexedDB cache (populated by the parental/kids TMDB checks).
+    const seeds: RecSeed[] = await Promise.all(rawSeeds.map(async (raw, index) => {
+        const cached = raw.kind === 'vod'
+            ? await indexedDBCache.getCachedMovie(raw.name)
+            : await indexedDBCache.getCachedSeries(raw.name);
+        return {
+            kind: raw.kind,
+            name: raw.name,
+            recencyRank: index,
+            genres: cached?.genres?.filter(g => !!g) || [],
+            categoryId: raw.categoryId
+        };
+    }));
+
+    // 2) Up to 3 TMDB lookups for the most recent seeds with no cached genres.
+    let lookups = 0;
+    for (const seed of seeds) {
+        if (seed.genres.length > 0) continue;
+        if (lookups >= MAX_TMDB_LOOKUPS) break;
+        lookups++;
+        try {
+            const result = seed.kind === 'vod'
+                ? await searchMovieByName(seed.name)
+                : await searchSeriesByName(seed.name);
+            if (result?.genres?.length) {
+                seed.genres = result.genres.map(g => g.name);
+                // Fire-and-forget cache so next visit is free.
+                const cacheCall = seed.kind === 'vod'
+                    ? indexedDBCache.setCacheMovie(seed.name, result.certification ?? null, seed.genres)
+                    : indexedDBCache.setCacheSeries(seed.name, result.certification ?? null, seed.genres);
+                void cacheCall.catch(() => { /* best effort */ });
+            }
+        } catch {
+            // Network failure is fine — category/franchise signals still work.
+        }
+    }
+
+    return seeds;
+}
+
+// ==================== Public entry point ====================
+
+/**
+ * Compute up to 2 "Porque você assistiu {seed}" groups for the Home page.
+ * Returns [] when there is no history or nothing matches.
+ */
+export async function getHomeRecommendations(
+    movies: RecMovie[],
+    series: RecSeries[]
+): Promise<RecommendationGroup[]> {
+    const { seeds: rawSeeds, watchedTitles, watchedMovieIds, watchedSeriesIds } =
+        collectRawSeeds(movies, series);
+
+    if (rawSeeds.length === 0) return [];
+
+    const seeds = await resolveSeedGenres(rawSeeds);
+
+    const recommendations = buildRecommendations({
+        seeds,
+        movies,
+        series,
+        excludeTitles: watchedTitles,
+        excludeMovieIds: watchedMovieIds,
+        excludeSeriesIds: watchedSeriesIds,
+        maxItems: 40 // generous pool so each group can still show up to 20
+    });
+
+    return groupBySeed(recommendations, 2, 3).map(group => ({
+        seedName: group.seedName,
+        items: group.items.slice(0, 20)
+    }));
+}


### PR DESCRIPTION
## 💡 Recomendações de verdade na Home

A linha "Recomendados Para Você" tinha lógica só por categoria (e um shuffle quebrado que sempre embaralhava igual). Agora é um recomendador real:

### Como funciona
- **Sementes**: seus últimos 10 títulos assistidos (filmes + episódios)
- **Sinais**: sobreposição de gêneros (cache TMDB local; máx. 3 buscas pra sementes recentes sem cache) + mesma categoria + **mesma franquia** (prefixo do título: "Homem-Aranha...", "Matrix...")
- Peso por recência (o que você assistiu ontem vale mais que semana passada), excluindo o que já foi visto
- Até **2 linhas** "💡 Porque você assistiu {título}", com leve variação a cada visita
- Sem histórico → sem linha (zero ruído pra usuário novo)

### Verificação
tsc / eslint / vitest **166/166** (19 novos) / vite build / Playwright **11/11** ✅
Ao vivo: "Porque você assistiu Busca Sem Limites (2016)" com 20 itens na Home real ✅