### PR TITLE
feat: favoritos/histórico/progresso por playlist (não só por perfil)

### DIFF
--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -9,6 +9,7 @@ import {
     activatePlaylist,
     deactivatePlaylists,
     findPlaylist,
+    getActivePlaylistIdPublic,
     listPublicPlaylists,
     migratePlaylistsOnStartup,
     removePlaylist,
@@ -142,6 +143,13 @@ export function setupIpcHandlers() {
 
     ipcMain.handle('playlists:list', () => {
         return { success: true, playlists: listPublicPlaylists() }
+    })
+
+    // Synchronous-ish read of the active playlist id. The renderer namespaces
+    // per-profile user-state (favorites / watch progress) by it so stream ids
+    // from different providers don't bleed across playlists.
+    ipcMain.handle('playlists:get-active-id', () => {
+        return { id: getActivePlaylistIdPublic() }
     })
 
     ipcMain.handle('playlists:add', async (_, { name, url, username, password }) => {

--- a/electron/playlistManager.ts
+++ b/electron/playlistManager.ts
@@ -25,6 +25,11 @@ function getActivePlaylistId(): string | undefined {
     return store.get('activePlaylistId')
 }
 
+/** Public read of the active playlist id (renderer scopes per-playlist user-state by it). */
+export function getActivePlaylistIdPublic(): string | null {
+    return getActivePlaylistId() ?? null
+}
+
 /** Point the legacy `auth` mirror at one playlist (or clear it). */
 function mirrorAuth(entry: PlaylistEntry | null) {
     if (entry) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -69,6 +69,7 @@ const invokeChannels = new Set([
     'pip:getState',
     'pip:open',
     'playlists:add',
+    'playlists:get-active-id',
     'playlists:list',
     'playlists:remove',
     'playlists:rename',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { CustomTitleBar } from './components/CustomTitleBar';
 import { profileService } from './services/profileService';
 import { reminderService } from './services/reminderService';
 import { movieProgressService } from './services/movieProgressService';
+import { activePlaylistService } from './services/activePlaylistService';
 import { useState, useEffect, lazy, Suspense } from 'react';
 
 const Home = lazy(() => import('./pages/Home').then(m => ({ default: m.Home })));
@@ -77,32 +78,37 @@ function App() {
       runStorageCleanup()
     );
 
-    // Initialize profile service (migrate old data if needed)
-    profileService.initialize();
+    const boot = async () => {
+      // Resolve the active playlist id FIRST so per-(profile,playlist) scoping
+      // and the per-profile→per-playlist migrations below run with a known id
+      // (a playlist switch reloads the app, so this re-runs each boot).
+      await activePlaylistService.init();
 
-    // One-time: split the legacy global movie-progress key into per-profile
-    // keys (no-op once migrated). Runs after profiles exist.
-    movieProgressService.migrateLegacyGlobalProgress();
+      // Initialize profile service (migrate old data if needed)
+      profileService.initialize();
 
-    // Check if there's an active profile
-    const activeProfile = profileService.getActiveProfile();
-    setProfileSelected(!!activeProfile);
+      // One-time: split the legacy global movie-progress key into per-profile
+      // keys (no-op once migrated). Runs after profiles exist.
+      movieProgressService.migrateLegacyGlobalProgress();
 
-    // Then check auth
-    checkAuth();
+      // Check if there's an active profile
+      const activeProfile = profileService.getActiveProfile();
+      setProfileSelected(!!activeProfile);
+
+      // Then check auth
+      try {
+        const result = await window.ipcRenderer.invoke('auth:check');
+        setIsAuthenticated(result.authenticated);
+      } catch (error) {
+        console.error('Failed to check auth:', error);
+        setIsAuthenticated(false);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void boot();
   }, []);
-
-  const checkAuth = async () => {
-    try {
-      const result = await window.ipcRenderer.invoke('auth:check');
-      setIsAuthenticated(result.authenticated);
-    } catch (error) {
-      console.error('Failed to check auth:', error);
-      setIsAuthenticated(false);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleProfileSelected = () => {
     setProfileSelected(true);

--- a/src/services/activePlaylistService.test.ts
+++ b/src/services/activePlaylistService.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    init,
+    getActivePlaylistId,
+    hasKnownPlaylistId,
+    playlistScopedKey,
+} from './activePlaylistService';
+
+const MIRROR_KEY = 'neostream_active_playlist_id';
+
+// Reset the module-level cache between tests by re-importing fresh. Vitest
+// caches modules per file, so we instead drive state through init() + the
+// localStorage mirror, and ensure a clean mirror each test.
+describe('activePlaylistService', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        vi.unstubAllGlobals();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    function stubInvoke(result: unknown) {
+        vi.stubGlobal('window', {
+            ipcRenderer: { invoke: vi.fn().mockResolvedValue(result) },
+        });
+    }
+
+    it('init caches the id from IPC and mirrors it to localStorage', async () => {
+        stubInvoke({ id: 'plX' });
+        await init();
+        expect(getActivePlaylistId()).toBe('plX');
+        expect(localStorage.getItem(MIRROR_KEY)).toBe('plX');
+        expect(hasKnownPlaylistId()).toBe(true);
+    });
+
+    it('init with null id drops the mirror and falls back to default', async () => {
+        localStorage.setItem(MIRROR_KEY, 'stale');
+        stubInvoke({ id: null });
+        await init();
+        // module var is null, mirror removed → 'default'
+        expect(localStorage.getItem(MIRROR_KEY)).toBeNull();
+        expect(getActivePlaylistId()).toBe('default');
+        expect(hasKnownPlaylistId()).toBe(false);
+    });
+
+    it('getActivePlaylistId falls back to the localStorage mirror, then default', async () => {
+        // After an init that nulls the cache, a later mirror write is still read.
+        stubInvoke({ id: null });
+        await init();
+        localStorage.setItem(MIRROR_KEY, 'plMirror');
+        expect(getActivePlaylistId()).toBe('plMirror');
+
+        localStorage.removeItem(MIRROR_KEY);
+        expect(getActivePlaylistId()).toBe('default');
+    });
+
+    it('playlistScopedKey composes base, profile, and active playlist id', async () => {
+        stubInvoke({ id: 'plK' });
+        await init();
+        expect(playlistScopedKey('favs', 'profile7')).toBe('favs_profile7__pl_plK');
+    });
+
+    it('init tolerates IPC failure (keeps prior mirror)', async () => {
+        localStorage.setItem(MIRROR_KEY, 'kept');
+        vi.stubGlobal('window', {
+            ipcRenderer: { invoke: vi.fn().mockRejectedValue(new Error('boom')) },
+        });
+        await init();
+        expect(getActivePlaylistId()).toBe('kept');
+    });
+});

--- a/src/services/activePlaylistService.ts
+++ b/src/services/activePlaylistService.ts
@@ -1,0 +1,80 @@
+// Active-playlist accessor for the renderer.
+//
+// Per-profile user-state (favorites, movie/series watch progress) is ALSO
+// namespaced by the active playlist, because stream ids are not stable across
+// providers — the same numeric id means different content on each playlist, so
+// a global-per-profile scope would bleed favorites/progress between providers.
+//
+// Switching a playlist reloads the whole app (see playlistService), so the
+// active id is fixed for the lifetime of a boot. We fetch it once at boot via
+// IPC, cache it in a module variable, and mirror it to localStorage so the
+// synchronous getter below can answer even before init() resolves (e.g. a
+// content page that mounts in the same tick).
+
+const MIRROR_KEY = 'neostream_active_playlist_id';
+const FALLBACK = 'default';
+
+let cachedId: string | null = null;
+
+/**
+ * Fetch the active playlist id from the main process, cache it, and mirror it
+ * to localStorage. Re-runs each boot (a playlist switch reloads the app). Best
+ * effort: failures leave the previous mirror in place.
+ */
+export async function init(): Promise<void> {
+    // Re-resolve from scratch each boot; if the IPC fails we fall back to the
+    // localStorage mirror rather than a stale in-memory id.
+    cachedId = null;
+    try {
+        const result = await window.ipcRenderer.invoke('playlists:get-active-id');
+        const id = result && typeof result.id === 'string' ? result.id : null;
+        cachedId = id;
+        if (id) {
+            localStorage.setItem(MIRROR_KEY, id);
+        } else {
+            // No active playlist (logged out / none): drop the stale mirror so
+            // we fall back to FALLBACK instead of a previous playlist's id.
+            localStorage.removeItem(MIRROR_KEY);
+        }
+    } catch {
+        // Keep whatever the mirror already had; getActivePlaylistId() handles it.
+    }
+}
+
+/**
+ * The active playlist id, SYNCHRONOUSLY. Resolution order:
+ *   1. module variable (set by init this boot)
+ *   2. localStorage mirror (set by a previous init)
+ *   3. 'default' fallback (no playlist known yet)
+ */
+export function getActivePlaylistId(): string {
+    if (cachedId) return cachedId;
+    try {
+        const mirrored = localStorage.getItem(MIRROR_KEY);
+        if (mirrored) return mirrored;
+    } catch {
+        /* localStorage unavailable — fall through */
+    }
+    return FALLBACK;
+}
+
+/** True when a real playlist id is known (not the 'default' race fallback). */
+export function hasKnownPlaylistId(): boolean {
+    return getActivePlaylistId() !== FALLBACK;
+}
+
+/**
+ * Build a localStorage key scoped to both a profile and the active playlist:
+ *   `${base}_${profileId}__pl_${activePlaylistId}`
+ * The existing `${base}_${profileId}` form is kept as the migration source.
+ */
+export function playlistScopedKey(base: string, profileId: string): string {
+    return `${base}_${profileId}__pl_${getActivePlaylistId()}`;
+}
+
+export const activePlaylistService = {
+    init,
+    getActivePlaylistId,
+    hasKnownPlaylistId,
+    playlistScopedKey,
+};

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -26,16 +26,16 @@ const EXACT_KEYS = [
     'neostream_profiles',     // profiles + active profile + watch-later lists
     'neostream_language',     // UI language
     'parentalConfig',         // parental control config (PIN hash included)
-    'movie_watch_progress',   // movie resume positions
     'playerVolume',           // last player volume
     'watchLater',             // legacy pre-profile watch-later list
 ];
 
 // Keys included when they start with one of these prefixes
 const PREFIX_KEYS = [
-    'neostream_profile_',     // per-profile data (favorites)
+    'neostream_profile_',     // per-profile favorites, incl. _<profileId>__pl_<playlistId>
     'playbackConfig',         // playbackConfig and playbackConfig_<profileId>
-    'series_watch_progress',  // series_watch_progress and _<profileId>
+    'movie_watch_progress',   // movie resume positions, incl. per-(profile,playlist)
+    'series_watch_progress',  // series progress, incl. per-(profile,playlist)
     'usage_stats',            // usage_stats_<profileId> / usage_stats_default
 ];
 

--- a/src/services/favoritesService.test.ts
+++ b/src/services/favoritesService.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let activeId: string | null = 'p1';
+vi.mock('./profileService', () => ({
+    profileService: {
+        getActiveProfile: () => (activeId ? { id: activeId } : null)
+    }
+}));
+
+let playlistId = 'plA';
+vi.mock('./activePlaylistService', () => ({
+    getActivePlaylistId: () => playlistId,
+    hasKnownPlaylistId: () => playlistId !== 'default',
+    playlistScopedKey: (base: string, profileId: string) =>
+        `${base}_${profileId}__pl_${playlistId}`
+}));
+
+import { favoritesService } from './favoritesService';
+
+const fav = (id: string) => ({
+    id, type: 'movie' as const, title: 'T', poster: 'p'
+});
+
+describe('favoritesService — per-playlist scoping', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        activeId = 'p1';
+        playlistId = 'plA';
+    });
+
+    it('a favorite added under playlist A is not present under B; present again under A', () => {
+        playlistId = 'plA';
+        expect(favoritesService.add(fav('m1'))).toBe(true);
+        expect(favoritesService.has('m1', 'movie')).toBe(true);
+
+        playlistId = 'plB';
+        expect(favoritesService.has('m1', 'movie')).toBe(false);
+        expect(favoritesService.getAll()).toEqual([]);
+
+        playlistId = 'plA';
+        expect(favoritesService.has('m1', 'movie')).toBe(true);
+        expect(localStorage.getItem('neostream_profile_p1__pl_plA')).toBeTruthy();
+        expect(localStorage.getItem('neostream_profile_p1__pl_plB')).toBeNull();
+    });
+
+    it('isolates favorites across profiles too', () => {
+        activeId = 'p1';
+        favoritesService.add(fav('m1'));
+        activeId = 'p2';
+        expect(favoritesService.has('m1', 'movie')).toBe(false);
+    });
+});
+
+describe('favoritesService — per-profile → per-playlist migration', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        activeId = 'p1';
+        playlistId = 'plA';
+    });
+
+    it('copies the legacy per-profile key into the active playlist scope, then removes it', () => {
+        localStorage.setItem('neostream_profile_p1', JSON.stringify({ favorites: [{ ...fav('m1'), addedAt: 'x' }] }));
+
+        // Any access migrates.
+        expect(favoritesService.has('m1', 'movie')).toBe(true);
+
+        expect(localStorage.getItem('neostream_profile_p1')).toBeNull();
+        const scoped = JSON.parse(localStorage.getItem('neostream_profile_p1__pl_plA')!);
+        expect(scoped.favorites.map((f: { id: string }) => f.id)).toEqual(['m1']);
+    });
+
+    it('is idempotent and does not clobber existing scoped favorites', () => {
+        localStorage.setItem('neostream_profile_p1__pl_plA', JSON.stringify({ favorites: [{ ...fav('keep'), addedAt: 'x' }] }));
+        localStorage.setItem('neostream_profile_p1', JSON.stringify({ favorites: [{ ...fav('old'), addedAt: 'x' }] }));
+
+        favoritesService.getAll(); // migrate
+        favoritesService.getAll(); // no-op
+
+        expect(localStorage.getItem('neostream_profile_p1')).toBeNull();
+        const scoped = JSON.parse(localStorage.getItem('neostream_profile_p1__pl_plA')!);
+        expect(scoped.favorites.map((f: { id: string }) => f.id)).toEqual(['keep']);
+    });
+
+    it('is skipped while the active playlist id is unknown (default fallback)', () => {
+        playlistId = 'default';
+        localStorage.setItem('neostream_profile_p1', JSON.stringify({ favorites: [{ ...fav('m1'), addedAt: 'x' }] }));
+
+        favoritesService.getAll();
+
+        expect(localStorage.getItem('neostream_profile_p1')).toBeTruthy();
+        expect(localStorage.getItem('neostream_profile_p1__pl_default')).toBeNull();
+    });
+});

--- a/src/services/favoritesService.ts
+++ b/src/services/favoritesService.ts
@@ -1,5 +1,11 @@
 // Favorites localStorage utility (adapted for profiles)
 import { profileService } from './profileService';
+import { playlistScopedKey, hasKnownPlaylistId } from './activePlaylistService';
+
+// localStorage key base. Per-profile per-playlist key is
+// `neostream_profile_${profileId}__pl_${activePlaylistId}`; the legacy
+// per-profile-only key `neostream_profile_${profileId}` is the migration source.
+const KEY_BASE = 'neostream_profile';
 
 export interface FavoriteItem {
     id: string;
@@ -101,13 +107,14 @@ export const favoritesService = {
         this.saveProfileData({ ...profileData, favorites: [] });
     },
 
-    // Get profile data from localStorage
+    // Get profile data from localStorage (per-profile per-playlist key)
     getProfileData(): FavoriteProfileData {
         const activeProfile = profileService.getActiveProfile();
         if (!activeProfile) return {};
 
+        this.migrate();
         try {
-            const key = `neostream_profile_${activeProfile.id}`;
+            const key = playlistScopedKey(KEY_BASE, activeProfile.id);
             const data = localStorage.getItem(key);
             return data ? JSON.parse(data) as FavoriteProfileData : {};
         } catch {
@@ -115,12 +122,35 @@ export const favoritesService = {
         }
     },
 
-    // Save profile data to localStorage
+    // Save profile data to localStorage (per-profile per-playlist key)
     saveProfileData(data: FavoriteProfileData): void {
         const activeProfile = profileService.getActiveProfile();
         if (!activeProfile) return;
 
-        const key = `neostream_profile_${activeProfile.id}`;
+        const key = playlistScopedKey(KEY_BASE, activeProfile.id);
         localStorage.setItem(key, JSON.stringify(data));
+    },
+
+    /**
+     * One-time, idempotent migration: copy the legacy per-profile-only key
+     * `neostream_profile_${profileId}` into the per-(profile,playlist) key for
+     * the CURRENT active playlist (the only playlist data existed under until
+     * now), then remove the old key. Skipped while the active playlist id is
+     * unknown ('default' race) — it re-runs next access once known.
+     */
+    migrate(): void {
+        const activeProfile = profileService.getActiveProfile();
+        if (!activeProfile) return;
+        if (!hasKnownPlaylistId()) return;
+
+        const oldKey = `${KEY_BASE}_${activeProfile.id}`;
+        const old = localStorage.getItem(oldKey);
+        if (old === null) return;
+
+        const newKey = playlistScopedKey(KEY_BASE, activeProfile.id);
+        if (localStorage.getItem(newKey) === null) {
+            localStorage.setItem(newKey, old);
+        }
+        localStorage.removeItem(oldKey);
     }
 };

--- a/src/services/movieProgressService.test.ts
+++ b/src/services/movieProgressService.test.ts
@@ -8,6 +8,18 @@ vi.mock('./profileService', () => ({
     }
 }));
 
+// Mock the active playlist so keys are scoped to a known playlist id. Defaults
+// to 'plA'; tests flip it to assert per-playlist isolation. With a known id,
+// the per-profile→per-playlist migration runs and storage keys become
+// `movie_watch_progress_${profileId}__pl_${playlistId}`.
+let playlistId = 'plA';
+vi.mock('./activePlaylistService', () => ({
+    getActivePlaylistId: () => playlistId,
+    hasKnownPlaylistId: () => playlistId !== 'default',
+    playlistScopedKey: (base: string, profileId: string) =>
+        `${base}_${profileId}__pl_${playlistId}`
+}));
+
 import { movieProgressService, type MovieProgress } from './movieProgressService';
 
 const entry = (over: Partial<MovieProgress> & { movieId: string; profileId: string }): MovieProgress => ({
@@ -24,6 +36,7 @@ describe('movieProgressService — per-profile', () => {
     beforeEach(() => {
         localStorage.clear();
         activeId = 'p1';
+        playlistId = 'plA';
     });
 
     it('keys progress per profile (no leak across profiles)', () => {
@@ -35,8 +48,8 @@ describe('movieProgressService — per-profile', () => {
 
         activeId = 'p1';
         expect(movieProgressService.getMoviePositionById('m1')?.movieId).toBe('m1');
-        expect(localStorage.getItem('movie_watch_progress_p1')).toBeTruthy();
-        expect(localStorage.getItem('movie_watch_progress_p2')).toBeNull();
+        expect(localStorage.getItem('movie_watch_progress_p1__pl_plA')).toBeTruthy();
+        expect(localStorage.getItem('movie_watch_progress_p2__pl_plA')).toBeNull();
     });
 
     it('classifies in-progress vs watched by percentage', () => {
@@ -61,10 +74,77 @@ describe('movieProgressService — per-profile', () => {
     });
 });
 
+describe('movieProgressService — per-playlist isolation', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        activeId = 'p1';
+        playlistId = 'plA';
+    });
+
+    it('progress saved under playlist A is not visible under playlist B', () => {
+        playlistId = 'plA';
+        movieProgressService.saveMovieTime('m1', 'Filme 1', 50, 100);
+        expect(movieProgressService.getMoviePositionById('m1')?.movieId).toBe('m1');
+
+        playlistId = 'plB';
+        expect(movieProgressService.getMoviePositionById('m1')).toBeNull();
+        expect(movieProgressService.getMoviesInProgress()).toEqual([]);
+
+        playlistId = 'plA';
+        expect(movieProgressService.getMoviePositionById('m1')?.movieId).toBe('m1');
+        expect(localStorage.getItem('movie_watch_progress_p1__pl_plA')).toBeTruthy();
+        expect(localStorage.getItem('movie_watch_progress_p1__pl_plB')).toBeNull();
+    });
+});
+
+describe('movieProgressService — per-profile → per-playlist migration', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        activeId = 'p1';
+        playlistId = 'plA';
+    });
+
+    it('copies the per-profile key into the active playlist scope, then removes it', () => {
+        localStorage.setItem('movie_watch_progress_p1', JSON.stringify([entry({ movieId: 'm1', profileId: 'p1' })]));
+
+        // Any read triggers getStorageKey() → migration.
+        expect(movieProgressService.getMoviePositionById('m1')?.movieId).toBe('m1');
+
+        expect(localStorage.getItem('movie_watch_progress_p1')).toBeNull();
+        const scoped = JSON.parse(localStorage.getItem('movie_watch_progress_p1__pl_plA')!);
+        expect(scoped.map((e: MovieProgress) => e.movieId)).toEqual(['m1']);
+    });
+
+    it('is idempotent and does not clobber existing scoped data', () => {
+        localStorage.setItem('movie_watch_progress_p1__pl_plA', JSON.stringify([entry({ movieId: 'keep', profileId: 'p1' })]));
+        localStorage.setItem('movie_watch_progress_p1', JSON.stringify([entry({ movieId: 'old', profileId: 'p1' })]));
+
+        movieProgressService.getMoviesInProgress(); // triggers migration
+        movieProgressService.getMoviesInProgress(); // again — no-op
+
+        expect(localStorage.getItem('movie_watch_progress_p1')).toBeNull();
+        const scoped = JSON.parse(localStorage.getItem('movie_watch_progress_p1__pl_plA')!);
+        // Existing scoped data preserved (old per-profile key NOT copied over it).
+        expect(scoped.map((e: MovieProgress) => e.movieId)).toEqual(['keep']);
+    });
+
+    it('is skipped while the active playlist id is unknown (default fallback)', () => {
+        playlistId = 'default';
+        localStorage.setItem('movie_watch_progress_p1', JSON.stringify([entry({ movieId: 'm1', profileId: 'p1' })]));
+
+        movieProgressService.getMoviesInProgress();
+
+        // Old per-profile key untouched; nothing migrated to a scoped key.
+        expect(localStorage.getItem('movie_watch_progress_p1')).toBeTruthy();
+        expect(localStorage.getItem('movie_watch_progress_p1__pl_default')).toBeNull();
+    });
+});
+
 describe('movieProgressService — legacy migration', () => {
     beforeEach(() => {
         localStorage.clear();
         activeId = 'p1';
+        playlistId = 'plA';
     });
 
     it('splits the global key into per-profile keys, newest wins, and removes the legacy key', () => {

--- a/src/services/movieProgressService.ts
+++ b/src/services/movieProgressService.ts
@@ -1,4 +1,5 @@
 import { profileService } from './profileService';
+import { playlistScopedKey, hasKnownPlaylistId } from './activePlaylistService';
 
 export interface MovieProgress {
     movieId: string;
@@ -21,9 +22,29 @@ class MovieProgressService {
 
     private getStorageKey(): string {
         const activeProfile = profileService.getActiveProfile();
-        return activeProfile
-            ? `${this.STORAGE_KEY_PREFIX}_${activeProfile.id}`
-            : this.STORAGE_KEY_PREFIX; // fallback (no active profile)
+        if (!activeProfile) return this.STORAGE_KEY_PREFIX; // fallback (no active profile)
+        this.migratePerProfileToPlaylist(activeProfile.id);
+        return playlistScopedKey(this.STORAGE_KEY_PREFIX, activeProfile.id);
+    }
+
+    /**
+     * One-time, idempotent migration: copy the per-profile-only key
+     * `movie_watch_progress_${profileId}` into the per-(profile,playlist) key
+     * for the CURRENT active playlist, then remove the old key. Skipped while
+     * the active playlist id is unknown ('default' race) — re-runs next access.
+     */
+    private migratePerProfileToPlaylist(profileId: string): void {
+        if (!hasKnownPlaylistId()) return;
+
+        const oldKey = `${this.STORAGE_KEY_PREFIX}_${profileId}`;
+        const old = localStorage.getItem(oldKey);
+        if (old === null) return;
+
+        const newKey = playlistScopedKey(this.STORAGE_KEY_PREFIX, profileId);
+        if (localStorage.getItem(newKey) === null) {
+            localStorage.setItem(newKey, old);
+        }
+        localStorage.removeItem(oldKey);
     }
 
     // Get all movie progress for the active profile

--- a/src/services/watchProgressService.test.ts
+++ b/src/services/watchProgressService.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let activeId: string | null = 'p1';
+vi.mock('./profileService', () => ({
+    profileService: {
+        getActiveProfile: () => (activeId ? { id: activeId } : null)
+    }
+}));
+
+let playlistId = 'plA';
+vi.mock('./activePlaylistService', () => ({
+    getActivePlaylistId: () => playlistId,
+    hasKnownPlaylistId: () => playlistId !== 'default',
+    playlistScopedKey: (base: string, profileId: string) =>
+        `${base}_${profileId}__pl_${playlistId}`
+}));
+
+import { watchProgressService, type EpisodeProgress } from './watchProgressService';
+
+describe('watchProgressService — per-playlist scoping', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        activeId = 'p1';
+        playlistId = 'plA';
+    });
+
+    it('progress under playlist A is not visible under B; back under A it returns', () => {
+        playlistId = 'plA';
+        watchProgressService.markEpisodeWatched('s1', 1, 1);
+        expect(watchProgressService.isEpisodeWatched('s1', 1, 1)).toBe(true);
+
+        playlistId = 'plB';
+        expect(watchProgressService.isEpisodeWatched('s1', 1, 1)).toBe(false);
+        expect(watchProgressService.getEpisodeHistory()).toEqual([]);
+
+        playlistId = 'plA';
+        expect(watchProgressService.isEpisodeWatched('s1', 1, 1)).toBe(true);
+        expect(localStorage.getItem('series_watch_progress_p1__pl_plA')).toBeTruthy();
+        expect(localStorage.getItem('series_watch_progress_p1__pl_plB')).toBeNull();
+    });
+});
+
+describe('watchProgressService — per-profile → per-playlist migration', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        activeId = 'p1';
+        playlistId = 'plA';
+    });
+
+    const ep = (over: Partial<EpisodeProgress> = {}): EpisodeProgress => ({
+        seriesId: 's1', seasonNumber: 1, episodeNumber: 1, profileId: 'p1',
+        watchedAt: 1000, completed: true, ...over
+    });
+
+    it('copies the legacy per-profile key into the active playlist scope, then removes it', () => {
+        localStorage.setItem('series_watch_progress_p1', JSON.stringify([ep()]));
+
+        expect(watchProgressService.isEpisodeWatched('s1', 1, 1)).toBe(true);
+
+        expect(localStorage.getItem('series_watch_progress_p1')).toBeNull();
+        const scoped = JSON.parse(localStorage.getItem('series_watch_progress_p1__pl_plA')!);
+        expect(scoped).toHaveLength(1);
+    });
+
+    it('is idempotent and does not clobber existing scoped data', () => {
+        localStorage.setItem('series_watch_progress_p1__pl_plA', JSON.stringify([ep({ seriesId: 'keep' })]));
+        localStorage.setItem('series_watch_progress_p1', JSON.stringify([ep({ seriesId: 'old' })]));
+
+        watchProgressService.getEpisodeHistory();
+        watchProgressService.getEpisodeHistory();
+
+        expect(localStorage.getItem('series_watch_progress_p1')).toBeNull();
+        const scoped = JSON.parse(localStorage.getItem('series_watch_progress_p1__pl_plA')!);
+        expect(scoped.map((e: EpisodeProgress) => e.seriesId)).toEqual(['keep']);
+    });
+
+    it('is skipped while the active playlist id is unknown (default fallback)', () => {
+        playlistId = 'default';
+        localStorage.setItem('series_watch_progress_p1', JSON.stringify([ep()]));
+
+        watchProgressService.getEpisodeHistory();
+
+        expect(localStorage.getItem('series_watch_progress_p1')).toBeTruthy();
+        expect(localStorage.getItem('series_watch_progress_p1__pl_default')).toBeNull();
+    });
+});

--- a/src/services/watchProgressService.ts
+++ b/src/services/watchProgressService.ts
@@ -1,4 +1,5 @@
 import { profileService } from './profileService';
+import { playlistScopedKey, hasKnownPlaylistId } from './activePlaylistService';
 
 export interface EpisodeProgress {
     seriesId: string;
@@ -23,13 +24,32 @@ export interface SeriesProgress {
 class WatchProgressService {
     private STORAGE_KEY_PREFIX = 'series_watch_progress';
 
-    // Get storage key for current profile
+    // Get storage key for current profile (per-profile per-playlist)
     private getStorageKey(): string {
         const activeProfile = profileService.getActiveProfile();
-        if (activeProfile) {
-            return `${this.STORAGE_KEY_PREFIX}_${activeProfile.id}`;
+        if (!activeProfile) return this.STORAGE_KEY_PREFIX; // Fallback for no profile
+        this.migratePerProfileToPlaylist(activeProfile.id);
+        return playlistScopedKey(this.STORAGE_KEY_PREFIX, activeProfile.id);
+    }
+
+    /**
+     * One-time, idempotent migration: copy the per-profile-only key
+     * `series_watch_progress_${profileId}` into the per-(profile,playlist) key
+     * for the CURRENT active playlist, then remove the old key. Skipped while
+     * the active playlist id is unknown ('default' race) — re-runs next access.
+     */
+    private migratePerProfileToPlaylist(profileId: string): void {
+        if (!hasKnownPlaylistId()) return;
+
+        const oldKey = `${this.STORAGE_KEY_PREFIX}_${profileId}`;
+        const old = localStorage.getItem(oldKey);
+        if (old === null) return;
+
+        const newKey = playlistScopedKey(this.STORAGE_KEY_PREFIX, profileId);
+        if (localStorage.getItem(newKey) === null) {
+            localStorage.setItem(newKey, old);
         }
-        return this.STORAGE_KEY_PREFIX; // Fallback for no profile
+        localStorage.removeItem(oldKey);
     }
 
     // Get all watch progress for current profile


### PR DESCRIPTION
## 📡 Estado de usuário escopado por playlist

Os ids de stream são específicos de cada provedor, então favoritos e progresso (que eram só por perfil) **vazavam entre playlists** — o mesmo id significava outro conteúdo em outro provedor. Agora tudo é namespaceado por **(perfil × playlist ativa)**.

### Como funciona
- IPC novo `playlists:get-active-id` + `activePlaylistService` que pega o id da playlist ativa no boot, cacheia e espelha no localStorage (acesso **síncrono** pros serviços). Trocar de playlist já recarrega o app, então sempre fica fresco.
- Favoritos, progresso de filme e progresso de série ganham sufixo `__pl_<id>`.
- **Migração automática** (idempotente): copia a chave antiga por-perfil pra chave escopada da playlist atual (a única em que os dados existiam até agora), depois remove a antiga. Com guarda de corrida (pula se o id ainda não é conhecido).
- Backup ajustado pra capturar as chaves novas.

### Decisão sobre "assistir depois"
Ficou **por perfil** — ele vive dentro do objeto de perfis (não é uma chave separada), e escopá-lo por playlist exigiria reestruturar esse store. Documentado como limitação por ora.

### Verificação
tsc / eslint / vitest **269/269** (4 arquivos de teste novos) / vite build / Playwright **15/15** ✅

> Rodada 9, PR 3/4. Falta só os EPG mappings.