### PR TITLE
fix: MPV — download confiável + corrige play que parava na hora

### DIFF
--- a/electron/mpvDownloader.ts
+++ b/electron/mpvDownloader.ts
@@ -49,6 +49,8 @@ export interface MpvInstallResult {
     /** Build version parsed from the asset name, e.g. "20260612-git-7d245fd100". */
     version?: string
     reason?: MpvInstallFailureReason
+    /** Diagnostic detail for the failure (logged, not shown to the user). */
+    message?: string
 }
 
 export interface MpvInstallOptions {
@@ -157,6 +159,17 @@ async function downloadToFile(
     }
 }
 
+/**
+ * Windows' bundled bsdtar, by ABSOLUTE path. Resolving plain 'tar' from PATH
+ * can pick up Git's GNU tar (MSYS), which treats "C:\..." as a remote host
+ * ("Cannot connect to C") — found the hard way when the app inherited a Git
+ * Bash PATH. System32's bsdtar handles drive letters and both zip and 7z.
+ */
+function tarExecutable(): string {
+    const systemRoot = process.env.SystemRoot || process.env.windir
+    return systemRoot ? path.join(systemRoot, 'System32', 'tar.exe') : 'tar'
+}
+
 /** Extract with Windows' bundled bsdtar (auto-detects zip and 7z). */
 function extractArchive(archivePath: string, destDir: string, signal?: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -172,7 +185,7 @@ function extractArchive(archivePath: string, destDir: string, signal?: AbortSign
 
         let child: ReturnType<typeof spawn>
         try {
-            child = spawn('tar', buildExtractArgs(archivePath, destDir), { windowsHide: true, stdio: 'ignore' })
+            child = spawn(tarExecutable(), buildExtractArgs(archivePath, destDir), { windowsHide: true, stdio: 'ignore' })
         } catch (error) {
             done(new InstallError('extract-failed', `tar spawn failed: ${error instanceof Error ? error.message : String(error)}`))
             return
@@ -287,8 +300,9 @@ export async function installMpv(options: MpvInstallOptions): Promise<MpvInstall
         }
     } catch (error) {
         const reason = error instanceof InstallError ? error.reason : 'download-failed'
+        const message = error instanceof Error ? error.message : String(error)
         await rm(tmpDir, { recursive: true, force: true }).catch(() => undefined)
-        return { success: false, reason }
+        return { success: false, reason, message }
     } finally {
         if (archivePath) {
             await rm(archivePath, { force: true }).catch(() => undefined)

--- a/electron/mpvPlayer.ts
+++ b/electron/mpvPlayer.ts
@@ -28,7 +28,7 @@
  * via the `geometry` and `window-minimized` properties.
  */
 
-import { app, ipcMain, BrowserWindow } from 'electron'
+import { app, ipcMain, BrowserWindow, net as electronNet } from 'electron'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import net from 'node:net'
@@ -387,6 +387,7 @@ export function setupMpvHandlers() {
         if (!/^https?:\/\//i.test(url)) {
             return { success: false, reason: 'invalid-url' }
         }
+        log.info(`[MPV] mpv:play requested (${payload?.title ?? 'sem título'})`)
         return launchMpv({
             url,
             title: typeof payload?.title === 'string' ? payload.title : undefined,
@@ -424,6 +425,7 @@ export function setupMpvHandlers() {
     })
 
     ipcMain.handle('mpv:stop', () => {
+        log.info('[MPV] mpv:stop requested by renderer')
         stopMpv()
         return { success: true }
     })
@@ -442,8 +444,11 @@ export function setupMpvHandlers() {
         downloadController = controller
         const sender = event.sender
         try {
-            const result = await installMpv({
+            const runInstall = () => installMpv({
                 installDir: path.join(app.getPath('userData'), 'mpv'),
+                // Chromium's network stack (system proxy/TLS) — Node's undici
+                // fetch proved flaky on multi-adapter/VPN machines.
+                fetchImpl: electronNet.fetch as typeof fetch,
                 signal: controller.signal,
                 onProgress: (progress) => {
                     if (!sender.isDestroyed()) {
@@ -451,13 +456,21 @@ export function setupMpvHandlers() {
                     }
                 },
             })
+            let result = await runInstall()
+            // One automatic retry for transient mid-stream interruptions —
+            // a 30MB GitHub asset stream occasionally drops on flaky links.
+            if (!result.success && result.reason === 'network' && !controller.signal.aborted) {
+                log.warn(`[MPV] auto-download network failure, retrying once: ${result.message ?? ''}`)
+                await new Promise(resolve => setTimeout(resolve, 1500))
+                result = await runInstall()
+            }
             if (result.success && result.path) {
                 // Same flow as mpv:set-path: persist + invalidate the resolver cache.
                 store.set('settings', { ...store.get('settings'), mpvPath: result.path })
                 await resolveMpvPath(true)
                 log.info(`[MPV] auto-download installed ${result.path} (${result.version ?? 'unknown version'})`)
             } else if (!result.success) {
-                log.warn(`[MPV] auto-download failed: ${result.reason}`)
+                log.warn(`[MPV] auto-download failed: ${result.reason} — ${result.message ?? 'no detail'}`)
             }
             return result
         } finally {

--- a/src/components/AsyncVideoPlayer.tsx
+++ b/src/components/AsyncVideoPlayer.tsx
@@ -117,8 +117,11 @@ function AsyncVideoPlayer<TMovie extends MediaItem, TVersion extends MediaItem =
         }
         lastEpisodeRef.current = currentEpisodeKey;
 
-        // Skip if already loaded for same content
-        if (urlLoadedRef.current && streamUrl) {
+        // Skip if already loaded for this content. Uses the ref only (not the
+        // streamUrl closure) so a re-run can never re-enter the load path once
+        // the URL is in — re-entering would setLoading(true) and, under the
+        // experimental MPV path, unmount MpvPlayerView right after it launched.
+        if (urlLoadedRef.current) {
             return;
         }
 
@@ -152,7 +155,12 @@ function AsyncVideoPlayer<TMovie extends MediaItem, TVersion extends MediaItem =
         return () => {
             cancelled = true;
         };
-    }, [movie, buildStreamUrl, currentEpisode, seriesId, seasonNumber, episodeNumber, streamUrl]);
+        // Re-run only when the CONTENT changes (movie/episode), not when the
+        // parent re-creates buildStreamUrl or when streamUrl is set — those
+        // caused the effect to churn (cancel + restart the load) on every
+        // parent render. buildStreamUrl is intentionally omitted.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [movie, currentEpisode, seriesId, seasonNumber, episodeNumber]);
 
     const resumeTime = useMemo(() => {
         if (!streamUrl || loading) return null;

--- a/src/pages/LiveTV.tsx
+++ b/src/pages/LiveTV.tsx
@@ -447,7 +447,11 @@ export function LiveTV() {
         return variants.length > 1 ? variants : [];
     };
 
-    const buildLiveStreamUrl = async (channel: LiveStream): Promise<string> => {
+    // Memoized so AsyncVideoPlayer's URL effect (which lists buildStreamUrl in
+    // its deps) doesn't re-run on every LiveTV render. Without this, the rapid
+    // re-runs cancel + restart the load, which under the experimental MPV path
+    // could mount→unmount MpvPlayerView (launch then immediate stop).
+    const buildLiveStreamUrl = useCallback(async (channel: LiveStream): Promise<string> => {
         try {
             const result = await window.ipcRenderer.invoke('auth:get-credentials');
 
@@ -462,7 +466,7 @@ export function LiveTV() {
             console.error('❌ Error building live stream URL:', error);
             throw error;
         }
-    };
+    }, []);
 
     // Timeshift URL builder for the replay player — same shared service the
     // EPG guide uses (main process probes the URL form + provider timezone).


### PR DESCRIPTION
## 🎬 QA real do MPV (PR 4 da Rodada 8)

Testei o MPV de verdade nesta máquina (baixando pelo próprio app) e achei **dois bugs reais**, ambos corrigidos.

### ⬇️ Download (Configurações → Reprodução → Baixar MPV)
1. **Extração falhava** (`tar exited 128 / Cannot connect to C: resolve failed`): o `tar` do PATH caía no GNU tar do Git (MSYS), que interpreta `C:\...` como host remoto. Agora uso o **bsdtar nativo do Windows por caminho absoluto** (`System32\tar.exe`) — lê drive letter e .7z.
2. **`fetch failed`** nesta máquina (vários adaptadores/VPN): o fetch do Node (undici) estava instável. Troquei pelo **`net.fetch` do Electron** (stack de rede do Chromium) + **1 retry automático** em erro de rede transitório.

✅ **Verificado de ponta a ponta**: baixou e instalou o **mpv v0.41.0**.

### ▶️ Playback travado em "Preparando seu vídeo…"
O log mostrava `mpv:play → launched → mpv:stop → exited` em ~2ms. **Causa raiz**: o efeito de URL do AsyncVideoPlayer tinha `buildStreamUrl` e `streamUrl` nas dependências, então **todo re-render do pai** (o `buildLiveStreamUrl` não era memoizado) re-rodava o efeito, cancelando/reiniciando o load e voltando pra tela de loading — o que **desmontava o MpvPlayerView logo após ele lançar o mpv** (cleanup → stop).

Corrigido na raiz:
- o efeito re-roda só quando o **conteúdo** muda (filme/episódio), não na identidade do builder nem quando o streamUrl é setado; guard só por ref, nunca reentra no load. **Cobre VOD/Séries/Home também.**
- `buildLiveStreamUrl` memoizado (useCallback) como reforço.

### Verificação
tsc / eslint / vitest **217/217** / vite build / Playwright **11/11** ✅

⚠️ **O download está verificado ao vivo.** O fix do playback embutido é bem fundamentado e verificado estaticamente, mas perdi o acesso à automação de GUI no meio — **vale um retest seu**: liga o MPV, abre um canal e confirma que o vídeo aparece embutido com a barra de controles (sem travar no "Preparando seu vídeo").

🤖 Generated with [Claude Code](https://claude.com/claude-code)