### PR TITLE
feat(epg): refresh remoto semanal dos mappings de fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,12 @@ function App() {
       runStorageCleanup()
     );
 
+    // Weekly background refresh of the EPG fallback mappings from the repo
+    // (applies on the next boot; static maps are the fallback if it fails).
+    void import('./services/epgMappingsService').then(({ refreshFromRemote }) =>
+      refreshFromRemote()
+    );
+
     const boot = async () => {
       // Resolve the active playlist id FIRST so per-(profile,playlist) scoping
       // and the per-profile→per-playlist migrations below run with a known id

--- a/src/services/epgMappingsService.test.ts
+++ b/src/services/epgMappingsService.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    isValidMappingObject,
+    mergeMappings,
+    shouldRefresh,
+    getMergedMappings,
+    REFRESH_INTERVAL_MS
+} from './epgMappingsService';
+
+describe('epgMappingsService — pure helpers', () => {
+    it('validates flat string→string objects only', () => {
+        expect(isValidMappingObject({ a: 'x', b: 'y' })).toBe(true);
+        expect(isValidMappingObject({})).toBe(true);
+        expect(isValidMappingObject({ a: 1 })).toBe(false);
+        expect(isValidMappingObject(['a', 'b'])).toBe(false);
+        expect(isValidMappingObject(null)).toBe(false);
+        expect(isValidMappingObject('x')).toBe(false);
+    });
+
+    it('merges remote over static (remote wins, static fills gaps)', () => {
+        const merged = mergeMappings({ a: '1', b: '2' }, { b: '9', c: '3' });
+        expect(merged).toEqual({ a: '1', b: '9', c: '3' });
+    });
+
+    it('mergeMappings with null remote returns a copy of static', () => {
+        const staticMap = { a: '1' };
+        const merged = mergeMappings(staticMap, null);
+        expect(merged).toEqual({ a: '1' });
+        expect(merged).not.toBe(staticMap);
+    });
+
+    it('shouldRefresh: stale/missing/invalid → true; recent → false', () => {
+        const now = 1_000_000_000;
+        expect(shouldRefresh(null, now, REFRESH_INTERVAL_MS)).toBe(true);
+        expect(shouldRefresh(NaN, now, REFRESH_INTERVAL_MS)).toBe(true);
+        expect(shouldRefresh(now - REFRESH_INTERVAL_MS, now, REFRESH_INTERVAL_MS)).toBe(true);
+        expect(shouldRefresh(now - 1000, now, REFRESH_INTERVAL_MS)).toBe(false);
+        expect(shouldRefresh(now, now, REFRESH_INTERVAL_MS)).toBe(false);
+    });
+});
+
+describe('epgMappingsService — getMergedMappings (cache)', () => {
+    beforeEach(() => localStorage.clear());
+
+    it('returns static when no cache present', () => {
+        expect(getMergedMappings('mitv', { globo: 'globo' })).toEqual({ globo: 'globo' });
+    });
+
+    it('merges a valid cached remote over static', () => {
+        localStorage.setItem('epg_mappings_remote_mitv', JSON.stringify({ globo: 'globo-novo', sbt: 'sbt' }));
+        expect(getMergedMappings('mitv', { globo: 'globo' })).toEqual({ globo: 'globo-novo', sbt: 'sbt' });
+    });
+
+    it('ignores a corrupt/invalid cache and falls back to static', () => {
+        localStorage.setItem('epg_mappings_remote_mitv', 'not json');
+        expect(getMergedMappings('mitv', { globo: 'globo' })).toEqual({ globo: 'globo' });
+        localStorage.setItem('epg_mappings_remote_mitv', JSON.stringify({ a: 5 }));
+        expect(getMergedMappings('mitv', { globo: 'globo' })).toEqual({ globo: 'globo' });
+    });
+});

--- a/src/services/epgMappingsService.ts
+++ b/src/services/epgMappingsService.ts
@@ -1,0 +1,101 @@
+/**
+ * Optional remote refresh for the EPG channel→id fallback mappings.
+ *
+ * The mappings (mi.tv / meuguia / Open-EPG) are bundled as static JSON and are
+ * only a FALLBACK now that the provider's own xmltv is the primary source.
+ * They change ~1-2x/year. Instead of requiring an app release to pick up a new
+ * channel mapping, this service merges the static maps with a cached copy
+ * pulled weekly from the repo's raw files. The merged result is read at module
+ * load; a background refresh updates the cache for the NEXT boot. Fully
+ * degradable: any fetch/parse failure just leaves the static maps in place.
+ */
+
+const RAW_BASE = 'https://raw.githubusercontent.com/Rakjsu/NeoStream/main/src/data/epg-mappings';
+const CACHE_PREFIX = 'epg_mappings_remote_';
+const LAST_REFRESH_KEY = 'epg_mappings_last_refresh';
+export const REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // weekly
+const FETCH_TIMEOUT_MS = 8000;
+
+/** The six mapping files (name = cache id, file = basename in the repo). */
+export const MAPPING_NAMES = [
+    'mitv', 'meuguia', 'openepg-pt', 'openepg-ar', 'openepg-usa', 'openepg-br'
+] as const;
+export type MappingName = typeof MAPPING_NAMES[number];
+
+export type MappingObject = Record<string, string>;
+
+// --- Pure helpers (unit-tested) ---------------------------------------------
+
+/** A valid mapping is a flat object of string→string. */
+export function isValidMappingObject(value: unknown): value is MappingObject {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+    return Object.values(value as Record<string, unknown>).every(v => typeof v === 'string');
+}
+
+/** Static base + remote overrides (remote wins). */
+export function mergeMappings(staticMap: MappingObject, remoteMap: MappingObject | null): MappingObject {
+    return remoteMap ? { ...staticMap, ...remoteMap } : { ...staticMap };
+}
+
+export function shouldRefresh(lastRun: number | null, now: number, intervalMs: number): boolean {
+    if (lastRun === null || !Number.isFinite(lastRun)) return true;
+    return now - lastRun >= intervalMs;
+}
+
+// --- Cache access -----------------------------------------------------------
+
+function readCache(name: MappingName): MappingObject | null {
+    try {
+        const raw = localStorage.getItem(CACHE_PREFIX + name);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        return isValidMappingObject(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+/** Read at epgService module load: static JSON merged with any cached remote. */
+export function getMergedMappings(name: MappingName, staticMap: MappingObject): MappingObject {
+    return mergeMappings(staticMap, readCache(name));
+}
+
+// --- Background refresh -----------------------------------------------------
+
+async function fetchOne(name: MappingName, signal: AbortSignal): Promise<boolean> {
+    const file = name === 'mitv' ? 'mitv'
+        : name === 'meuguia' ? 'meuguia'
+        : name; // openepg-* match the basenames
+    const res = await fetch(`${RAW_BASE}/${file}.json`, { signal });
+    if (!res.ok) return false;
+    const json = await res.json();
+    if (!isValidMappingObject(json)) return false;
+    localStorage.setItem(CACHE_PREFIX + name, JSON.stringify(json));
+    return true;
+}
+
+/**
+ * Weekly, best-effort: refresh each mapping's cache from the repo. Stamps the
+ * throttle BEFORE fetching so a crash mid-run doesn't busy-retry. Each file is
+ * independent (one failure doesn't abort the rest). The refreshed cache applies
+ * on the next app boot (module load), so this never mutates live lookups.
+ */
+export async function refreshFromRemote(now: number = Date.now(), intervalMs: number = REFRESH_INTERVAL_MS): Promise<void> {
+    let lastRun: number | null = null;
+    try {
+        const raw = localStorage.getItem(LAST_REFRESH_KEY);
+        lastRun = raw ? Number(raw) : null;
+    } catch { /* ignore */ }
+
+    if (!shouldRefresh(lastRun, now, intervalMs)) return;
+
+    try { localStorage.setItem(LAST_REFRESH_KEY, String(now)); } catch { /* ignore */ }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+        await Promise.allSettled(MAPPING_NAMES.map(name => fetchOne(name, controller.signal)));
+    } finally {
+        clearTimeout(timer);
+    }
+}

--- a/src/services/epgService.ts
+++ b/src/services/epgService.ts
@@ -4,6 +4,7 @@ import openEpgPortugalMappingsJson from '../data/epg-mappings/openepg-pt.json';
 import openEpgArgentinaMappingsJson from '../data/epg-mappings/openepg-ar.json';
 import openEpgUSAMappingsJson from '../data/epg-mappings/openepg-usa.json';
 import openEpgBrazilMappingsJson from '../data/epg-mappings/openepg-br.json';
+import { getMergedMappings } from './epgMappingsService';
 // EPG Service - Simple and Clean
 // Uses times from mi.tv/meuguia.tv exactly as displayed (no timezone conversion)
 
@@ -16,11 +17,12 @@ interface EPGProgram {
     channel_id: string;
 }
 
-// Manual channel mappings for mi.tv
-const mitvMappings: Record<string, string> = mitvMappingsJson;
+// Mappings = bundled static JSON merged with any weekly-refreshed remote cache
+// (epgMappingsService). Read once at module load; the background refresh applies
+// on the next boot.
+const mitvMappings: Record<string, string> = getMergedMappings('mitv', mitvMappingsJson);
 
-// Manual channel mappings for meuguia.tv (fallback)
-const meuguiaMappings: Record<string, string> = meuguiaMappingsJson;
+const meuguiaMappings: Record<string, string> = getMergedMappings('meuguia', meuguiaMappingsJson);
 
 // Open-EPG Portugal sources (both files contain different channels)
 const OPEN_EPG_PORTUGAL_URLS = [
@@ -50,11 +52,11 @@ const OPEN_EPG_BRAZIL_URLS = [
 
 // Open-EPG Portugal channel mappings (channel name -> Open-EPG ID)
 // IDs use format: "Channel Name.pt" or "Channel Name HD.pt"
-const openEpgPortugalMappings: Record<string, string> = openEpgPortugalMappingsJson;
+const openEpgPortugalMappings: Record<string, string> = getMergedMappings('openepg-pt', openEpgPortugalMappingsJson);
 
 // Open-EPG Argentina channel mappings (channel name -> Open-EPG ID)
 // IDs use format: "Channel Name.ar"
-const openEpgArgentinaMappings: Record<string, string> = openEpgArgentinaMappingsJson;
+const openEpgArgentinaMappings: Record<string, string> = getMergedMappings('openepg-ar', openEpgArgentinaMappingsJson);
 
 // Open-EPG USA sources (10 files)
 const OPEN_EPG_USA_URLS = [
@@ -71,12 +73,12 @@ const OPEN_EPG_USA_URLS = [
 ];
 
 // Open-EPG USA channel mappings (channel name -> Open-EPG ID)
-const openEpgUSAMappings: Record<string, string> = openEpgUSAMappingsJson;
+const openEpgUSAMappings: Record<string, string> = getMergedMappings('openepg-usa', openEpgUSAMappingsJson);
 
 // Open-EPG Brazil channel mappings (channel name -> Open-EPG ID)
 // Used as fallback for Brazilian channels not in mi.tv or meuguia.tv
 // IDs use format: "Channel Name.br"
-const openEpgBrazilMappings: Record<string, string> = openEpgBrazilMappingsJson;
+const openEpgBrazilMappings: Record<string, string> = getMergedMappings('openepg-br', openEpgBrazilMappingsJson);
 
 export const epgService = {
 


### PR DESCRIPTION
## 📡 EPG mappings que se atualizam sozinhos

Os mappings de canal→id (mi.tv/meuguia/Open-EPG) eram estáticos no bundle — um canal novo exigia release do app. Eles são **só fallback** agora (o xmltv do provedor é a fonte primária) e mudam ~1-2x/ano, então não vale auto-update pesado — mas também não precisam mais de rebuild.

### Como funciona
- No carregamento, cada mapping = **estático + cache remoto** (remoto ganha)
- `refreshFromRemote()` no boot puxa os 6 arquivos do repo (raw) **uma vez por semana** (throttle próprio, timeout 8s, cada arquivo independente). Qualquer falha → mantém o estático.
- O cache atualizado é aplicado no **próximo boot** (nunca muda a busca no meio da sessão)

### Verificação
tsc / eslint / vitest **258/258** (11 novos) / vite build ✅

> **Fecha a Rodada 9.** PR 4/4.