### PR TITLE
fix: ícone do app no exe + rolagem nas abas de Configurações

### DIFF
--- a/installer-shell/electron-builder.yml
+++ b/installer-shell/electron-builder.yml
@@ -28,7 +28,9 @@ win:
       arch:
         - x64
   icon: build/icons/icon.ico
-  signAndEditExecutable: false
+  # signExecutable (not signAndEditExecutable): keep icon/metadata embedding
+  # via rcedit, skip only code signing
+  signExecutable: false
   verifyUpdateCodeSignature: false
 
 portable:

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         }
       ],
       "icon": "build/icons/icon.ico",
-      "signAndEditExecutable": false,
+      "signExecutable": false,
       "verifyUpdateCodeSignature": false
     },
     "portable": {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -288,9 +288,28 @@ const settingsStyles = `
     white-space: nowrap;
 }
 
-/* Content Area */
+/* Content Area — independently scrollable so tall sections (EPG results,
+   Reprodução with the MPV block) aren't cut off in the 800px window */
 .settings-content {
     flex: 1;
+    max-height: calc(100vh - 180px);
+    overflow-y: auto;
+    padding-right: 6px;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(var(--ns-accent-rgb), 0.4) transparent;
+}
+
+.settings-content::-webkit-scrollbar {
+    width: 6px;
+}
+
+.settings-content::-webkit-scrollbar-thumb {
+    background: rgba(var(--ns-accent-rgb), 0.4);
+    border-radius: 3px;
+}
+
+.settings-content::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 /* Section Card */


### PR DESCRIPTION
## 🖼️ Ícone do app (report do usuário)
A área de trabalho/barra de tarefas mostrava o ícone padrão do Electron. Causa: `signAndEditExecutable: false` pulava **toda** a edição de recursos do exe (ícone, nome do produto, empresa) — não só a assinatura. Trocado por `signExecutable: false` nos dois builds (app + instalador).

**Verificado em build local**: ícone extraído do exe é o logo do NeoStream, metadata ProductName/CompanyName corretos. ⚠️ O ícone novo aparece depois de instalar a próxima release (e o cache de ícones do Windows pode demorar uns minutos pra atualizar atalhos antigos).

## 📜 Rolagem nas Configurações (report do usuário)
Abas altas (EPG com resultados, Reprodução com o bloco MPV) estouravam a janela de 800px sem rolagem. O painel de conteúdo agora rola sozinho com scrollbar temática fina, mantendo o menu de seções fixo. Verificado ao vivo: Reprodução rola até o final do bloco MPV.

### Verificação
tsc / eslint / vite build ✅ + gate visual da rolagem ✅ + build NSIS local com ícone confirmado ✅
