### PR TITLE
fix: progresso de filme per-profile (corrige vazamento entre perfis)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { MiniPlayerProvider } from './components/MiniPlayer';
 import { CustomTitleBar } from './components/CustomTitleBar';
 import { profileService } from './services/profileService';
 import { reminderService } from './services/reminderService';
+import { movieProgressService } from './services/movieProgressService';
 import { useState, useEffect, lazy, Suspense } from 'react';
 
 const Home = lazy(() => import('./pages/Home').then(m => ({ default: m.Home })));
@@ -73,6 +74,10 @@ function App() {
 
     // Initialize profile service (migrate old data if needed)
     profileService.initialize();
+
+    // One-time: split the legacy global movie-progress key into per-profile
+    // keys (no-op once migrated). Runs after profiles exist.
+    movieProgressService.migrateLegacyGlobalProgress();
 
     // Check if there's an active profile
     const activeProfile = profileService.getActiveProfile();

--- a/src/services/movieProgressService.test.ts
+++ b/src/services/movieProgressService.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the active profile so the service keys deterministically.
+let activeId: string | null = 'p1';
+vi.mock('./profileService', () => ({
+    profileService: {
+        getActiveProfile: () => (activeId ? { id: activeId } : null)
+    }
+}));
+
+import { movieProgressService, type MovieProgress } from './movieProgressService';
+
+const entry = (over: Partial<MovieProgress> & { movieId: string; profileId: string }): MovieProgress => ({
+    movieName: 'M',
+    currentTime: 10,
+    duration: 100,
+    progress: 10,
+    watchedAt: 1000,
+    completed: false,
+    ...over
+});
+
+describe('movieProgressService — per-profile', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        activeId = 'p1';
+    });
+
+    it('keys progress per profile (no leak across profiles)', () => {
+        activeId = 'p1';
+        movieProgressService.saveMovieTime('m1', 'Filme 1', 50, 100);
+        activeId = 'p2';
+        expect(movieProgressService.getMoviePositionById('m1')).toBeNull();
+        expect(movieProgressService.getMoviesInProgress()).toEqual([]);
+
+        activeId = 'p1';
+        expect(movieProgressService.getMoviePositionById('m1')?.movieId).toBe('m1');
+        expect(localStorage.getItem('movie_watch_progress_p1')).toBeTruthy();
+        expect(localStorage.getItem('movie_watch_progress_p2')).toBeNull();
+    });
+
+    it('classifies in-progress vs watched by percentage', () => {
+        movieProgressService.saveMovieTime('inprog', 'A', 40, 100); // 40%
+        movieProgressService.saveMovieTime('done', 'B', 98, 100);   // 98% -> completed
+        expect(movieProgressService.getMoviesInProgress()).toEqual(['inprog']);
+        expect(movieProgressService.getWatchedMovies()).toEqual(['done']);
+    });
+
+    it('clearMovieProgress only affects the active profile', () => {
+        movieProgressService.saveMovieTime('m1', 'A', 50, 100);
+        movieProgressService.saveMovieTime('m2', 'B', 50, 100);
+        movieProgressService.clearMovieProgress('m1');
+        expect(movieProgressService.getMoviePositionById('m1')).toBeNull();
+        expect(movieProgressService.getMoviePositionById('m2')?.movieId).toBe('m2');
+    });
+
+    it('no active profile -> reads return empty', () => {
+        activeId = null;
+        expect(movieProgressService.getMoviesInProgress()).toEqual([]);
+        expect(movieProgressService.getHistory()).toEqual([]);
+    });
+});
+
+describe('movieProgressService — legacy migration', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        activeId = 'p1';
+    });
+
+    it('splits the global key into per-profile keys, newest wins, and removes the legacy key', () => {
+        const legacy: MovieProgress[] = [
+            entry({ movieId: 'm1', profileId: 'p1', watchedAt: 100 }),
+            entry({ movieId: 'm1', profileId: 'p1', watchedAt: 300, currentTime: 30 }), // newer dup
+            entry({ movieId: 'm9', profileId: 'p2', watchedAt: 200 })
+        ];
+        localStorage.setItem('movie_watch_progress', JSON.stringify(legacy));
+
+        movieProgressService.migrateLegacyGlobalProgress();
+
+        expect(localStorage.getItem('movie_watch_progress')).toBeNull();
+        const p1 = JSON.parse(localStorage.getItem('movie_watch_progress_p1')!);
+        expect(p1).toHaveLength(1);
+        expect(p1[0].currentTime).toBe(30); // newest dup won
+        const p2 = JSON.parse(localStorage.getItem('movie_watch_progress_p2')!);
+        expect(p2.map((e: MovieProgress) => e.movieId)).toEqual(['m9']);
+    });
+
+    it('merges with existing per-profile data without losing it', () => {
+        localStorage.setItem('movie_watch_progress_p1', JSON.stringify([entry({ movieId: 'keep', profileId: 'p1', watchedAt: 500 })]));
+        localStorage.setItem('movie_watch_progress', JSON.stringify([entry({ movieId: 'm1', profileId: 'p1', watchedAt: 100 })]));
+
+        movieProgressService.migrateLegacyGlobalProgress();
+
+        const ids = JSON.parse(localStorage.getItem('movie_watch_progress_p1')!).map((e: MovieProgress) => e.movieId).sort();
+        expect(ids).toEqual(['keep', 'm1']);
+    });
+
+    it('is idempotent / no-op when the legacy key is absent or garbage', () => {
+        movieProgressService.migrateLegacyGlobalProgress(); // absent
+        localStorage.setItem('movie_watch_progress', 'not json');
+        movieProgressService.migrateLegacyGlobalProgress();
+        expect(localStorage.getItem('movie_watch_progress')).toBeNull();
+    });
+});

--- a/src/services/movieProgressService.ts
+++ b/src/services/movieProgressService.ts
@@ -12,17 +12,29 @@ export interface MovieProgress {
 }
 
 class MovieProgressService {
-    private STORAGE_KEY = 'movie_watch_progress';
+    // Per-profile key, mirroring watchProgressService (series). Previously a
+    // single global key `movie_watch_progress` held every profile's data and
+    // filtered at query time — that leaked progress across profiles. The
+    // legacy key is split into per-profile keys by migrateLegacyGlobalProgress().
+    private STORAGE_KEY_PREFIX = 'movie_watch_progress';
+    private LEGACY_GLOBAL_KEY = 'movie_watch_progress';
 
-    // Get all movie progress
+    private getStorageKey(): string {
+        const activeProfile = profileService.getActiveProfile();
+        return activeProfile
+            ? `${this.STORAGE_KEY_PREFIX}_${activeProfile.id}`
+            : this.STORAGE_KEY_PREFIX; // fallback (no active profile)
+    }
+
+    // Get all movie progress for the active profile
     private getProgress(): MovieProgress[] {
-        const stored = localStorage.getItem(this.STORAGE_KEY);
+        const stored = localStorage.getItem(this.getStorageKey());
         return stored ? JSON.parse(stored) : [];
     }
 
-    // Save movie progress
+    // Save movie progress for the active profile
     private saveProgress(progress: MovieProgress[]): void {
-        localStorage.setItem(this.STORAGE_KEY, JSON.stringify(progress));
+        localStorage.setItem(this.getStorageKey(), JSON.stringify(progress));
     }
 
     // Save/update movie watch progress
@@ -39,9 +51,7 @@ class MovieProgressService {
         const progressPercent = (currentTime / duration) * 100;
         const completed = progressPercent >= 95;
 
-        const existing = progress.findIndex(
-            (p) => p.movieId === movieId && p.profileId === activeProfile.id
-        );
+        const existing = progress.findIndex((p) => p.movieId === movieId);
 
         const entry: MovieProgress = {
             movieId,
@@ -63,66 +73,93 @@ class MovieProgressService {
         this.saveProgress(progress);
     }
 
-    // Get specific movie progress
+    // Get specific movie progress (active profile)
     getMoviePositionById(movieId: string): MovieProgress | null {
-        const activeProfile = profileService.getActiveProfile();
-        if (!activeProfile) return null;
-
-        const progress = this.getProgress();
-        return progress.find(
-            (p) => p.movieId === movieId && p.profileId === activeProfile.id
-        ) || null;
+        if (!profileService.getActiveProfile()) return null;
+        return this.getProgress().find((p) => p.movieId === movieId) || null;
     }
 
     // Get movies in progress (1-94%)
     getMoviesInProgress(): string[] {
-        const activeProfile = profileService.getActiveProfile();
-        if (!activeProfile) return [];
-
-        const progress = this.getProgress();
-        return progress
-            .filter(
-                (p) =>
-                    p.profileId === activeProfile.id &&
-                    p.progress > 0 &&
-                    p.progress < 95
-            )
+        if (!profileService.getActiveProfile()) return [];
+        return this.getProgress()
+            .filter((p) => p.progress > 0 && p.progress < 95)
             .map((p) => p.movieId);
     }
 
     // Get watched/completed movies (95%+)
     getWatchedMovies(): string[] {
-        const activeProfile = profileService.getActiveProfile();
-        if (!activeProfile) return [];
-
-        const progress = this.getProgress();
-        return progress
-            .filter(
-                (p) =>
-                    p.profileId === activeProfile.id &&
-                    (p.progress >= 95 || p.completed)
-            )
+        if (!profileService.getActiveProfile()) return [];
+        return this.getProgress()
+            .filter((p) => p.progress >= 95 || p.completed)
             .map((p) => p.movieId);
     }
 
     // Read-only watch history for the active profile (every movie with progress)
     getHistory(): MovieProgress[] {
-        const activeProfile = profileService.getActiveProfile();
-        if (!activeProfile) return [];
-
-        return this.getProgress().filter((p) => p.profileId === activeProfile.id);
+        if (!profileService.getActiveProfile()) return [];
+        return this.getProgress();
     }
 
-    // Clear movie progress
+    // Clear a single movie's progress (active profile)
     clearMovieProgress(movieId: string): void {
-        const progress = this.getProgress();
-        const filtered = progress.filter((p) => p.movieId !== movieId);
+        const filtered = this.getProgress().filter((p) => p.movieId !== movieId);
         this.saveProgress(filtered);
     }
 
-    // Clear all movie progress
+    // Clear all movie progress for the active profile
     clearAllProgress(): void {
-        localStorage.removeItem(this.STORAGE_KEY);
+        localStorage.removeItem(this.getStorageKey());
+    }
+
+    /**
+     * One-time migration: split the legacy global `movie_watch_progress` array
+     * (entries tagged with profileId) into per-profile keys
+     * `movie_watch_progress_${profileId}`, then drop the legacy key. Idempotent
+     * and safe to call on every boot (no-op once the legacy key is gone).
+     */
+    migrateLegacyGlobalProgress(): void {
+        const legacy = localStorage.getItem(this.LEGACY_GLOBAL_KEY);
+        if (!legacy) return;
+
+        let entries: MovieProgress[];
+        try {
+            entries = JSON.parse(legacy);
+        } catch {
+            localStorage.removeItem(this.LEGACY_GLOBAL_KEY);
+            return;
+        }
+        if (!Array.isArray(entries)) {
+            localStorage.removeItem(this.LEGACY_GLOBAL_KEY);
+            return;
+        }
+
+        // Group by profileId and merge into each profile's per-profile key.
+        const byProfile = new Map<string, MovieProgress[]>();
+        for (const entry of entries) {
+            if (!entry || typeof entry.profileId !== 'string') continue;
+            const list = byProfile.get(entry.profileId) ?? [];
+            list.push(entry);
+            byProfile.set(entry.profileId, list);
+        }
+
+        for (const [profileId, list] of byProfile) {
+            const key = `${this.STORAGE_KEY_PREFIX}_${profileId}`;
+            const existing: MovieProgress[] = (() => {
+                const stored = localStorage.getItem(key);
+                if (!stored) return [];
+                try { return JSON.parse(stored); } catch { return []; }
+            })();
+            // Merge: keep the most-recent entry per movieId.
+            const merged = new Map<string, MovieProgress>();
+            for (const e of [...existing, ...list]) {
+                const prev = merged.get(e.movieId);
+                if (!prev || e.watchedAt > prev.watchedAt) merged.set(e.movieId, e);
+            }
+            localStorage.setItem(key, JSON.stringify([...merged.values()]));
+        }
+
+        localStorage.removeItem(this.LEGACY_GLOBAL_KEY);
     }
 }
 


### PR DESCRIPTION
## 🎬 Progresso de filme agora é por perfil

**Bug:** o progresso de filmes ficava numa única chave global (`movie_watch_progress`) e era só *filtrado* por perfil na hora de ler. Resultado: "continuar assistindo", assistidos e histórico **vazavam entre perfis**, e apagar um perfil não isolava os dados dele. As séries já eram per-profile — agora os filmes também.

### O que mudou
- Chave por perfil (`movie_watch_progress_${profileId}`), espelhando o serviço de séries
- **Migração automática** no boot: divide o array global antigo em chaves por perfil (entrada mais recente vence por filme, mescla com o que já existir), depois remove a chave legada. Idempotente — roda uma vez e vira no-op.
- 7 testes novos (isolamento entre perfis, in-progress/assistido, clear escopado, migração com split/merge/idempotência)

### Verificação
tsc / eslint / vitest **233/233** (7 novos) / vite build ✅

> Parte da Rodada 9 (coerência de persistência). Próximo: limpeza de localStorage acumulado, depois escopo por playlist.