### PR TITLE
feat: download automático do MPV com um clique (~30MB)

### DIFF
--- a/electron/mpvDownloader.ts
+++ b/electron/mpvDownloader.ts
@@ -1,0 +1,297 @@
+/**
+ * EXPERIMENTAL — MPV auto-download engine (main process).
+ *
+ * Downloads the latest mpv Windows build from GitHub (zhongfly/mpv-winbuild,
+ * see mpvDownloaderProtocol.ts for the asset choice) into a caller-provided
+ * directory, extracts it with Windows' bundled bsdtar (tar.exe handles both
+ * .zip and .7z), and returns the path of the extracted mpv.exe.
+ *
+ * Deliberately Electron-free: the install dir, progress callback and abort
+ * signal are injected, so the exact same code path can be exercised by a
+ * plain Node script (and was, during development). The IPC wiring
+ * (mpv:download-start / mpv:download-cancel) lives in mpvPlayer.ts.
+ */
+
+import { createWriteStream } from 'node:fs'
+import { mkdir, readdir, rename, rm, stat } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import {
+    MPV_RELEASE_API_URL,
+    buildExtractArgs,
+    computeDownloadProgress,
+    parseMpvVersionFromAssetName,
+    pickMpvAsset,
+    type MpvDownloadProgress,
+    type MpvRelease,
+} from './mpvDownloaderProtocol'
+
+const DOWNLOAD_USER_AGENT = 'NeoStream-IPTV (mpv auto-download)'
+const PROGRESS_MIN_INTERVAL_MS = 250
+const EXTRACT_TIMEOUT_MS = 120_000
+/** The zip/7z may root files directly or inside one wrapper folder. */
+const EXE_SEARCH_MAX_DEPTH = 2
+
+export type MpvInstallFailureReason =
+    | 'network'
+    | 'no-asset'
+    | 'download-failed'
+    | 'extract-failed'
+    | 'exe-not-found'
+    | 'disk'
+    | 'cancelled'
+    | 'in-progress'
+
+export interface MpvInstallResult {
+    success: boolean
+    /** Absolute path of the installed mpv.exe (success only). */
+    path?: string
+    /** Build version parsed from the asset name, e.g. "20260612-git-7d245fd100". */
+    version?: string
+    reason?: MpvInstallFailureReason
+}
+
+export interface MpvInstallOptions {
+    /** Directory owned by the downloader (e.g. {userData}/mpv). Created if missing. */
+    installDir: string
+    signal?: AbortSignal
+    onProgress?: (progress: MpvDownloadProgress) => void
+    /** Injectable for tests/scripts; defaults to the global fetch. */
+    fetchImpl?: typeof fetch
+}
+
+class InstallError extends Error {
+    constructor(readonly reason: MpvInstallFailureReason, message: string) {
+        super(message)
+    }
+}
+
+const throwIfAborted = (signal?: AbortSignal) => {
+    if (signal?.aborted) throw new InstallError('cancelled', 'download cancelled')
+}
+
+async function fetchLatestRelease(fetchImpl: typeof fetch, signal?: AbortSignal): Promise<MpvRelease> {
+    let response: Response
+    try {
+        response = await fetchImpl(MPV_RELEASE_API_URL, {
+            signal,
+            headers: {
+                'User-Agent': DOWNLOAD_USER_AGENT,
+                Accept: 'application/vnd.github+json',
+            },
+        })
+    } catch (error) {
+        throwIfAborted(signal)
+        throw new InstallError('network', `release lookup failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    if (!response.ok) {
+        throw new InstallError('network', `release lookup failed: HTTP ${response.status}`)
+    }
+    try {
+        return await response.json() as MpvRelease
+    } catch {
+        throw new InstallError('network', 'release lookup returned invalid JSON')
+    }
+}
+
+async function downloadToFile(
+    url: string,
+    filePath: string,
+    expectedBytes: number,
+    fetchImpl: typeof fetch,
+    onProgress?: (progress: MpvDownloadProgress) => void,
+    signal?: AbortSignal,
+): Promise<void> {
+    let response: Response
+    try {
+        response = await fetchImpl(url, {
+            signal,
+            headers: { 'User-Agent': DOWNLOAD_USER_AGENT },
+        })
+    } catch (error) {
+        throwIfAborted(signal)
+        throw new InstallError('network', `download failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    if (!response.ok || !response.body) {
+        throw new InstallError('download-failed', `download failed: HTTP ${response.status}`)
+    }
+
+    const headerLength = Number(response.headers.get('content-length'))
+    const totalBytes = Number.isFinite(headerLength) && headerLength > 0 ? headerLength : expectedBytes
+
+    const file = createWriteStream(filePath)
+    const reader = response.body.getReader()
+    let transferred = 0
+    let lastEmit = 0
+
+    const emit = (force: boolean) => {
+        if (!onProgress) return
+        const now = Date.now()
+        if (!force && now - lastEmit < PROGRESS_MIN_INTERVAL_MS) return
+        lastEmit = now
+        onProgress(computeDownloadProgress(transferred, totalBytes))
+    }
+
+    try {
+        emit(true)
+        for (;;) {
+            throwIfAborted(signal)
+            const { done, value } = await reader.read()
+            if (done) break
+            transferred += value.byteLength
+            await new Promise<void>((resolve, reject) => {
+                file.write(value, (error) => (error ? reject(new InstallError('disk', `write failed: ${error.message}`)) : resolve()))
+            })
+            emit(false)
+        }
+        await new Promise<void>((resolve, reject) => {
+            file.end((error?: Error | null) => (error ? reject(new InstallError('disk', `write failed: ${error.message}`)) : resolve()))
+        })
+        emit(true)
+    } catch (error) {
+        file.destroy()
+        try { reader.cancel() } catch { /* stream already done */ }
+        throwIfAborted(signal)
+        if (error instanceof InstallError) throw error
+        throw new InstallError('network', `download interrupted: ${error instanceof Error ? error.message : String(error)}`)
+    }
+}
+
+/** Extract with Windows' bundled bsdtar (auto-detects zip and 7z). */
+function extractArchive(archivePath: string, destDir: string, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+        let settled = false
+        const done = (error?: InstallError) => {
+            if (settled) return
+            settled = true
+            signal?.removeEventListener('abort', onAbort)
+            clearTimeout(timer)
+            if (error) reject(error)
+            else resolve()
+        }
+
+        let child: ReturnType<typeof spawn>
+        try {
+            child = spawn('tar', buildExtractArgs(archivePath, destDir), { windowsHide: true, stdio: 'ignore' })
+        } catch (error) {
+            done(new InstallError('extract-failed', `tar spawn failed: ${error instanceof Error ? error.message : String(error)}`))
+            return
+        }
+
+        const onAbort = () => {
+            try { child.kill() } catch { /* already gone */ }
+            done(new InstallError('cancelled', 'download cancelled'))
+        }
+        const timer = setTimeout(() => {
+            try { child.kill() } catch { /* already gone */ }
+            done(new InstallError('extract-failed', 'tar timed out'))
+        }, EXTRACT_TIMEOUT_MS)
+
+        signal?.addEventListener('abort', onAbort)
+        child.on('error', (error) => done(new InstallError('extract-failed', `tar not available: ${error.message}`)))
+        child.on('exit', (code) => {
+            if (code === 0) done()
+            else done(new InstallError('extract-failed', `tar exited with code ${code}`))
+        })
+    })
+}
+
+/**
+ * Find mpv.exe under `dir`, descending at most `maxDepth` levels — the
+ * archive may root its files directly or inside one wrapper folder.
+ */
+export async function findMpvExe(dir: string, maxDepth: number = EXE_SEARCH_MAX_DEPTH): Promise<string | null> {
+    let entries
+    try {
+        entries = await readdir(dir, { withFileTypes: true })
+    } catch {
+        return null
+    }
+    for (const entry of entries) {
+        if (entry.isFile() && entry.name.toLowerCase() === 'mpv.exe') {
+            return path.join(dir, entry.name)
+        }
+    }
+    if (maxDepth <= 1) return null
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            const found = await findMpvExe(path.join(dir, entry.name), maxDepth - 1)
+            if (found) return found
+        }
+    }
+    return null
+}
+
+/**
+ * Download + extract + locate mpv.exe. Never throws — inspect `success`.
+ * Layout inside installDir:
+ *   download.<ext>   transient archive (always removed)
+ *   extract-tmp/     transient extraction target (removed on failure)
+ *   bin/             final install (replaced atomically via rename)
+ */
+export async function installMpv(options: MpvInstallOptions): Promise<MpvInstallResult> {
+    const { installDir, signal, onProgress } = options
+    const fetchImpl = options.fetchImpl ?? fetch
+    const tmpDir = path.join(installDir, 'extract-tmp')
+    const binDir = path.join(installDir, 'bin')
+    let archivePath: string | null = null
+
+    try {
+        throwIfAborted(signal)
+        try {
+            await mkdir(installDir, { recursive: true })
+        } catch (error) {
+            throw new InstallError('disk', `cannot create install dir: ${error instanceof Error ? error.message : String(error)}`)
+        }
+
+        const release = await fetchLatestRelease(fetchImpl, signal)
+        const asset = pickMpvAsset(release.assets)
+        if (!asset) {
+            throw new InstallError('no-asset', 'no suitable mpv-x86_64 asset in the latest release')
+        }
+        const extension = asset.name.toLowerCase().endsWith('.zip') ? 'zip' : '7z'
+        archivePath = path.join(installDir, `download.${extension}`)
+
+        throwIfAborted(signal)
+        await downloadToFile(asset.browser_download_url, archivePath, asset.size, fetchImpl, onProgress, signal)
+
+        // Sanity-check the file actually landed with content.
+        const archiveStat = await stat(archivePath).catch(() => null)
+        if (!archiveStat || archiveStat.size === 0) {
+            throw new InstallError('download-failed', 'downloaded archive is empty')
+        }
+
+        throwIfAborted(signal)
+        await rm(tmpDir, { recursive: true, force: true })
+        await mkdir(tmpDir, { recursive: true })
+        await extractArchive(archivePath, tmpDir, signal)
+
+        const extractedExe = await findMpvExe(tmpDir)
+        if (!extractedExe) {
+            throw new InstallError('exe-not-found', 'mpv.exe not found in the extracted archive')
+        }
+
+        // Swap the new build in (a running mpv.exe would block the rm — surface as disk error).
+        try {
+            await rm(binDir, { recursive: true, force: true })
+            await rename(tmpDir, binDir)
+        } catch (error) {
+            throw new InstallError('disk', `cannot move install into place: ${error instanceof Error ? error.message : String(error)}`)
+        }
+
+        const exePath = path.join(binDir, path.relative(tmpDir, extractedExe))
+        return {
+            success: true,
+            path: exePath,
+            version: parseMpvVersionFromAssetName(asset.name) ?? undefined,
+        }
+    } catch (error) {
+        const reason = error instanceof InstallError ? error.reason : 'download-failed'
+        await rm(tmpDir, { recursive: true, force: true }).catch(() => undefined)
+        return { success: false, reason }
+    } finally {
+        if (archivePath) {
+            await rm(archivePath, { force: true }).catch(() => undefined)
+        }
+    }
+}

--- a/electron/mpvDownloaderProtocol.test.ts
+++ b/electron/mpvDownloaderProtocol.test.ts
@@ -1,0 +1,122 @@
+/**
+ * EXPERIMENTAL — MPV auto-download. Unit tests for the pure release-asset
+ * picking and progress helpers.
+ *
+ * REAL_RELEASE_ASSETS is trimmed from the actual GitHub API response of
+ * https://api.github.com/repos/zhongfly/mpv-winbuild/releases/latest
+ * fetched on 2026-06-12 (tag 2026-06-12-7d245fd100) — names and sizes are
+ * verbatim; only the asset list fields we consume were kept.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+    MPV_RELEASE_API_URL,
+    buildExtractArgs,
+    computeDownloadProgress,
+    parseMpvVersionFromAssetName,
+    pickMpvAsset,
+    type MpvReleaseAsset,
+} from './mpvDownloaderProtocol'
+
+const url = (name: string) =>
+    `https://github.com/zhongfly/mpv-winbuild/releases/download/2026-06-12-7d245fd100/${name}`
+
+const asset = (name: string, size: number): MpvReleaseAsset =>
+    ({ name, browser_download_url: url(name), size })
+
+const REAL_RELEASE_ASSETS: MpvReleaseAsset[] = [
+    asset('ffmpeg-aarch64-git-dd9083cb8.7z', 22_122_209),
+    asset('ffmpeg-lgpl-aarch64-git-dd9083cb8.7z', 19_503_438),
+    asset('ffmpeg-lgpl-x86_64-git-dd9083cb8.7z', 23_700_633),
+    asset('ffmpeg-lgpl-x86_64-v3-git-dd9083cb8.7z', 24_643_982),
+    asset('ffmpeg-x86_64-git-dd9083cb8.7z', 27_053_854),
+    asset('ffmpeg-x86_64-v3-git-dd9083cb8.7z', 28_101_337),
+    asset('mpv-aarch64-20260612-git-7d245fd100.7z', 26_738_688),
+    asset('mpv-debug-aarch64-20260612-git-7d245fd100.7z', 50_750_054),
+    asset('mpv-debug-x86_64-20260612-git-7d245fd100.7z', 55_683_481),
+    asset('mpv-debug-x86_64-v3-20260612-git-7d245fd100.7z', 55_369_134),
+    asset('mpv-dev-aarch64-20260612-git-7d245fd100.7z', 26_004_685),
+    asset('mpv-dev-lgpl-aarch64-20260612-git-7d245fd100.7z', 22_963_404),
+    asset('mpv-dev-lgpl-x86_64-20260612-git-7d245fd100.7z', 27_577_549),
+    asset('mpv-dev-lgpl-x86_64-v3-20260612-git-7d245fd100.7z', 28_730_982),
+    asset('mpv-dev-x86_64-20260612-git-7d245fd100.7z', 31_236_915),
+    asset('mpv-dev-x86_64-v3-20260612-git-7d245fd100.7z', 32_553_323),
+    asset('mpv-x86_64-20260612-git-7d245fd100.7z', 31_989_350),
+    asset('mpv-x86_64-v3-20260612-git-7d245fd100.7z', 33_271_316),
+    asset('sha256.txt', 2_269),
+]
+
+describe('pickMpvAsset', () => {
+    it('picks exactly the plain x86_64 player build from the real release', () => {
+        const picked = pickMpvAsset(REAL_RELEASE_ASSETS)
+        expect(picked?.name).toBe('mpv-x86_64-20260612-git-7d245fd100.7z')
+        expect(picked?.browser_download_url).toBe(url('mpv-x86_64-20260612-git-7d245fd100.7z'))
+        expect(picked?.size).toBe(31_989_350)
+    })
+
+    it('never picks v3, aarch64, dev, debug, lgpl or ffmpeg variants', () => {
+        const others = REAL_RELEASE_ASSETS.filter((a) => a.name !== 'mpv-x86_64-20260612-git-7d245fd100.7z')
+        expect(pickMpvAsset(others)).toBeNull()
+    })
+
+    it('prefers a .zip over a .7z when both are published', () => {
+        const withZip = [
+            ...REAL_RELEASE_ASSETS,
+            asset('mpv-x86_64-20260612-git-7d245fd100.zip', 40_000_000),
+        ]
+        expect(pickMpvAsset(withZip)?.name).toBe('mpv-x86_64-20260612-git-7d245fd100.zip')
+    })
+
+    it('handles missing/empty/malformed asset lists', () => {
+        expect(pickMpvAsset(undefined)).toBeNull()
+        expect(pickMpvAsset(null)).toBeNull()
+        expect(pickMpvAsset([])).toBeNull()
+        expect(pickMpvAsset([{ name: 123, browser_download_url: null } as unknown as MpvReleaseAsset])).toBeNull()
+    })
+})
+
+describe('parseMpvVersionFromAssetName', () => {
+    it('extracts date+hash from the asset name', () => {
+        expect(parseMpvVersionFromAssetName('mpv-x86_64-20260612-git-7d245fd100.7z'))
+            .toBe('20260612-git-7d245fd100')
+        expect(parseMpvVersionFromAssetName('mpv-x86_64-20260612-git-7d245fd100.zip'))
+            .toBe('20260612-git-7d245fd100')
+    })
+
+    it('returns null for other names', () => {
+        expect(parseMpvVersionFromAssetName('mpv-dev-x86_64-20260612-git-7d245fd100.7z')).toBeNull()
+        expect(parseMpvVersionFromAssetName('sha256.txt')).toBeNull()
+    })
+})
+
+describe('computeDownloadProgress', () => {
+    it('computes percent and MB values', () => {
+        const progress = computeDownloadProgress(15_994_675, 31_989_350)
+        expect(progress.percent).toBe(50)
+        expect(progress.transferredMB).toBe(15.3)
+        expect(progress.totalMB).toBe(30.5)
+    })
+
+    it('floors percent so 100% is only shown when complete', () => {
+        expect(computeDownloadProgress(31_989_349, 31_989_350).percent).toBe(99)
+        expect(computeDownloadProgress(31_989_350, 31_989_350).percent).toBe(100)
+    })
+
+    it('clamps overshoot and handles unknown totals', () => {
+        expect(computeDownloadProgress(200, 100).percent).toBe(100)
+        expect(computeDownloadProgress(500, 0)).toEqual({ percent: 0, transferredMB: 0, totalMB: 0 })
+        expect(computeDownloadProgress(-5, -10)).toEqual({ percent: 0, transferredMB: 0, totalMB: 0 })
+    })
+})
+
+describe('buildExtractArgs', () => {
+    it('builds bsdtar extract arguments', () => {
+        expect(buildExtractArgs('C:\\tmp\\download.7z', 'C:\\tmp\\out'))
+            .toEqual(['-xf', 'C:\\tmp\\download.7z', '-C', 'C:\\tmp\\out'])
+    })
+})
+
+describe('MPV_RELEASE_API_URL', () => {
+    it('points at the zhongfly/mpv-winbuild latest release endpoint', () => {
+        expect(MPV_RELEASE_API_URL).toBe('https://api.github.com/repos/zhongfly/mpv-winbuild/releases/latest')
+    })
+})

--- a/electron/mpvDownloaderProtocol.ts
+++ b/electron/mpvDownloaderProtocol.ts
@@ -1,0 +1,84 @@
+/**
+ * EXPERIMENTAL — MPV auto-download.
+ *
+ * Pure helpers for picking/parsing the mpv Windows build release asset and
+ * for the download progress math — no Electron, no fs, no network, no state.
+ * Everything here is unit-testable; the side-effectful engine (fetch, file
+ * streaming, tar extraction) lives in mpvDownloader.ts.
+ *
+ * Source: GitHub releases of zhongfly/mpv-winbuild (daily Windows builds).
+ * Verified 2026-06-12: the release ships ONLY .7z assets (no .zip), e.g.
+ * mpv-x86_64-20260612-git-7d245fd100.7z (~31 MB). Windows 10+ bundles
+ * bsdtar as tar.exe (libarchive), which extracts 7-Zip archives natively,
+ * so .7z needs no extra tooling. The picker still prefers .zip should the
+ * repo ever publish one.
+ */
+
+export const MPV_RELEASE_API_URL = 'https://api.github.com/repos/zhongfly/mpv-winbuild/releases/latest'
+
+export interface MpvReleaseAsset {
+    name: string
+    browser_download_url: string
+    size: number
+}
+
+export interface MpvRelease {
+    tag_name?: string
+    assets?: MpvReleaseAsset[]
+}
+
+/**
+ * Exactly the plain x86_64 player build: `mpv-x86_64-<date>-git-<hash>.<ext>`.
+ * The strict date+hash shape rules out every sibling variant — `-v3-`
+ * (needs AVX2 CPUs), `aarch64`, `mpv-dev-` (libmpv SDK), `mpv-debug-` and
+ * `-lgpl-` — without listing them.
+ */
+const ASSET_NAME_PATTERN = /^mpv-x86_64-\d{8}-git-[0-9a-f]+\.(zip|7z)$/i
+
+/**
+ * Pick the downloadable player asset from a release's asset list.
+ * Prefers .zip over .7z when both exist (plain deflate, fastest extract);
+ * returns null when no suitable asset is present.
+ */
+export function pickMpvAsset(assets: ReadonlyArray<MpvReleaseAsset> | undefined | null): MpvReleaseAsset | null {
+    if (!Array.isArray(assets)) return null
+    const matches = assets.filter((asset) =>
+        typeof asset?.name === 'string'
+        && typeof asset?.browser_download_url === 'string'
+        && ASSET_NAME_PATTERN.test(asset.name))
+    if (matches.length === 0) return null
+    return matches.find((asset) => asset.name.toLowerCase().endsWith('.zip')) ?? matches[0]
+}
+
+/** "mpv-x86_64-20260612-git-7d245fd100.7z" -> "20260612-git-7d245fd100". */
+export function parseMpvVersionFromAssetName(name: string): string | null {
+    const match = /^mpv-x86_64-(\d{8}-git-[0-9a-f]+)\./i.exec(name)
+    return match ? match[1] : null
+}
+
+export interface MpvDownloadProgress {
+    /** 0..100 integer; 0 when the total size is unknown. */
+    percent: number
+    transferredMB: number
+    totalMB: number
+}
+
+const toMB = (bytes: number): number => Math.round((bytes / (1024 * 1024)) * 10) / 10
+
+/** Progress snapshot sent to the renderer (mpv:download-progress). */
+export function computeDownloadProgress(transferredBytes: number, totalBytes: number): MpvDownloadProgress {
+    const safeTransferred = Math.max(0, transferredBytes)
+    const safeTotal = Math.max(0, totalBytes)
+    const percent = safeTotal > 0
+        ? Math.min(100, Math.floor((safeTransferred / safeTotal) * 100))
+        : 0
+    return { percent, transferredMB: toMB(safeTransferred), totalMB: toMB(safeTotal) }
+}
+
+/**
+ * Arguments for Windows' bundled bsdtar (C:\Windows\System32\tar.exe).
+ * bsdtar auto-detects the archive format (zip and 7z both supported).
+ */
+export function buildExtractArgs(archivePath: string, destDir: string): string[] {
+    return ['-xf', archivePath, '-C', destDir]
+}

--- a/electron/mpvPlayer.ts
+++ b/electron/mpvPlayer.ts
@@ -16,6 +16,9 @@
  *   mpv:set-fullscreen -> { success }            ({ fullscreen: boolean })
  *   mpv:status         -> MpvStatus snapshot (polled by the renderer)
  *   mpv:set-path       -> { path: string | null } (persists to electron-store)
+ *   mpv:download-start -> MpvInstallResult (one-click install, see mpvDownloader.ts)
+ *   mpv:download-cancel-> { success: boolean }
+ *   mpv:download-progress (main -> renderer) { percent, transferredMB, totalMB }
  *
  * Phase 2 pseudo-embedding: mpv is spawned borderless/ontop with --geometry
  * matching the caller window's client area minus the bottom controls strip
@@ -29,8 +32,10 @@ import { app, ipcMain, BrowserWindow } from 'electron'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import net from 'node:net'
+import path from 'node:path'
 import store from './store'
 import log from './logger'
+import { installMpv } from './mpvDownloader'
 import {
     applyIpcMessage,
     buildMpvArgs,
@@ -424,6 +429,49 @@ export function setupMpvHandlers() {
     })
 
     ipcMain.handle('mpv:status', () => getStatusSnapshot())
+
+    // EXPERIMENTAL — one-click MPV install. Single in-flight download; the
+    // controller doubles as the guard (null = idle).
+    let downloadController: AbortController | null = null
+
+    ipcMain.handle('mpv:download-start', async (event) => {
+        if (downloadController) {
+            return { success: false, reason: 'in-progress' }
+        }
+        const controller = new AbortController()
+        downloadController = controller
+        const sender = event.sender
+        try {
+            const result = await installMpv({
+                installDir: path.join(app.getPath('userData'), 'mpv'),
+                signal: controller.signal,
+                onProgress: (progress) => {
+                    if (!sender.isDestroyed()) {
+                        sender.send('mpv:download-progress', progress)
+                    }
+                },
+            })
+            if (result.success && result.path) {
+                // Same flow as mpv:set-path: persist + invalidate the resolver cache.
+                store.set('settings', { ...store.get('settings'), mpvPath: result.path })
+                await resolveMpvPath(true)
+                log.info(`[MPV] auto-download installed ${result.path} (${result.version ?? 'unknown version'})`)
+            } else if (!result.success) {
+                log.warn(`[MPV] auto-download failed: ${result.reason}`)
+            }
+            return result
+        } finally {
+            if (downloadController === controller) {
+                downloadController = null
+            }
+        }
+    })
+
+    ipcMain.handle('mpv:download-cancel', () => {
+        if (!downloadController) return { success: false }
+        downloadController.abort()
+        return { success: true }
+    })
 
     ipcMain.handle('mpv:set-path', async (_event, payload: { path?: string }) => {
         const path = typeof payload?.path === 'string' ? payload.path.trim() : ''

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -46,6 +46,8 @@ const invokeChannels = new Set([
     'epg:provider-channel',
     'fetch-url',
     'mpv:available',
+    'mpv:download-cancel',
+    'mpv:download-start',
     'mpv:pause',
     'mpv:play',
     'mpv:resume',
@@ -99,6 +101,7 @@ const sendChannels = new Set([
 const receiveChannels = new Set([
     'download:progress',
     'main-process-message',
+    'mpv:download-progress',
     'pip:clickThroughChanged',
     'pip:closed',
     'pip:control',

--- a/src/locales/ui/en.json
+++ b/src/locales/ui/en.json
@@ -310,7 +310,13 @@
     "mpvDetecting": "Detecting...",
     "mpvFoundAt": "MPV found at",
     "mpvNotFound": "mpv not found",
-    "mpvInstallHint": "Install with scoop install mpv, choco install mpv or download from mpv.io"
+    "mpvInstallHint": "Install with scoop install mpv, choco install mpv or download from mpv.io",
+    "mpvDownloadButton": "Download MPV automatically (~30MB)",
+    "mpvDownloading": "Downloading MPV...",
+    "mpvDownloadCancel": "Cancel",
+    "mpvDownloadSuccess": "MPV installed",
+    "mpvDownloadError": "MPV download failed. Check your connection.",
+    "mpvDownloadRetry": "Try again"
   },
   "appearance": {
     "title": "Appearance",

--- a/src/locales/ui/es.json
+++ b/src/locales/ui/es.json
@@ -310,7 +310,13 @@
     "mpvDetecting": "Detectando...",
     "mpvFoundAt": "MPV encontrado en",
     "mpvNotFound": "mpv no encontrado",
-    "mpvInstallHint": "Instala con scoop install mpv, choco install mpv o descarga desde mpv.io"
+    "mpvInstallHint": "Instala con scoop install mpv, choco install mpv o descarga desde mpv.io",
+    "mpvDownloadButton": "Descargar MPV automáticamente (~30MB)",
+    "mpvDownloading": "Descargando MPV...",
+    "mpvDownloadCancel": "Cancelar",
+    "mpvDownloadSuccess": "MPV instalado",
+    "mpvDownloadError": "Error al descargar MPV. Verifica tu conexión.",
+    "mpvDownloadRetry": "Reintentar"
   },
   "appearance": {
     "title": "Apariencia",

--- a/src/locales/ui/pt.json
+++ b/src/locales/ui/pt.json
@@ -409,7 +409,13 @@
     "mpvDetecting": "Detectando...",
     "mpvFoundAt": "MPV encontrado em",
     "mpvNotFound": "mpv não encontrado",
-    "mpvInstallHint": "Instale com scoop install mpv, choco install mpv ou baixe em mpv.io"
+    "mpvInstallHint": "Instale com scoop install mpv, choco install mpv ou baixe em mpv.io",
+    "mpvDownloadButton": "Baixar MPV automaticamente (~30MB)",
+    "mpvDownloading": "Baixando MPV...",
+    "mpvDownloadCancel": "Cancelar",
+    "mpvDownloadSuccess": "MPV instalado",
+    "mpvDownloadError": "Falha ao baixar o MPV. Verifique sua conexão.",
+    "mpvDownloadRetry": "Tentar novamente"
   },
   "appearance": {
     "title": "Aparência",

--- a/src/pages/settings/PlaybackSection.tsx
+++ b/src/pages/settings/PlaybackSection.tsx
@@ -2,8 +2,16 @@ import { useEffect, useState } from 'react';
 import { playbackService } from '../../services/playbackService';
 import type { PlaybackConfig } from '../../services/playbackService';
 import { mpvService } from '../../services/mpvService';
+import type { MpvDownloadProgress } from '../../services/mpvService';
 import { useLanguage } from '../../services/languageService';
 import { useSaveAnimation } from './useSaveAnimation';
+
+// EXPERIMENTAL — one-click MPV download state machine
+type MpvDownloadState =
+    | { phase: 'idle' }
+    | { phase: 'downloading'; progress: MpvDownloadProgress | null }
+    | { phase: 'success'; path: string }
+    | { phase: 'error' };
 
 export function PlaybackSection() {
     const [playbackConfig, setPlaybackConfig] = useState<PlaybackConfig>(playbackService.getConfig());
@@ -14,6 +22,7 @@ export function PlaybackSection() {
     const [mpvPathInput, setMpvPathInput] = useState('');
     const [mpvDetecting, setMpvDetecting] = useState(false);
     const [mpvResolvedPath, setMpvResolvedPath] = useState<string | null | undefined>(undefined);
+    const [mpvDownload, setMpvDownload] = useState<MpvDownloadState>({ phase: 'idle' });
 
     const handlePlaybackConfigChange = <K extends keyof PlaybackConfig>(key: K, value: PlaybackConfig[K]) => {
         const newConfig = { ...playbackConfig, [key]: value };
@@ -45,6 +54,28 @@ export function PlaybackSection() {
             setMpvResolvedPath(resolved);
         } finally {
             setMpvDetecting(false);
+        }
+    };
+
+    // EXPERIMENTAL — one-click MPV download (progress streams via mpv:download-progress)
+    const handleMpvDownload = async () => {
+        setMpvDownload({ phase: 'downloading', progress: null });
+        const unsubscribe = mpvService.onDownloadProgress((progress) => {
+            setMpvDownload((prev) => (prev.phase === 'downloading' ? { phase: 'downloading', progress } : prev));
+        });
+        try {
+            const result = await mpvService.startDownload();
+            if (result.success && result.path) {
+                setMpvResolvedPath(result.path);
+                setMpvPathInput(result.path);
+                setMpvDownload({ phase: 'success', path: result.path });
+            } else if (result.reason === 'cancelled') {
+                setMpvDownload({ phase: 'idle' });
+            } else {
+                setMpvDownload({ phase: 'error' });
+            }
+        } finally {
+            unsubscribe();
         }
     };
 
@@ -235,6 +266,82 @@ export function PlaybackSection() {
                                     : (t('playback', 'mpvDetect') || 'Detectar')}
                             </button>
                         </div>
+
+                        {/* EXPERIMENTAL — one-click MPV download (mpv not found, or download in progress) */}
+                        {(mpvResolvedPath === null || mpvDownload.phase !== 'idle') && (
+                            <div style={{ width: '100%' }}>
+                                {(mpvDownload.phase === 'idle' || mpvDownload.phase === 'error') && (
+                                    <div style={{ display: 'flex', gap: '12px', alignItems: 'center', flexWrap: 'wrap' }}>
+                                        <button
+                                            onClick={handleMpvDownload}
+                                            style={{
+                                                cursor: 'pointer',
+                                                border: 'none',
+                                                borderRadius: '8px',
+                                                padding: '10px 18px',
+                                                fontWeight: 600,
+                                                color: '#fff',
+                                                background: 'linear-gradient(135deg, var(--ns-accent) 0%, var(--ns-accent-dark) 100%)',
+                                            }}
+                                        >
+                                            {mpvDownload.phase === 'error'
+                                                ? (t('playback', 'mpvDownloadRetry') || 'Tentar novamente')
+                                                : (t('playback', 'mpvDownloadButton') || 'Baixar MPV automaticamente (~30MB)')}
+                                        </button>
+                                        {mpvDownload.phase === 'error' && (
+                                            <span style={{ color: '#ef4444', fontSize: '13px' }}>
+                                                ✕ {t('playback', 'mpvDownloadError') || 'Falha ao baixar o MPV. Verifique sua conexão.'}
+                                            </span>
+                                        )}
+                                    </div>
+                                )}
+
+                                {mpvDownload.phase === 'downloading' && (
+                                    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                                        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '13px' }}>
+                                            <span>{t('playback', 'mpvDownloading') || 'Baixando MPV...'}</span>
+                                            <span style={{ opacity: 0.8 }}>
+                                                {mpvDownload.progress
+                                                    ? `${mpvDownload.progress.percent}% — ${mpvDownload.progress.transferredMB} / ${mpvDownload.progress.totalMB} MB`
+                                                    : '...'}
+                                            </span>
+                                        </div>
+                                        <div
+                                            style={{
+                                                height: '8px',
+                                                borderRadius: '4px',
+                                                overflow: 'hidden',
+                                                background: 'rgba(var(--ns-accent-rgb), 0.15)',
+                                            }}
+                                        >
+                                            <div
+                                                style={{
+                                                    height: '100%',
+                                                    width: `${mpvDownload.progress?.percent ?? 0}%`,
+                                                    transition: 'width 0.3s ease',
+                                                    background: 'linear-gradient(90deg, var(--ns-accent) 0%, var(--ns-accent-dark) 100%)',
+                                                }}
+                                            />
+                                        </div>
+                                        <div>
+                                            <button
+                                                className="setting-select"
+                                                style={{ cursor: 'pointer' }}
+                                                onClick={() => mpvService.cancelDownload()}
+                                            >
+                                                {t('playback', 'mpvDownloadCancel') || 'Cancelar'}
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
+
+                                {mpvDownload.phase === 'success' && (
+                                    <span style={{ color: '#10b981', fontSize: '13px' }}>
+                                        ✓ {t('playback', 'mpvDownloadSuccess') || 'MPV instalado'}: {mpvDownload.path}
+                                    </span>
+                                )}
+                            </div>
+                        )}
                     </div>
                 )}
             </div>

--- a/src/services/mpvService.ts
+++ b/src/services/mpvService.ts
@@ -26,6 +26,19 @@ export interface MpvPlayResult {
     reason?: string;
 }
 
+export interface MpvDownloadProgress {
+    percent: number;
+    transferredMB: number;
+    totalMB: number;
+}
+
+export interface MpvDownloadResult {
+    success: boolean;
+    path?: string;
+    version?: string;
+    reason?: string;
+}
+
 class MpvService {
     /** Resolved mpv path (configured > PATH > common install dirs) or null. */
     async getAvailability(): Promise<MpvAvailability> {
@@ -89,6 +102,35 @@ class MpvService {
         } catch {
             return null;
         }
+    }
+
+    /**
+     * One-click MPV install: download the latest Windows build and persist
+     * its path. Resolves with the final result (progress arrives via
+     * onDownloadProgress). Never throws — inspect `success`/`reason`.
+     */
+    async startDownload(): Promise<MpvDownloadResult> {
+        try {
+            const result = await window.ipcRenderer.invoke('mpv:download-start');
+            return result ?? { success: false, reason: 'no-response' };
+        } catch (error) {
+            console.warn('[MPV] download failed:', error);
+            return { success: false, reason: 'ipc-error' };
+        }
+    }
+
+    /** Abort an in-flight download (startDownload resolves with reason 'cancelled'). */
+    async cancelDownload(): Promise<void> {
+        await window.ipcRenderer.invoke('mpv:download-cancel').catch(() => undefined);
+    }
+
+    /** Subscribe to download progress events. Returns the unsubscribe function. */
+    onDownloadProgress(listener: (progress: MpvDownloadProgress) => void): () => void {
+        const wrapped = (_event: unknown, progress: unknown) => {
+            listener(progress as MpvDownloadProgress);
+        };
+        window.ipcRenderer.on('mpv:download-progress', wrapped);
+        return () => window.ipcRenderer.off('mpv:download-progress', wrapped);
     }
 
     /** Persist a user-chosen mpv.exe path (empty clears it). Returns the re-resolved path. */


### PR DESCRIPTION
## ⬇️ MPV plug-and-play

Ligou o "Player MPV (experimental)" e não tem mpv instalado? Agora aparece um botão **"Baixar MPV automaticamente (~30MB)"** — barra de progresso temática, Cancelar, e ao terminar o player já funciona na hora (caminho preenchido sozinho).

### Detalhes
- Baixa o build oficial mais recente (zhongfly/mpv-winbuild, o recomendado pelo mpv.io)
- Extração com o `tar.exe` nativo do Windows 10+ (bsdtar lê 7z) — **zero dependências novas**
- Download cancelável, limpeza completa em falha, guarda contra cliques duplos
- ~30MB reais (medido), não os ~80MB estimados

### Teste real nesta máquina
O motor de download foi executado de verdade: baixou `mpv-x86_64-20260612`, extraiu e o `mpv --version` respondeu **v0.41.0** ✅ (arquivos de teste removidos — o fluxo no app fica virgem pra você testar)

### Verificação
tsc / eslint / vitest **184/184** (11 novos) / vite build / Playwright **11/11** ✅