### PR TITLE
chore: limpeza de localStorage no boot (chaves que acumulavam)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,11 @@ function App() {
       indexedDBCache.cleanupExpired()
     );
 
+    // Best-effort sweep of unbounded localStorage keys (self-throttled to 24h).
+    void import('./services/storageCleanup').then(({ runStorageCleanup }) =>
+      runStorageCleanup()
+    );
+
     // Initialize profile service (migrate old data if needed)
     profileService.initialize();
 

--- a/src/services/epgTestService.test.ts
+++ b/src/services/epgTestService.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// epgService is pulled in at module load; stub so importing the test target is
+// side-effect free. pruneOldResults never calls it.
+vi.mock('./epgService', () => ({
+    epgService: {
+        getOpenEpgPortugalId: vi.fn(),
+        getOpenEpgArgentinaId: vi.fn(),
+        getOpenEpgUSAId: vi.fn(),
+        getMiTVSlug: vi.fn(),
+        fetchChannelEPG: vi.fn()
+    }
+}));
+
+import epgTestService, { type EpgTestResult } from './epgTestService';
+
+const KEY = 'epg_test_results';
+const DAY = 24 * 60 * 60 * 1000;
+
+function makeResult(timestamp: number): EpgTestResult {
+    return {
+        working: [{ channel: 'TV A', source: 'src', epgId: 'a', programCount: 5, country: 'BR' }],
+        notWorking: [{ channel: 'TV B', source: 'src', epgId: 'b', reason: 'no data', country: 'BR' }],
+        summary: { total: 2, working: 1, notWorking: 1 },
+        timestamp,
+        isPartial: false,
+        scannedChannels: ['TV A', 'TV B'],
+        lastScannedIndex: 2
+    };
+}
+
+describe('epgTestService.pruneOldResults', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        // Reset singleton state to idle with no cached result.
+        epgTestService.clearCache();
+    });
+
+    it('drops a result older than 7 days and resets in-memory state', () => {
+        const now = 100 * DAY;
+        localStorage.setItem(KEY, JSON.stringify(makeResult(now - 8 * DAY)));
+
+        const removed = epgTestService.pruneOldResults(now);
+
+        expect(removed).toBe(true);
+        expect(localStorage.getItem(KEY)).toBeNull();
+        // EpgSection reads `.results` / `.lastTestDate` — both cleared.
+        expect(epgTestService.results).toBeNull();
+        expect(epgTestService.lastTestDate).toBeNull();
+    });
+
+    it('keeps a recent result and leaves the read path intact', () => {
+        const now = 100 * DAY;
+        const fresh = makeResult(now - 1 * DAY);
+        localStorage.setItem(KEY, JSON.stringify(fresh));
+
+        const removed = epgTestService.pruneOldResults(now);
+
+        expect(removed).toBe(false);
+        // The EpgSection read path (epgTestService.results) still gets valid data.
+        const persisted = JSON.parse(localStorage.getItem(KEY)!) as EpgTestResult;
+        expect(persisted.working).toHaveLength(1);
+        expect(persisted.notWorking).toHaveLength(1);
+        expect(persisted.summary.total).toBe(2);
+    });
+
+    it('leaves a result without a timestamp alone (legacy)', () => {
+        const now = 100 * DAY;
+        const noTs = makeResult(now);
+        delete (noTs as Partial<EpgTestResult>).timestamp;
+        localStorage.setItem(KEY, JSON.stringify(noTs));
+
+        const removed = epgTestService.pruneOldResults(now);
+
+        expect(removed).toBe(false);
+        expect(localStorage.getItem(KEY)).not.toBeNull();
+    });
+
+    it('is a no-op when there is no cached result', () => {
+        expect(epgTestService.pruneOldResults(Date.now())).toBe(false);
+    });
+});

--- a/src/services/epgTestService.ts
+++ b/src/services/epgTestService.ts
@@ -28,6 +28,9 @@ type StateListener = () => void;
 class EpgTestService {
     private static instance: EpgTestService;
 
+    /** A cached test result older than this is considered stale and dropped. */
+    private static readonly MAX_RESULT_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
     // State
     private _status: TestStatus = 'idle';
     private _progress: EpgTestProgress = { current: 0, total: 0, currentChannel: '' };
@@ -109,6 +112,46 @@ class EpgTestService {
         this._lastTestDate = null;
         this._status = 'idle';
         this.notifyListeners();
+    }
+
+    /**
+     * Drop the cached EPG test result once it goes stale (>7 days old).
+     *
+     * `epg_test_results` is a single snapshot — one object holding the
+     * working/notWorking arrays of the most recent run — not an accumulating
+     * log, so it is naturally bounded by the channel count and overwritten each
+     * run. The only unbounded-in-time concern is a result that lingers forever
+     * after the user stops running tests; channels listed there can also go
+     * stale. We treat a result older than MAX_RESULT_AGE_MS as expired and
+     * clear it (same effect as clearCache), leaving fresh results untouched.
+     *
+     * A running/paused test is never pruned. Results without a timestamp
+     * (legacy) are left alone. Returns true if a stale result was removed.
+     */
+    pruneOldResults(now: number = Date.now()): boolean {
+        // Don't disturb an in-flight or resumable run.
+        if (this._status === 'running' || this._status === 'paused') return false;
+
+        let cached: EpgTestResult | null = this._results;
+        if (!cached) {
+            try {
+                const raw = localStorage.getItem('epg_test_results');
+                cached = raw ? (JSON.parse(raw) as EpgTestResult) : null;
+            } catch {
+                cached = null;
+            }
+        }
+        if (!cached || typeof cached.timestamp !== 'number') return false;
+
+        if (now - cached.timestamp > EpgTestService.MAX_RESULT_AGE_MS) {
+            localStorage.removeItem('epg_test_results');
+            this._results = null;
+            this._lastTestDate = null;
+            this._status = 'idle';
+            this.notifyListeners();
+            return true;
+        }
+        return false;
     }
 
     // Pause the test

--- a/src/services/episodeNotificationService.test.ts
+++ b/src/services/episodeNotificationService.test.ts
@@ -182,3 +182,77 @@ describe('background episode check — concurrency guard', () => {
         svc.getSeriesToMonitor = original;
     });
 });
+
+describe('pruneStaleSeriesData — drop un-monitored series entries', () => {
+    // No active profile in test → storage key suffix is `_default`.
+    const KEY = 'series_episode_data_default';
+
+    const entry = (id: string) => ({
+        seriesId: id,
+        seriesName: `Series ${id}`,
+        poster: '',
+        lastKnownSeasons: 1,
+        lastKnownEpisodes: 10,
+        lastChecked: '2026-01-01T00:00:00.000Z'
+    });
+
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    const mockMonitored = (ids: string[]) => {
+        const svc = appNotificationService as unknown as {
+            getSeriesToMonitor: () => Promise<Array<{ id: string; name: string; poster: string }>>;
+        };
+        vi.spyOn(svc, 'getSeriesToMonitor').mockResolvedValue(
+            ids.map(id => ({ id, name: `Series ${id}`, poster: '' }))
+        );
+    };
+
+    it('removes only the entries no longer in the monitored set', async () => {
+        localStorage.setItem(
+            KEY,
+            JSON.stringify({ tracked: entry('tracked'), untracked: entry('untracked') })
+        );
+        // Only "tracked" is still a favorite / has progress.
+        mockMonitored(['tracked']);
+
+        const removed = await appNotificationService.pruneStaleSeriesData();
+
+        expect(removed).toBe(1);
+        const after = JSON.parse(localStorage.getItem(KEY)!);
+        expect(Object.keys(after)).toEqual(['tracked']);
+        expect(after.untracked).toBeUndefined();
+    });
+
+    it('keeps everything when all entries are still monitored', async () => {
+        localStorage.setItem(
+            KEY,
+            JSON.stringify({ a: entry('a'), b: entry('b') })
+        );
+        mockMonitored(['a', 'b']);
+
+        const removed = await appNotificationService.pruneStaleSeriesData();
+
+        expect(removed).toBe(0);
+        const after = JSON.parse(localStorage.getItem(KEY)!);
+        expect(Object.keys(after).sort()).toEqual(['a', 'b']);
+    });
+
+    it('is a no-op (and does not query the monitor set) when storage is empty', async () => {
+        const svc = appNotificationService as unknown as {
+            getSeriesToMonitor: () => Promise<unknown[]>;
+        };
+        const spy = vi.spyOn(svc, 'getSeriesToMonitor').mockResolvedValue([]);
+
+        const removed = await appNotificationService.pruneStaleSeriesData();
+
+        expect(removed).toBe(0);
+        expect(spy).not.toHaveBeenCalled();
+    });
+});

--- a/src/services/episodeNotificationService.ts
+++ b/src/services/episodeNotificationService.ts
@@ -406,6 +406,39 @@ class AppNotificationService {
         seriesData.delete(seriesId);
         this.saveSeriesData(seriesData);
     }
+
+    /**
+     * Drop tracked-series entries that are no longer monitored.
+     *
+     * `series_episode_data_<profile>` accumulates one entry per series we ever
+     * checked for new episodes and is never pruned automatically
+     * (removeSeriesFromTracking is only called by hand). The monitored set is
+     * "favorites + series with watch progress" (see getSeriesToMonitor): once a
+     * series leaves both, its entry is dead weight. This removes exactly those
+     * stale entries and is a no-op when nothing is stale.
+     *
+     * Returns the number of entries removed (handy for tests/telemetry).
+     */
+    async pruneStaleSeriesData(): Promise<number> {
+        const seriesData = this.getSeriesData();
+        if (seriesData.size === 0) return 0;
+
+        const monitored = await this.getSeriesToMonitor();
+        const monitoredIds = new Set(monitored.map(s => s.id));
+
+        let removed = 0;
+        for (const seriesId of Array.from(seriesData.keys())) {
+            if (!monitoredIds.has(seriesId)) {
+                seriesData.delete(seriesId);
+                removed += 1;
+            }
+        }
+
+        if (removed > 0) {
+            this.saveSeriesData(seriesData);
+        }
+        return removed;
+    }
 }
 
 export const appNotificationService = new AppNotificationService();

--- a/src/services/storageCleanup.test.ts
+++ b/src/services/storageCleanup.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { shouldRunCleanup, STORAGE_CLEANUP_INTERVAL_MS } from './storageCleanup';
+
+describe('storageCleanup — shouldRunCleanup throttle', () => {
+    const DAY = STORAGE_CLEANUP_INTERVAL_MS;
+
+    it('runs when there is no recorded last run (null)', () => {
+        expect(shouldRunCleanup(null, 1_000_000)).toBe(true);
+    });
+
+    it('runs when the stored value is not finite (garbage)', () => {
+        expect(shouldRunCleanup(NaN, 1_000_000)).toBe(true);
+        expect(shouldRunCleanup(Infinity, 1_000_000)).toBe(true);
+    });
+
+    it('skips when the interval has not yet elapsed', () => {
+        const now = 10 * DAY;
+        expect(shouldRunCleanup(now - 1, now)).toBe(false);
+        expect(shouldRunCleanup(now - (DAY - 1), now)).toBe(false);
+    });
+
+    it('runs once exactly the interval has elapsed', () => {
+        const last = 5 * DAY;
+        expect(shouldRunCleanup(last, last + DAY)).toBe(true);
+    });
+
+    it('runs when well past the interval', () => {
+        const last = 5 * DAY;
+        expect(shouldRunCleanup(last, last + 3 * DAY)).toBe(true);
+    });
+
+    it('honours a custom interval', () => {
+        const custom = 60 * 1000; // 1 min
+        const last = 1_000_000;
+        expect(shouldRunCleanup(last, last + custom - 1, custom)).toBe(false);
+        expect(shouldRunCleanup(last, last + custom, custom)).toBe(true);
+    });
+
+    it('the default interval is 24 hours', () => {
+        expect(STORAGE_CLEANUP_INTERVAL_MS).toBe(24 * 60 * 60 * 1000);
+    });
+});

--- a/src/services/storageCleanup.ts
+++ b/src/services/storageCleanup.ts
@@ -1,0 +1,94 @@
+/**
+ * Boot-time localStorage cleanup orchestrator.
+ *
+ * A handful of localStorage keys grow without bound over the app's lifetime:
+ *   - `series_episode_data_<profile>` — one entry per series ever checked for
+ *     new episodes, never pruned automatically.
+ *   - `epg_test_results` — a lingering stale snapshot of the last EPG test.
+ *   - `tmdb_cache_movies` / `tmdb_cache_series` — one entry per VOD title seen,
+ *     compacted only on read, never swept from storage.
+ *
+ * `runStorageCleanup()` calls each owning service's prune (each guarded so one
+ * failure can't block the others) and is cheap + idempotent. It self-throttles
+ * to at most once per 24h via a `lastStorageCleanup` timestamp, so wiring it
+ * into the app boot path costs effectively nothing on subsequent launches.
+ */
+
+const LAST_RUN_KEY = 'lastStorageCleanup';
+
+/** Run the cleanup sweep at most this often. */
+export const STORAGE_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+
+/**
+ * Pure throttle decision: should the sweep run given the last-run timestamp?
+ *
+ * `lastRun` is null/NaN when we've never run (or the stored value is garbage),
+ * in which case we run. Otherwise run only once `intervalMs` has elapsed.
+ */
+export function shouldRunCleanup(
+    lastRun: number | null,
+    now: number,
+    intervalMs: number = STORAGE_CLEANUP_INTERVAL_MS
+): boolean {
+    if (lastRun === null || !Number.isFinite(lastRun)) return true;
+    return now - lastRun >= intervalMs;
+}
+
+function readLastRun(): number | null {
+    try {
+        const raw = localStorage.getItem(LAST_RUN_KEY);
+        if (raw === null) return null;
+        const parsed = Number(raw);
+        return Number.isFinite(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Orchestrate the per-key prunes, throttled to once per `intervalMs`.
+ *
+ * Each prune is wrapped in its own try/catch so a failure in one service does
+ * not block the others or abort the boot path. The throttle timestamp is
+ * stamped only after a sweep actually runs. Returns true if a sweep ran, false
+ * if it was skipped by the throttle.
+ */
+export async function runStorageCleanup(
+    now: number = Date.now(),
+    intervalMs: number = STORAGE_CLEANUP_INTERVAL_MS
+): Promise<boolean> {
+    if (!shouldRunCleanup(readLastRun(), now, intervalMs)) {
+        return false;
+    }
+
+    // Stamp first so a crash mid-sweep doesn't cause a busy-retry loop on every
+    // boot; the prunes are idempotent so re-running tomorrow is harmless.
+    try {
+        localStorage.setItem(LAST_RUN_KEY, String(now));
+    } catch {
+        // localStorage unavailable/full — nothing more we can do here.
+    }
+
+    try {
+        const { appNotificationService } = await import('./episodeNotificationService');
+        await appNotificationService.pruneStaleSeriesData();
+    } catch (e) {
+        console.error('[StorageCleanup] pruneStaleSeriesData failed:', e);
+    }
+
+    try {
+        const { default: epgTestService } = await import('./epgTestService');
+        epgTestService.pruneOldResults(now);
+    } catch (e) {
+        console.error('[StorageCleanup] epg pruneOldResults failed:', e);
+    }
+
+    try {
+        const { tmdbCacheService } = await import('./tmdbCacheService');
+        tmdbCacheService.pruneExpired(now);
+    } catch (e) {
+        console.error('[StorageCleanup] tmdb pruneExpired failed:', e);
+    }
+
+    return true;
+}

--- a/src/services/tmdbCacheService.test.ts
+++ b/src/services/tmdbCacheService.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// The service imports ./tmdb (network helpers) at module load. pruneExpired
+// never calls them, but stub the module so importing the service is side-effect
+// free in jsdom.
+vi.mock('./tmdb', () => ({
+    searchMovieByName: vi.fn(),
+    searchSeriesByName: vi.fn(),
+    isKidsFriendly: vi.fn(() => true)
+}));
+
+import { tmdbCacheService } from './tmdbCacheService';
+
+const MOVIE_KEY = 'tmdb_cache_movies';
+const SERIES_KEY = 'tmdb_cache_series';
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('tmdbCacheService.pruneExpired', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('removes stamped-old entries (>30 days) and keeps fresh ones', () => {
+        const now = 100 * DAY;
+        localStorage.setItem(
+            MOVIE_KEY,
+            JSON.stringify({
+                old: { certification: 'R', genres: [], cachedAt: now - 31 * DAY },
+                fresh: { certification: 'PG', genres: [], cachedAt: now - 1 * DAY }
+            })
+        );
+
+        const removed = tmdbCacheService.pruneExpired(now);
+
+        expect(removed).toBe(1);
+        const after = JSON.parse(localStorage.getItem(MOVIE_KEY)!);
+        expect(Object.keys(after)).toEqual(['fresh']);
+    });
+
+    it('keeps unstamped (legacy) entries on the first pass but stamps them', () => {
+        const now = 100 * DAY;
+        localStorage.setItem(
+            MOVIE_KEY,
+            JSON.stringify({
+                legacy: { certification: null, genres: [] } // no cachedAt
+            })
+        );
+
+        const removed = tmdbCacheService.pruneExpired(now);
+
+        expect(removed).toBe(0);
+        const after = JSON.parse(localStorage.getItem(MOVIE_KEY)!);
+        expect(after.legacy).toBeDefined();
+        // Now stamped with `now` so a future sweep can expire it.
+        expect(after.legacy.cachedAt).toBe(now);
+
+        // A sweep 31 days later removes the now-stale (previously legacy) entry.
+        const removedLater = tmdbCacheService.pruneExpired(now + 31 * DAY);
+        expect(removedLater).toBe(1);
+        expect(localStorage.getItem(MOVIE_KEY)).toBe('{}');
+    });
+
+    it('sweeps both the movie and series caches', () => {
+        const now = 100 * DAY;
+        localStorage.setItem(
+            MOVIE_KEY,
+            JSON.stringify({ m: { certification: null, genres: [], cachedAt: now - 40 * DAY } })
+        );
+        localStorage.setItem(
+            SERIES_KEY,
+            JSON.stringify({ s: { certification: null, genres: [], cachedAt: now - 40 * DAY } })
+        );
+
+        const removed = tmdbCacheService.pruneExpired(now);
+
+        expect(removed).toBe(2);
+        expect(localStorage.getItem(MOVIE_KEY)).toBe('{}');
+        expect(localStorage.getItem(SERIES_KEY)).toBe('{}');
+    });
+
+    it('is idempotent — a second immediate pass removes nothing new', () => {
+        const now = 100 * DAY;
+        localStorage.setItem(
+            MOVIE_KEY,
+            JSON.stringify({
+                old: { certification: 'R', genres: [], cachedAt: now - 31 * DAY },
+                fresh: { certification: 'PG', genres: [], cachedAt: now - 1 * DAY }
+            })
+        );
+
+        expect(tmdbCacheService.pruneExpired(now)).toBe(1);
+        expect(tmdbCacheService.pruneExpired(now)).toBe(0);
+    });
+});

--- a/src/services/tmdbCacheService.ts
+++ b/src/services/tmdbCacheService.ts
@@ -233,5 +233,49 @@ export const tmdbCacheService = {
     clearCache(): void {
         localStorage.removeItem(MOVIE_CACHE_KEY);
         localStorage.removeItem(SERIES_CACHE_KEY);
+    },
+
+    /**
+     * Drop expired entries from the movie/series name caches.
+     *
+     * Both caches grow one entry per VOD title seen (including "not found"
+     * misses) and are never compacted — reads honour the 30-day TTL but stale
+     * entries linger in localStorage forever. This sweeps each cache:
+     *   - entries past CACHE_EXPIRY_DAYS are deleted;
+     *   - legacy entries without a `cachedAt` are kept once but stamped with
+     *     `now`, so they become eligible for expiry on a later sweep (matches
+     *     the indexedDBCache "treat-once-then-stamp" convention).
+     *
+     * Pure-ish and idempotent: a second call right after the first removes
+     * nothing new. Returns how many entries were removed across both caches.
+     */
+    pruneExpired(now: number = Date.now()): number {
+        let removed = 0;
+
+        const sweep = (
+            cache: TMDBCache,
+            save: (c: TMDBCache) => void
+        ): void => {
+            let changed = false;
+            for (const key of Object.keys(cache)) {
+                const item = cache[key];
+                if (typeof item?.cachedAt !== 'number') {
+                    // Legacy / unstamped: keep once, stamp so it can expire later.
+                    cache[key] = { ...item, cachedAt: now };
+                    changed = true;
+                    continue;
+                }
+                if (now - item.cachedAt > CACHE_EXPIRY_DAYS * 24 * 60 * 60 * 1000) {
+                    delete cache[key];
+                    removed += 1;
+                    changed = true;
+                }
+            }
+            if (changed) save(cache);
+        };
+
+        sweep(getMovieCache(), saveMovieCache);
+        sweep(getSeriesCache(), saveSeriesCache);
+        return removed;
     }
 };


### PR DESCRIPTION
## 🧹 Limpeza de localStorage

Algumas chaves cresciam sem limite. Adicionei uma **varredura no boot** (no máximo 1×/24h) que poda elas, com a lógica em cada serviço dono:

- **`series_episode_data_${profileId}`** — remove séries que não são mais monitoradas (não estão nos favoritos e sem progresso)
- **`epg_test_results`** — limpa se o snapshot tem >7 dias (nunca mexe num teste em andamento)
- **cache TMDB** (`tmdb_cache_movies/_series`) — TTL de 30 dias (igual ao indexedDBCache); entradas antigas sem timestamp são mantidas uma vez e carimbadas

Orquestrador `runStorageCleanup()` com try/catch por poda e import lazy, ligado no boot junto do cleanup do IndexedDB. As chaves de progresso/favoritos **não foram tocadas** (são de outros PRs).

### Verificação
tsc / eslint / vitest **244/244** (18 novos) / vite build ✅

> Rodada 9, PR 2/4.