### PR TITLE
feat: temas fase 2 (telas restantes) + guia fase 2 (paginação e busca)

### DIFF
--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -608,7 +608,7 @@ const globalSearchStyles = `
     align-items: center;
     gap: 8px;
     padding: 10px 12px 6px;
-    color: rgba(196, 181, 253, 0.8);
+    color: var(--ns-accent-light);
     font-size: 12px;
     font-weight: 700;
     text-transform: uppercase;

--- a/src/components/PostUpdateChangelog.tsx
+++ b/src/components/PostUpdateChangelog.tsx
@@ -134,7 +134,7 @@ const changelogStyles = `
     max-width: 480px;
     max-height: 80vh;
     overflow-y: auto;
-    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%);
     border: 1px solid rgba(16, 185, 129, 0.3);
     border-radius: 24px;
     padding: 24px;

--- a/src/locales/ui/en.json
+++ b/src/locales/ui/en.json
@@ -650,7 +650,12 @@
     "loadingEpg": "Loading...",
     "noEpg": "No program data",
     "noChannels": "No channels in this category",
-    "now": "Now"
+    "now": "Now",
+    "searchPlaceholder": "Search loaded programming...",
+    "searchNoResults": "Nothing found in loaded programming",
+    "today": "Today / Now",
+    "earlier": "Earlier",
+    "later": "Later"
   },
   "search": {
     "placeholder": "Search channels, movies and series...",

--- a/src/locales/ui/es.json
+++ b/src/locales/ui/es.json
@@ -650,7 +650,12 @@
     "loadingEpg": "Cargando...",
     "noEpg": "Sin programación",
     "noChannels": "No hay canales en esta categoría",
-    "now": "Ahora"
+    "now": "Ahora",
+    "searchPlaceholder": "Buscar en la programación cargada...",
+    "searchNoResults": "Nada encontrado en la programación cargada",
+    "today": "Hoy / Ahora",
+    "earlier": "Más temprano",
+    "later": "Más tarde"
   },
   "search": {
     "placeholder": "Buscar canales, películas y series...",

--- a/src/locales/ui/pt.json
+++ b/src/locales/ui/pt.json
@@ -650,7 +650,12 @@
     "loadingEpg": "Carregando...",
     "noEpg": "Sem programação",
     "noChannels": "Nenhum canal nesta categoria",
-    "now": "Agora"
+    "now": "Agora",
+    "searchPlaceholder": "Buscar na programação carregada...",
+    "searchNoResults": "Nada encontrado na programação carregada",
+    "today": "Hoje / Agora",
+    "earlier": "Mais cedo",
+    "later": "Mais tarde"
   },
   "search": {
     "placeholder": "Buscar canais, filmes e séries...",

--- a/src/pages/Downloads.tsx
+++ b/src/pages/Downloads.tsx
@@ -439,13 +439,13 @@ export function Downloads() {
                         width: '90%',
                         maxWidth: 800,
                         maxHeight: '85vh',
-                        background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)',
+                        background: 'linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%)',
                         borderRadius: 20,
                         overflow: 'hidden',
                         display: 'flex',
                         zIndex: 1001,
                         boxShadow: '0 25px 80px rgba(0, 0, 0, 0.6)',
-                        border: '1px solid rgba(168, 85, 247, 0.3)'
+                        border: '1px solid rgba(var(--ns-accent-rgb), 0.3)'
                     }}>
                         {/* Poster */}
                         <div style={{ width: 260, minWidth: 260, position: 'relative' }}>
@@ -474,7 +474,7 @@ export function Downloads() {
                             <h2 style={{ color: 'white', fontSize: 24, marginBottom: 8 }}>{seriesModal.series.seriesName}</h2>
 
                             <div style={{ display: 'flex', gap: 8, marginBottom: 16, flexWrap: 'wrap' }}>
-                                {seriesModal.series.year && <span style={{ background: 'rgba(168,85,247,0.3)', padding: '4px 10px', borderRadius: 6, color: '#c4b5fd', fontSize: 12 }}>{seriesModal.series.year}</span>}
+                                {seriesModal.series.year && <span style={{ background: 'rgba(var(--ns-accent-rgb),0.3)', padding: '4px 10px', borderRadius: 6, color: 'var(--ns-accent-light)', fontSize: 12 }}>{seriesModal.series.year}</span>}
                                 {seriesModal.series.rating && <span style={{ background: 'rgba(251,191,36,0.3)', padding: '4px 10px', borderRadius: 6, color: '#fcd34d', fontSize: 12 }}>⭐ {seriesModal.series.rating}</span>}
                                 <span style={{ background: 'rgba(16,185,129,0.3)', padding: '4px 10px', borderRadius: 6, color: '#6ee7b7', fontSize: 12 }}>{seriesModal.series.seasons.length} {seriesModal.series.seasons.length > 1 ? t('downloads', 'seasons') : t('downloads', 'season')}</span>
                                 <span style={{ background: 'rgba(59,130,246,0.3)', padding: '4px 10px', borderRadius: 6, color: '#93c5fd', fontSize: 12 }}>📥 {t('downloads', 'offline')}</span>
@@ -562,9 +562,9 @@ export function Downloads() {
                                                     borderRadius: 10,
                                                     cursor: 'pointer',
                                                     background: isSelected
-                                                        ? 'linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.15))'
+                                                        ? 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.15))'
                                                         : 'transparent',
-                                                    border: isSelected ? '1px solid rgba(168, 85, 247, 0.4)' : '1px solid transparent',
+                                                    border: isSelected ? '1px solid rgba(var(--ns-accent-rgb), 0.4)' : '1px solid transparent',
                                                     opacity: isCompleted ? 1 : 0.7,
                                                     transition: 'all 0.2s'
                                                 }}
@@ -734,7 +734,7 @@ export function Downloads() {
                         width: '90%',
                         maxWidth: 700,
                         maxHeight: '85vh',
-                        background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)',
+                        background: 'linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%)',
                         borderRadius: 20,
                         overflow: 'hidden',
                         display: 'flex',
@@ -769,7 +769,7 @@ export function Downloads() {
                             <h2 style={{ color: 'white', fontSize: 24, marginBottom: 8 }}>{movieModal.movie.name}</h2>
 
                             <div style={{ display: 'flex', gap: 8, marginBottom: 16, flexWrap: 'wrap' }}>
-                                {movieModal.movie.year && <span style={{ background: 'rgba(168,85,247,0.3)', padding: '4px 10px', borderRadius: 6, color: '#c4b5fd', fontSize: 12 }}>{movieModal.movie.year}</span>}
+                                {movieModal.movie.year && <span style={{ background: 'rgba(var(--ns-accent-rgb),0.3)', padding: '4px 10px', borderRadius: 6, color: 'var(--ns-accent-light)', fontSize: 12 }}>{movieModal.movie.year}</span>}
                                 {movieModal.movie.rating && <span style={{ background: 'rgba(251,191,36,0.3)', padding: '4px 10px', borderRadius: 6, color: '#fcd34d', fontSize: 12 }}>⭐ {movieModal.movie.rating}</span>}
                                 <span style={{
                                     background: movieModal.movie.status === 'completed' ? 'rgba(16,185,129,0.3)' : 'rgba(245,158,11,0.3)',
@@ -884,7 +884,7 @@ const downloadsStyles = `
     min-height: 100vh;
     padding: 32px;
     overflow-x: hidden;
-    background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%);
 }
 
 .downloads-backdrop {
@@ -892,7 +892,7 @@ const downloadsStyles = `
     inset: 0;
     background: 
         radial-gradient(ellipse at 30% 30%, rgba(6, 182, 212, 0.1) 0%, transparent 50%),
-        radial-gradient(ellipse at 70% 70%, rgba(168, 85, 247, 0.08) 0%, transparent 50%);
+        radial-gradient(ellipse at 70% 70%, rgba(var(--ns-accent-rgb), 0.08) 0%, transparent 50%);
     pointer-events: none;
     z-index: 0;
 }
@@ -1192,7 +1192,7 @@ const downloadsStyles = `
     position: relative;
     aspect-ratio: 2 / 3;
     overflow: hidden;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
 }
 
 .card-poster img {
@@ -1436,7 +1436,7 @@ const downloadsStyles = `
     transform: translate(-50%, -50%);
     width: 90%;
     max-width: 420px;
-    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%);
     border: 1px solid rgba(239, 68, 68, 0.3);
     border-radius: 20px;
     padding: 32px;

--- a/src/pages/EpgGuide.tsx
+++ b/src/pages/EpgGuide.tsx
@@ -12,9 +12,15 @@ import {
     nowOffsetPx,
     isAiringNow,
     formatGuideTime,
+    shiftWindow,
+    clampWindow,
+    searchPrograms,
+    HALF_HOUR_MS,
     PX_PER_HALF_HOUR,
-    WINDOW_HALF_HOURS
+    WINDOW_HALF_HOURS,
+    WINDOW_SHIFT_MS
 } from '../utils/epgGuide';
+import type { ProgramSearchResult } from '../utils/epgGuide';
 
 interface LiveStream {
     num: number;
@@ -119,9 +125,15 @@ export function EpgGuide() {
     const isKidsProfile = profileService.getActiveProfile()?.isKids || false;
     const { t } = useLanguage();
 
-    // Fixed window for the page's lifetime; the "now" line moves within it.
-    const guideWindow = useMemo(() => getGuideWindow(), []);
+    // Pageable window (◀/▶ shift it by 2h; "Hoje/Agora" resets to default).
+    const [guideWindow, setGuideWindow] = useState(() => getGuideWindow());
     const ticks = useMemo(() => buildTimeTicks(guideWindow), [guideWindow]);
+
+    // Program search over the already-loaded EPG data
+    const [searchQuery, setSearchQuery] = useState('');
+    const [pendingScrollChannel, setPendingScrollChannel] = useState<string | null>(null);
+    const [highlightedChannel, setHighlightedChannel] = useState<string | null>(null);
+    const rowRefs = useRef(new Map<string, HTMLDivElement>());
 
     // "Now" line updates every minute
     useEffect(() => {
@@ -230,6 +242,58 @@ export function EpgGuide() {
         }
     }, [categoryStreams.length]);
 
+    // Time paging: shift the visible window in 2h steps, clamped to the data range
+    const pageWindow = useCallback((direction: 1 | -1) => {
+        setGuideWindow(w => shiftWindow(w, direction * WINDOW_SHIFT_MS));
+    }, []);
+    const resetWindow = useCallback(() => {
+        setGuideWindow(getGuideWindow());
+    }, []);
+
+    // Search over everything already fetched (module cache + this page's state)
+    const searchResults = useMemo<ProgramSearchResult[]>(() => {
+        if (!searchQuery.trim()) return [];
+        const merged = new Map<string, EPGProgram[]>(epgCache);
+        for (const [name, programs] of Object.entries(epgByChannel)) {
+            if (programs) merged.set(name, programs);
+        }
+        return searchPrograms(merged, searchQuery);
+    }, [searchQuery, epgByChannel]);
+
+    const goToSearchResult = useCallback((result: ProgramSearchResult) => {
+        setSearchQuery('');
+        const channel = streams.find(s => s.name === result.channelKey);
+        if (!channel) return;
+        // Page the window so the program's start is visible
+        setGuideWindow(w => {
+            if (result.startMs >= w.start && result.startMs < w.end) return w;
+            const span = w.end - w.start;
+            const start = Math.floor(result.startMs / HALF_HOUR_MS) * HALF_HOUR_MS - HALF_HOUR_MS;
+            return clampWindow({ start, end: start + span });
+        });
+        // Switch category if needed; the effect below scrolls once the row exists
+        if (channel.category_id !== selectedCategory) setSelectedCategory(channel.category_id);
+        setPendingScrollChannel(channel.name);
+    }, [streams, selectedCategory]);
+
+    // Scroll to (and briefly highlight) the searched channel's row once rendered
+    useEffect(() => {
+        if (!pendingScrollChannel) return;
+        const index = categoryStreams.findIndex(s => s.name === pendingScrollChannel);
+        if (index === -1) return;
+        if (index >= visibleRows) {
+            setVisibleRows(index + 1);
+            return;
+        }
+        const row = rowRefs.current.get(pendingScrollChannel);
+        if (!row) return;
+        row.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        setHighlightedChannel(pendingScrollChannel);
+        setPendingScrollChannel(null);
+        const timer = setTimeout(() => setHighlightedChannel(null), 2200);
+        return () => clearTimeout(timer);
+    }, [pendingScrollChannel, categoryStreams, visibleRows]);
+
     const buildLiveStreamUrl = async (channel: LiveStream): Promise<string> => {
         const result = await window.ipcRenderer.invoke('auth:get-credentials');
         if (result.success) {
@@ -284,6 +348,13 @@ export function EpgGuide() {
                 }
                 .guide-program:hover { filter: brightness(1.25); }
                 .guide-channel-cell:hover { background: rgba(var(--ns-accent-rgb), 0.12) !important; }
+                .guide-pager-btn:hover { background: rgba(var(--ns-accent-rgb), 0.25) !important; }
+                .guide-search-result:hover { background: rgba(var(--ns-accent-rgb), 0.18) !important; }
+                .guide-row-highlight { animation: guideRowFlash 2.2s ease; }
+                @keyframes guideRowFlash {
+                    0%, 55% { background: rgba(var(--ns-accent-rgb), 0.22); }
+                    100% { background: transparent; }
+                }
             `}</style>
 
             {/* Header: title + category selector */}
@@ -294,7 +365,7 @@ export function EpgGuide() {
             }}>
                 <h1 style={{
                     fontSize: '24px', fontWeight: 800, margin: 0,
-                    background: 'linear-gradient(135deg, #ffffff 0%, #c4b5fd 100%)',
+                    background: 'linear-gradient(135deg, #ffffff 0%, var(--ns-accent-light) 100%)',
                     WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent'
                 }}>
                     {t('guide', 'title')}
@@ -322,6 +393,102 @@ export function EpgGuide() {
                         </option>
                     ))}
                 </select>
+
+                {/* Time paging: ◀ Hoje/Agora ▶ */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    <button
+                        className="guide-pager-btn"
+                        onClick={() => pageWindow(-1)}
+                        aria-label={t('guide', 'earlier')}
+                        title={t('guide', 'earlier')}
+                        style={pagerButtonStyle}
+                    >
+                        ◀
+                    </button>
+                    <button
+                        className="guide-pager-btn"
+                        onClick={resetWindow}
+                        title={t('guide', 'today')}
+                        style={{ ...pagerButtonStyle, width: 'auto', padding: '0 12px', fontSize: '12px', fontWeight: 600 }}
+                    >
+                        {t('guide', 'today')}
+                    </button>
+                    <button
+                        className="guide-pager-btn"
+                        onClick={() => pageWindow(1)}
+                        aria-label={t('guide', 'later')}
+                        title={t('guide', 'later')}
+                        style={pagerButtonStyle}
+                    >
+                        ▶
+                    </button>
+                </div>
+
+                {/* Program search across the loaded EPG data */}
+                <div style={{ position: 'relative', flex: '0 1 300px', minWidth: '210px' }}>
+                    <input
+                        type="text"
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        placeholder={t('guide', 'searchPlaceholder')}
+                        aria-label={t('guide', 'searchPlaceholder')}
+                        style={{
+                            width: '100%',
+                            boxSizing: 'border-box',
+                            background: 'rgba(31, 41, 55, 0.9)',
+                            color: 'white',
+                            border: '1px solid rgba(var(--ns-accent-rgb), 0.4)',
+                            borderRadius: '10px',
+                            padding: '8px 14px',
+                            fontSize: '13px',
+                            outline: 'none'
+                        }}
+                    />
+                    {searchQuery.trim() !== '' && (
+                        <div
+                            className="guide-scroll"
+                            style={{
+                                position: 'absolute', top: 'calc(100% + 6px)', left: 0, right: 0,
+                                zIndex: 60, maxHeight: '320px', overflowY: 'auto',
+                                background: 'var(--ns-bg-panel)',
+                                border: '1px solid rgba(var(--ns-accent-rgb), 0.35)',
+                                borderRadius: '10px',
+                                boxShadow: '0 12px 32px rgba(0, 0, 0, 0.5)'
+                            }}
+                        >
+                            {searchResults.length === 0 ? (
+                                <div style={{ padding: '12px 14px', fontSize: '12px', fontStyle: 'italic', color: 'rgba(148, 163, 184, 0.9)' }}>
+                                    {t('guide', 'searchNoResults')}
+                                </div>
+                            ) : (
+                                searchResults.map(result => (
+                                    <button
+                                        key={result.channelKey + result.start + result.title}
+                                        className="guide-search-result"
+                                        onClick={() => goToSearchResult(result)}
+                                        style={{
+                                            display: 'block', width: '100%', textAlign: 'left',
+                                            background: 'transparent', border: 'none', cursor: 'pointer',
+                                            padding: '8px 14px',
+                                            borderBottom: '1px solid rgba(255, 255, 255, 0.05)'
+                                        }}
+                                    >
+                                        <div style={{
+                                            fontSize: '13px', fontWeight: 600, color: 'rgba(229, 231, 235, 1)',
+                                            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+                                        }}>
+                                            {result.title}
+                                        </div>
+                                        <div style={{ fontSize: '11px', color: 'var(--ns-accent-light)' }}>
+                                            {result.channelKey} · {formatGuideDayTime(result.startMs)}
+                                        </div>
+                                    </button>
+                                ))
+                            )}
+                        </div>
+                    )}
+                </div>
+
                 <span style={{ fontSize: '13px', color: 'rgba(148, 163, 184, 0.9)' }}>
                     {categoryStreams.length} {t('guide', 'channels')}
                 </span>
@@ -362,7 +529,7 @@ export function EpgGuide() {
                                 background: 'linear-gradient(180deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%)',
                                 borderRight: '1px solid rgba(255, 255, 255, 0.08)',
                                 fontSize: '11px', fontWeight: 700, letterSpacing: '1px',
-                                textTransform: 'uppercase', color: 'rgba(196, 181, 253, 0.9)'
+                                textTransform: 'uppercase', color: 'var(--ns-accent-light)'
                             }}>
                                 {t('guide', 'channelsHeader')}
                             </div>
@@ -403,10 +570,18 @@ export function EpgGuide() {
                             {renderedStreams.map(channel => {
                                 const programs = epgByChannel[channel.name];
                                 return (
-                                    <div key={channel.stream_id} style={{
-                                        display: 'flex', height: ROW_HEIGHT,
-                                        borderBottom: '1px solid rgba(255, 255, 255, 0.05)'
-                                    }}>
+                                    <div
+                                        key={channel.stream_id}
+                                        className={highlightedChannel === channel.name ? 'guide-row-highlight' : undefined}
+                                        ref={el => {
+                                            if (el) rowRefs.current.set(channel.name, el);
+                                            else rowRefs.current.delete(channel.name);
+                                        }}
+                                        style={{
+                                            display: 'flex', height: ROW_HEIGHT,
+                                            borderBottom: '1px solid rgba(255, 255, 255, 0.05)'
+                                        }}
+                                    >
                                         {/* Sticky channel cell */}
                                         <div
                                             className="guide-channel-cell"
@@ -536,6 +711,15 @@ export function EpgGuide() {
     );
 }
 
+/** "HH:MM" plus "dd/MM" when the timestamp falls on another day. */
+function formatGuideDayTime(ms: number): string {
+    const time = formatGuideTime(ms);
+    const date = new Date(ms);
+    const today = new Date();
+    if (date.toDateString() === today.toDateString()) return time;
+    return `${date.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })} ${time}`;
+}
+
 function ChannelLetterFallback({ name }: { name: string }) {
     // Skip country/quality prefixes when picking the letter (e.g. "BR: Globo" → G)
     const cleaned = name.replace(/^[a-z]{2,3}\s*[:|]\s*/i, '').trim();
@@ -565,6 +749,21 @@ const backdropStyle: React.CSSProperties = {
     inset: 0,
     background: 'linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%)',
     zIndex: 0
+};
+
+const pagerButtonStyle: React.CSSProperties = {
+    width: '34px',
+    height: '34px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'rgba(var(--ns-accent-rgb), 0.12)',
+    color: 'var(--ns-accent-light)',
+    border: '1px solid rgba(var(--ns-accent-rgb), 0.4)',
+    borderRadius: '10px',
+    fontSize: '11px',
+    cursor: 'pointer',
+    transition: 'background 0.2s ease'
 };
 
 const rowPlaceholderStyle: React.CSSProperties = {

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -400,7 +400,7 @@ const favoritesStyles = `
 .favorites-backdrop {
     position: fixed;
     inset: 0;
-    background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%);
     z-index: 0;
 }
 

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -349,7 +349,7 @@ const historyStyles = `
     font-weight: 800;
     color: white;
     letter-spacing: -0.02em;
-    background: linear-gradient(135deg, #fff 0%, #c4b5fd 100%);
+    background: linear-gradient(135deg, #fff 0%, var(--ns-accent-light) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -373,7 +373,7 @@ const historyStyles = `
 .history-day-label {
     font-size: 18px;
     font-weight: 700;
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
     margin: 0 0 14px 0;
     text-transform: capitalize;
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -356,7 +356,7 @@ const loginStyles = `
 .login-orb-2 {
     width: 400px;
     height: 400px;
-    background: radial-gradient(circle, #a855f7 0%, transparent 70%);
+    background: radial-gradient(circle, var(--ns-accent) 0%, transparent 70%);
     bottom: -100px;
     left: -100px;
     animation-delay: -7s;
@@ -410,7 +410,7 @@ const loginStyles = `
 .login-logo-bg {
     width: 80px;
     height: 80px;
-    background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+    background: linear-gradient(135deg, var(--ns-accent-dark) 0%, var(--ns-accent) 100%);
     border-radius: 24px;
     display: flex;
     align-items: center;
@@ -439,10 +439,10 @@ const loginStyles = `
     gap: 6px;
     margin-top: 10px;
     padding: 5px 12px;
-    background: rgba(168, 85, 247, 0.15);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.15);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     border-radius: 16px;
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
     font-size: 11px;
     font-weight: 600;
     letter-spacing: 0.1em;
@@ -546,7 +546,7 @@ const loginStyles = `
 }
 
 .login-checkbox input:checked + .login-checkbox-mark {
-    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+    background: linear-gradient(135deg, var(--ns-accent-dark) 0%, var(--ns-accent) 100%);
     border-color: transparent;
 }
 
@@ -579,7 +579,7 @@ const loginStyles = `
 }
 
 .login-btn-primary {
-    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+    background: linear-gradient(135deg, var(--ns-accent-dark) 0%, var(--ns-accent) 100%);
     color: white;
     box-shadow: 0 8px 32px rgba(99, 102, 241, 0.3);
 }
@@ -677,7 +677,7 @@ const loginStyles = `
 }
 
 .login-stat-blue { background: rgba(59, 130, 246, 0.1); border: 1px solid rgba(59, 130, 246, 0.2); }
-.login-stat-purple { background: rgba(168, 85, 247, 0.1); border: 1px solid rgba(168, 85, 247, 0.2); }
+.login-stat-purple { background: rgba(var(--ns-accent-rgb), 0.1); border: 1px solid rgba(var(--ns-accent-rgb), 0.2); }
 .login-stat-green { background: rgba(34, 197, 94, 0.1); border: 1px solid rgba(34, 197, 94, 0.2); }
 
 .login-stat-icon {
@@ -691,7 +691,7 @@ const loginStyles = `
 }
 
 .login-stat-blue .login-stat-icon { background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%); }
-.login-stat-purple .login-stat-icon { background: linear-gradient(135deg, #a855f7 0%, #9333ea 100%); }
+.login-stat-purple .login-stat-icon { background: linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-dark) 100%); }
 .login-stat-green .login-stat-icon { background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%); }
 
 .login-stat-value {

--- a/src/pages/WatchLater.tsx
+++ b/src/pages/WatchLater.tsx
@@ -426,7 +426,7 @@ const watchLaterStyles = `
     min-height: 100vh;
     padding: 32px;
     overflow-x: hidden;
-    background: linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%);
+    background: linear-gradient(135deg, var(--ns-bg-deep) 0%, var(--ns-bg-panel) 50%, var(--ns-bg-tint) 100%);
 }
 
 /* Animated Backdrop */
@@ -434,7 +434,7 @@ const watchLaterStyles = `
     position: fixed;
     inset: 0;
     background: 
-        radial-gradient(ellipse at 20% 20%, rgba(168, 85, 247, 0.15) 0%, transparent 50%),
+        radial-gradient(ellipse at 20% 20%, rgba(var(--ns-accent-rgb), 0.15) 0%, transparent 50%),
         radial-gradient(ellipse at 80% 80%, rgba(236, 72, 153, 0.1) 0%, transparent 50%),
         radial-gradient(ellipse at 50% 50%, rgba(59, 130, 246, 0.05) 0%, transparent 70%);
     pointer-events: none;
@@ -491,7 +491,7 @@ const watchLaterStyles = `
     font-weight: 800;
     color: white;
     letter-spacing: -0.02em;
-    background: linear-gradient(135deg, #fff 0%, #c4b5fd 100%);
+    background: linear-gradient(135deg, #fff 0%, var(--ns-accent-light) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -564,9 +564,9 @@ const watchLaterStyles = `
 }
 
 .tab.active {
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.2) 0%, rgba(236, 72, 153, 0.2) 100%);
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.2) 100%);
     color: white;
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
 }
 
 .tab-icon {
@@ -582,7 +582,7 @@ const watchLaterStyles = `
 }
 
 .tab.active .tab-count {
-    background: rgba(168, 85, 247, 0.4);
+    background: rgba(var(--ns-accent-rgb), 0.4);
 }
 
 /* Content Scroll */
@@ -637,10 +637,10 @@ const watchLaterStyles = `
 
 .item-card:hover {
     transform: translateY(-10px) scale(1.02);
-    border-color: rgba(168, 85, 247, 0.5);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
     box-shadow: 
         0 25px 50px rgba(0, 0, 0, 0.4),
-        0 0 50px rgba(168, 85, 247, 0.15);
+        0 0 50px rgba(var(--ns-accent-rgb), 0.15);
 }
 
 .item-card.removing {
@@ -716,7 +716,7 @@ const watchLaterStyles = `
     position: relative;
     aspect-ratio: 2 / 3;
     overflow: hidden;
-    background: linear-gradient(135deg, #1a1a2e 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, var(--ns-bg-panel) 0%, var(--ns-bg-deep) 100%);
 }
 
 .card-poster img {
@@ -736,7 +736,7 @@ const watchLaterStyles = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, #1e1e3f 0%, #0f0f1a 100%);
+    background: linear-gradient(135deg, #1e1e3f 0%, var(--ns-bg-deep) 100%);
     font-size: 56px;
 }
 
@@ -764,7 +764,7 @@ const watchLaterStyles = `
 .play-icon {
     width: 70px;
     height: 70px;
-    background: linear-gradient(135deg, #a855f7 0%, #ec4899 100%);
+    background: linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-grad-to) 100%);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -773,7 +773,7 @@ const watchLaterStyles = `
     color: white;
     transform: scale(0);
     transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
-    box-shadow: 0 8px 30px rgba(168, 85, 247, 0.5);
+    box-shadow: 0 8px 30px rgba(var(--ns-accent-rgb), 0.5);
 }
 
 .item-card:hover .play-icon {
@@ -792,7 +792,7 @@ const watchLaterStyles = `
 
 .card-progress-bar {
     height: 100%;
-    background: linear-gradient(90deg, #a855f7, #ec4899);
+    background: linear-gradient(90deg, var(--ns-accent), var(--ns-accent-grad-to));
     transition: width 0.3s ease;
 }
 
@@ -853,7 +853,7 @@ const watchLaterStyles = `
 }
 
 .item-card:hover .card-title {
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
 }
 
 .card-type {
@@ -912,7 +912,7 @@ const watchLaterStyles = `
     transform: translateX(-50%);
     width: 80px;
     height: 20px;
-    background: radial-gradient(ellipse, rgba(168, 85, 247, 0.4) 0%, transparent 70%);
+    background: radial-gradient(ellipse, rgba(var(--ns-accent-rgb), 0.4) 0%, transparent 70%);
     border-radius: 50%;
     animation: glowPulse 3s ease-in-out infinite;
 }
@@ -938,7 +938,7 @@ const watchLaterStyles = `
 }
 
 .empty-text strong {
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
 }
 
 .empty-suggestions {
@@ -951,8 +951,8 @@ const watchLaterStyles = `
     align-items: center;
     gap: 10px;
     padding: 16px 28px;
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.15) 0%, rgba(236, 72, 153, 0.15) 100%);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.15) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.15) 100%);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     color: white;
     font-size: 15px;
     font-weight: 600;
@@ -962,10 +962,10 @@ const watchLaterStyles = `
 }
 
 .suggestion-btn:hover {
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.25) 0%, rgba(236, 72, 153, 0.25) 100%);
-    border-color: rgba(168, 85, 247, 0.5);
+    background: linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.25) 0%, rgba(var(--ns-accent-grad-to-rgb), 0.25) 100%);
+    border-color: rgba(var(--ns-accent-rgb), 0.5);
     transform: translateY(-3px);
-    box-shadow: 0 10px 30px rgba(168, 85, 247, 0.2);
+    box-shadow: 0 10px 30px rgba(var(--ns-accent-rgb), 0.2);
 }
 
 .suggestion-btn span:first-child {

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -167,7 +167,7 @@ const welcomeStyles = `
 .welcome-orb-2 {
     width: 400px;
     height: 400px;
-    background: radial-gradient(circle, #a855f7 0%, transparent 70%);
+    background: radial-gradient(circle, var(--ns-accent) 0%, transparent 70%);
     bottom: -100px;
     right: -100px;
     animation-delay: -7s;
@@ -220,7 +220,7 @@ const welcomeStyles = `
 .welcome-logo-bg {
     width: 100px;
     height: 100px;
-    background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+    background: linear-gradient(135deg, var(--ns-accent-dark) 0%, var(--ns-accent) 100%);
     border-radius: 28px;
     display: flex;
     align-items: center;
@@ -257,10 +257,10 @@ const welcomeStyles = `
     gap: 6px;
     margin-top: 12px;
     padding: 6px 14px;
-    background: rgba(168, 85, 247, 0.15);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+    background: rgba(var(--ns-accent-rgb), 0.15);
+    border: 1px solid rgba(var(--ns-accent-rgb), 0.3);
     border-radius: 20px;
-    color: #c4b5fd;
+    color: var(--ns-accent-light);
     font-size: 12px;
     font-weight: 600;
     letter-spacing: 0.1em;
@@ -304,7 +304,7 @@ const welcomeStyles = `
 }
 
 .welcome-card-primary {
-    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+    background: linear-gradient(135deg, var(--ns-accent-dark) 0%, var(--ns-accent) 100%);
     box-shadow: 0 8px 32px rgba(99, 102, 241, 0.3);
 }
 
@@ -393,7 +393,7 @@ const welcomeStyles = `
     left: 0;
     width: 340px;
     height: 100vh;
-    background: linear-gradient(180deg, #1a1a2e 0%, #16213e 100%);
+    background: linear-gradient(180deg, var(--ns-bg-panel) 0%, var(--ns-bg-tint) 100%);
     border-right: 1px solid rgba(255,255,255,0.1);
     z-index: 101;
     transform: translateX(-100%);

--- a/src/pages/settings/AboutSection.tsx
+++ b/src/pages/settings/AboutSection.tsx
@@ -24,8 +24,8 @@ export function AboutSection() {
                         <svg width="80" height="80" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                             <defs>
                                 <linearGradient id="logoGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-                                    <stop offset="0%" stopColor="#a855f7" />
-                                    <stop offset="100%" stopColor="#ec4899" />
+                                    <stop offset="0%" style={{ stopColor: 'var(--ns-accent)' }} />
+                                    <stop offset="100%" style={{ stopColor: 'var(--ns-accent-grad-to)' }} />
                                 </linearGradient>
                             </defs>
                             <path d="M 10,10 L 10,90 L 90,50 Z" fill="none" stroke="url(#logoGrad)" strokeWidth="6" strokeLinejoin="round" />

--- a/src/pages/settings/EpgSection.tsx
+++ b/src/pages/settings/EpgSection.tsx
@@ -145,7 +145,7 @@ export function EpgSection({
                     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
                 }
                 .epg-progress-bar {
-                    background: linear-gradient(90deg, #06b6d4, #8b5cf6, #06b6d4);
+                    background: linear-gradient(90deg, #06b6d4, var(--ns-accent), #06b6d4);
                     background-size: 200% 100%;
                     animation: epgProgressShine 2s linear infinite;
                 }
@@ -199,13 +199,13 @@ export function EpgSection({
                         {/* Featured Total Card */}
                         <div className="setting-item epg-grid-item" style={{
                             padding: '20px',
-                            background: 'linear-gradient(135deg, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.15))',
-                            border: '1px solid rgba(168, 85, 247, 0.4)',
+                            background: 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-grad-to-rgb), 0.15))',
+                            border: '1px solid rgba(var(--ns-accent-rgb), 0.4)',
                             marginBottom: '12px',
                             justifyContent: 'center'
                         }}>
                             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '16px' }}>
-                                <div style={{ fontSize: '42px', fontWeight: 800, color: '#a855f7' }}>
+                                <div style={{ fontSize: '42px', fontWeight: 800, color: 'var(--ns-accent)' }}>
                                     {playlistChannelCounts.total}
                                 </div>
                                 <div style={{ textAlign: 'left' }}>
@@ -250,7 +250,7 @@ export function EpgSection({
                 {/* Progress when testing */}
                 {testingEpg && (
                     <div className="setting-item" style={{
-                        background: 'linear-gradient(135deg, rgba(6, 182, 212, 0.15), rgba(139, 92, 246, 0.1))',
+                        background: 'linear-gradient(135deg, rgba(6, 182, 212, 0.15), rgba(var(--ns-accent-rgb), 0.1))',
                         border: '1px solid rgba(6, 182, 212, 0.3)'
                     }}>
                         <div style={{ flex: 1 }}>
@@ -306,7 +306,7 @@ export function EpgSection({
                         {epgTestResults.lastScannedIndex && epgTestResults.lastScannedIndex < (epgTestResults.summary?.total || 0) && (
                             <button className="check-btn" onClick={() => handleEpgTest('continue')} style={{
                                 flex: 1,
-                                background: 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)'
+                                background: 'linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-dark) 100%)'
                             }}>
                                 <span>▶️</span>
                                 <span>{t('epg', 'continueFrom')} ({epgTestResults.lastScannedIndex}/{epgTestResults.summary?.total})</span>
@@ -585,7 +585,7 @@ export function EpgSection({
                                                 <div style={{ color: 'rgba(255,255,255,0.4)', fontSize: '11px' }}>
                                                     <span style={{ color: '#06b6d4' }}>{item.source}</span>
                                                     <span style={{ margin: '0 6px' }}>•</span>
-                                                    <code style={{ color: '#a78bfa', background: 'rgba(167, 139, 250, 0.1)', padding: '2px 5px', borderRadius: '3px', fontSize: '10px' }}>{item.epgId}</code>
+                                                    <code style={{ color: 'var(--ns-accent-light)', background: 'rgba(var(--ns-accent-rgb), 0.1)', padding: '2px 5px', borderRadius: '3px', fontSize: '10px' }}>{item.epgId}</code>
                                                 </div>
                                             </div>
                                         ))}

--- a/src/pages/settings/PlaylistsSection.tsx
+++ b/src/pages/settings/PlaylistsSection.tsx
@@ -117,7 +117,7 @@ export function PlaylistsSection() {
         <div className="section-card">
             <style>{playlistsStyles}</style>
             <div className="section-header">
-                <div className="section-icon" style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)' }}>📺</div>
+                <div className="section-icon" style={{ background: 'linear-gradient(135deg, var(--ns-accent-dark), var(--ns-accent))' }}>📺</div>
                 <div>
                     <h2>{t('playlists', 'title')}</h2>
                     <p>{t('playlists', 'description')}</p>
@@ -280,7 +280,7 @@ const playlistsStyles = `
 
 .playlists-badge {
     padding: 2px 8px;
-    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    background: linear-gradient(135deg, var(--ns-accent-dark), var(--ns-accent));
     border-radius: 8px;
     font-size: 11px;
     font-weight: 600;
@@ -321,7 +321,7 @@ const playlistsStyles = `
 }
 
 .playlists-btn-primary {
-    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    background: linear-gradient(135deg, var(--ns-accent-dark), var(--ns-accent));
     border-color: transparent;
     color: #fff;
 }

--- a/src/pages/settings/StatsSection.tsx
+++ b/src/pages/settings/StatsSection.tsx
@@ -28,7 +28,7 @@ export function StatsSection() {
     return (
         <div className="section-card">
             <div className="section-header">
-                <div className="section-icon" style={{ background: 'linear-gradient(135deg, #8b5cf6, #7c3aed)' }}>📊</div>
+                <div className="section-icon" style={{ background: 'linear-gradient(135deg, var(--ns-accent), var(--ns-accent-dark))' }}>📊</div>
                 <div>
                     <h2>{t('stats', 'title')}</h2>
                     <p>{t('stats', 'description')}</p>
@@ -45,16 +45,16 @@ export function StatsSection() {
                 }}>
                     {/* Total Watch Time */}
                     <div style={{
-                        background: 'linear-gradient(135deg, rgba(139, 92, 246, 0.2), rgba(124, 58, 237, 0.1))',
+                        background: 'linear-gradient(135deg, rgba(var(--ns-accent-rgb), 0.2), rgba(var(--ns-accent-rgb), 0.1))',
                         borderRadius: '16px',
                         padding: '24px',
-                        border: '1px solid rgba(139, 92, 246, 0.3)'
+                        border: '1px solid rgba(var(--ns-accent-rgb), 0.3)'
                     }}>
                         <div style={{ fontSize: '32px', marginBottom: '8px' }}>⏱️</div>
                         <div style={{
                             fontSize: '28px',
                             fontWeight: 700,
-                            color: '#a78bfa',
+                            color: 'var(--ns-accent-light)',
                             marginBottom: '4px'
                         }}>
                             {formatWatchTime(usageStats?.totalWatchTimeThisMonth || 0)}
@@ -142,8 +142,8 @@ export function StatsSection() {
                                         style={{
                                             height: `${height}px`,
                                             background: isToday
-                                                ? 'linear-gradient(180deg, #8b5cf6, #6d28d9)'
-                                                : 'linear-gradient(180deg, rgba(139, 92, 246, 0.5), rgba(139, 92, 246, 0.2))',
+                                                ? 'linear-gradient(180deg, var(--ns-accent), var(--ns-accent-dark))'
+                                                : 'linear-gradient(180deg, rgba(var(--ns-accent-rgb), 0.5), rgba(var(--ns-accent-rgb), 0.2))',
                                             borderRadius: '4px',
                                             margin: '0 auto',
                                             width: '100%',
@@ -153,7 +153,7 @@ export function StatsSection() {
                                         title={`${formatWatchTime(day.totalSeconds)}`}
                                     />
                                     <div style={{
-                                        color: isToday ? '#a78bfa' : 'rgba(255,255,255,0.4)',
+                                        color: isToday ? 'var(--ns-accent-light)' : 'rgba(255,255,255,0.4)',
                                         fontSize: '11px',
                                         marginTop: '6px',
                                         fontWeight: isToday ? 600 : 400

--- a/src/utils/epgGuide.test.ts
+++ b/src/utils/epgGuide.test.ts
@@ -3,11 +3,17 @@ import {
     HALF_HOUR_MS,
     PX_PER_HALF_HOUR,
     WINDOW_HALF_HOURS,
+    WINDOW_SHIFT_MS,
+    WINDOW_MIN_OFFSET_MS,
+    WINDOW_MAX_OFFSET_MS,
     getGuideWindow,
     buildTimeTicks,
     programToBlock,
     nowOffsetPx,
-    isAiringNow
+    isAiringNow,
+    clampWindow,
+    shiftWindow,
+    searchPrograms
 } from './epgGuide';
 
 // Fixed reference: 2026-06-11T15:47:00Z
@@ -106,5 +112,74 @@ describe('isAiringNow', () => {
         const pastEnd = new Date(NOW - 30 * 60000).toISOString();
         expect(isAiringNow(past, pastEnd, NOW)).toBe(false);
         expect(isAiringNow('bad', pastEnd, NOW)).toBe(false);
+    });
+});
+
+describe('shiftWindow / clampWindow', () => {
+    const win = getGuideWindow(NOW);
+    const span = win.end - win.start;
+
+    it('shifts forward and backward by the paging step', () => {
+        const fwd = shiftWindow(win, WINDOW_SHIFT_MS, NOW);
+        expect(fwd.start).toBe(win.start + WINDOW_SHIFT_MS);
+        expect(fwd.end - fwd.start).toBe(span);
+
+        const back = shiftWindow(win, -WINDOW_SHIFT_MS, NOW);
+        expect(back.start).toBe(win.start - WINDOW_SHIFT_MS);
+    });
+
+    it('clamps at the past bound (now - 12h) on a 30-min lattice', () => {
+        let w = win;
+        for (let i = 0; i < 20; i++) w = shiftWindow(w, -WINDOW_SHIFT_MS, NOW);
+        const minStart = Math.ceil((NOW + WINDOW_MIN_OFFSET_MS) / HALF_HOUR_MS) * HALF_HOUR_MS;
+        expect(w.start).toBe(minStart);
+        expect(w.end - w.start).toBe(span);
+        expect(w.start % HALF_HOUR_MS).toBe(0);
+    });
+
+    it('clamps at the future bound (now + 36h)', () => {
+        let w = win;
+        for (let i = 0; i < 40; i++) w = shiftWindow(w, WINDOW_SHIFT_MS, NOW);
+        const maxEnd = Math.floor((NOW + WINDOW_MAX_OFFSET_MS) / HALF_HOUR_MS) * HALF_HOUR_MS;
+        expect(w.end).toBe(maxEnd);
+        expect(w.end - w.start).toBe(span);
+    });
+
+    it('clampWindow keeps an in-range window untouched', () => {
+        expect(clampWindow(win, NOW)).toEqual(win);
+    });
+});
+
+describe('searchPrograms', () => {
+    const iso = (min: number) => new Date(NOW + min * 60000).toISOString();
+    const entries: Array<[string, { title: string; start: string; end: string }[]]> = [
+        ['Globo', [
+            { title: 'Jornal Nacional', start: iso(60), end: iso(90) },
+            { title: 'Novela das Nove', start: iso(90), end: iso(150) }
+        ]],
+        ['SBT', [
+            { title: 'Jornal do SBT', start: iso(30), end: iso(60) },
+            { title: 'Cinema em Casa', start: iso(120), end: iso(240) }
+        ]]
+    ];
+
+    it('matches titles case-insensitively across channels, sorted by start', () => {
+        const results = searchPrograms(entries, 'jornal');
+        expect(results).toHaveLength(2);
+        expect(results[0].title).toBe('Jornal do SBT');
+        expect(results[0].channelKey).toBe('SBT');
+        expect(results[1].title).toBe('Jornal Nacional');
+    });
+
+    it('returns empty for blank queries and respects the limit', () => {
+        expect(searchPrograms(entries, '   ')).toEqual([]);
+        expect(searchPrograms(entries, 'a', 1)).toHaveLength(1);
+    });
+
+    it('skips programs with unparsable start times', () => {
+        const bad: Array<[string, { title: string; start: string; end: string }[]]> = [
+            ['X', [{ title: 'Foo', start: 'not-a-date', end: iso(30) }]]
+        ];
+        expect(searchPrograms(bad, 'foo')).toEqual([]);
     });
 });

--- a/src/utils/epgGuide.ts
+++ b/src/utils/epgGuide.ts
@@ -35,6 +35,73 @@ export function getGuideWindow(now: number = Date.now()): GuideWindow {
     return { start, end: start + WINDOW_HALF_HOURS * HALF_HOUR_MS };
 }
 
+/** Paging step for the ◀/▶ guide buttons. */
+export const WINDOW_SHIFT_MS = 2 * 60 * 60 * 1000;
+/** Earliest reachable point relative to "now" (provider EPG holds ~now-24h). */
+export const WINDOW_MIN_OFFSET_MS = -12 * 60 * 60 * 1000;
+/** Latest reachable point relative to "now" (provider EPG holds ~now+48h). */
+export const WINDOW_MAX_OFFSET_MS = 36 * 60 * 60 * 1000;
+
+/**
+ * Clamps a window into [now-12h, now+36h], preserving its span and keeping
+ * the start on the absolute 30-min lattice (bounds are rounded inward).
+ */
+export function clampWindow(window: GuideWindow, now: number = Date.now()): GuideWindow {
+    const span = window.end - window.start;
+    const minStart = Math.ceil((now + WINDOW_MIN_OFFSET_MS) / HALF_HOUR_MS) * HALF_HOUR_MS;
+    const maxEnd = Math.floor((now + WINDOW_MAX_OFFSET_MS) / HALF_HOUR_MS) * HALF_HOUR_MS;
+    let start = window.start;
+    if (start + span > maxEnd) start = maxEnd - span;
+    if (start < minStart) start = minStart;
+    return { start, end: start + span };
+}
+
+/** Shifts the window by deltaMs (e.g. ±WINDOW_SHIFT_MS), clamped to the data range. */
+export function shiftWindow(window: GuideWindow, deltaMs: number, now: number = Date.now()): GuideWindow {
+    return clampWindow({ start: window.start + deltaMs, end: window.end + deltaMs }, now);
+}
+
+/** Minimal program shape the search helper needs. */
+export interface GuideProgramLike {
+    title: string;
+    start: string;
+    end: string;
+}
+
+export interface ProgramSearchResult {
+    /** Channel key (the EPG cache key, i.e. the channel name) */
+    channelKey: string;
+    title: string;
+    /** ISO start (used to page the window to the program) */
+    start: string;
+    /** Parsed start in ms (for sorting/labels) */
+    startMs: number;
+}
+
+/**
+ * Case-insensitive title search across already-loaded EPG data.
+ * Results are sorted by start time and capped at `limit`.
+ */
+export function searchPrograms(
+    entries: Iterable<[string, GuideProgramLike[]]>,
+    query: string,
+    limit: number = 12
+): ProgramSearchResult[] {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    const results: ProgramSearchResult[] = [];
+    for (const [channelKey, programs] of entries) {
+        for (const program of programs) {
+            if (!program.title || !program.title.toLowerCase().includes(q)) continue;
+            const startMs = Date.parse(program.start);
+            if (Number.isNaN(startMs)) continue;
+            results.push({ channelKey, title: program.title, start: program.start, startMs });
+        }
+    }
+    results.sort((a, b) => a.startMs - b.startMs);
+    return results.slice(0, limit);
+}
+
 /** Timestamps (ms) for every 30-min tick in the window, including the start. */
 export function buildTimeTicks(window: GuideWindow): number[] {
     const ticks: number[] = [];


### PR DESCRIPTION
## 🎨 Temas fase 2
73 trocas em 13 arquivos — cobertura completa: **Login, Welcome, Downloads, Assistir Depois, Favoritos e todas as seções de Configurações** agora seguem a cor escolhida. Sobraram apenas cores de identidade documentadas (gradientes por seção da sidebar, badges de tipo, vermelho live, etc.) e os presets do próprio themeService.

## 📅 Guia de TV fase 2
- **Paginação no tempo**: ◀/▶ avançam/voltam 2h (até -12h/+36h), botão **Hoje/Agora** reseta; a linha AGORA some quando você navega pra fora dela
- **Busca de programa**: campo que busca na programação carregada — dropdown com título, canal e horário (com data quando não é hoje); clicar leva direto ao programa (pagina a janela, troca categoria se preciso, rola até o canal e pisca a linha)

### Verificação
tsc / eslint / vitest **173/173** (8 novos) / vite build / Playwright **11/11** ✅
Ao vivo: guia infantil denso com EPG do provedor, paginação movendo o header, busca achando "Como Treinar o Seu Dragão 2" (inclusive sessões de amanhã) ✅

**Fecha a Rodada 7.** 🏁