### PR TITLE
feat: error boundaries por página (fallback gracioso)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { HashRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { HashRouter, Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { Welcome } from './pages/Welcome';
 import { Login } from './pages/Login';
 import { Dashboard } from './pages/Dashboard';
@@ -57,6 +58,14 @@ function ProgramReminderBridge() {
 function EpisodeToastWithNavigation() {
   const navigate = useNavigate();
   return <EpisodeToast onNavigateToSeries={(seriesId) => navigate(`/dashboard/series?id=${seriesId}`)} />;
+}
+
+// Wraps a route element in an error boundary that auto-resets on navigation
+// (keyed by pathname), so a render crash in one page shows a fallback without
+// taking down the shell.
+function RouteBoundary({ name, children }: { name: string; children: React.ReactNode }) {
+  const location = useLocation();
+  return <ErrorBoundary name={name} resetKey={location.pathname}>{children}</ErrorBoundary>;
 }
 
 function App() {
@@ -145,24 +154,24 @@ function App() {
         <EpisodeToastWithNavigation />
         <Suspense fallback={<PageLoader />}>
           <Routes>
-            <Route path="/welcome" element={<Welcome />} />
-            <Route path="/pip" element={<PipWindow />} />
-            <Route path="/login" element={<Login />} />
+            <Route path="/welcome" element={<RouteBoundary name="Welcome"><Welcome /></RouteBoundary>} />
+            <Route path="/pip" element={<RouteBoundary name="PiP"><PipWindow /></RouteBoundary>} />
+            <Route path="/login" element={<RouteBoundary name="Login"><Login /></RouteBoundary>} />
             <Route
               path="/dashboard"
               element={isAuthenticated ? <Dashboard /> : <Navigate to="/login" replace />}
             >
               <Route index element={<Navigate to="home" replace />} />
-              <Route path="home" element={<Home />} />
-              <Route path="live" element={<LiveTV />} />
-              <Route path="guide" element={<EpgGuide />} />
-              <Route path="vod" element={<VOD />} />
-              <Route path="series" element={<Series />} />
-              <Route path="watch-later" element={<WatchLater />} />
-              <Route path="favorites" element={<Favorites />} />
-              <Route path="downloads" element={<Downloads />} />
-              <Route path="history" element={<History />} />
-              <Route path="settings" element={<Settings />} />
+              <Route path="home" element={<RouteBoundary name="Home"><Home /></RouteBoundary>} />
+              <Route path="live" element={<RouteBoundary name="LiveTV"><LiveTV /></RouteBoundary>} />
+              <Route path="guide" element={<RouteBoundary name="EpgGuide"><EpgGuide /></RouteBoundary>} />
+              <Route path="vod" element={<RouteBoundary name="VOD"><VOD /></RouteBoundary>} />
+              <Route path="series" element={<RouteBoundary name="Series"><Series /></RouteBoundary>} />
+              <Route path="watch-later" element={<RouteBoundary name="WatchLater"><WatchLater /></RouteBoundary>} />
+              <Route path="favorites" element={<RouteBoundary name="Favorites"><Favorites /></RouteBoundary>} />
+              <Route path="downloads" element={<RouteBoundary name="Downloads"><Downloads /></RouteBoundary>} />
+              <Route path="history" element={<RouteBoundary name="History"><History /></RouteBoundary>} />
+              <Route path="settings" element={<RouteBoundary name="Settings"><Settings /></RouteBoundary>} />
             </Route>
             <Route
               path="/"

--- a/src/components/ErrorBoundary.test.ts
+++ b/src/components/ErrorBoundary.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+
+describe('ErrorBoundary', () => {
+    it('getDerivedStateFromError captures the error into state', () => {
+        const err = new Error('boom');
+        expect(ErrorBoundary.getDerivedStateFromError(err)).toEqual({ error: err });
+    });
+
+    it('clears the error when resetKey changes (navigation)', () => {
+        const eb = new ErrorBoundary({ name: 'X', resetKey: 'b', children: null });
+        eb.state = { error: new Error('boom') };
+        const setState = vi.fn();
+        eb.setState = setState as unknown as typeof eb.setState;
+
+        eb.componentDidUpdate({ name: 'X', resetKey: 'a', children: null });
+        expect(setState).toHaveBeenCalledWith({ error: null });
+    });
+
+    it('does NOT clear when resetKey is unchanged', () => {
+        const eb = new ErrorBoundary({ name: 'X', resetKey: 'a', children: null });
+        eb.state = { error: new Error('boom') };
+        const setState = vi.fn();
+        eb.setState = setState as unknown as typeof eb.setState;
+
+        eb.componentDidUpdate({ name: 'X', resetKey: 'a', children: null });
+        expect(setState).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when there is no error', () => {
+        const eb = new ErrorBoundary({ name: 'X', resetKey: 'b', children: null });
+        eb.state = { error: null };
+        const setState = vi.fn();
+        eb.setState = setState as unknown as typeof eb.setState;
+
+        eb.componentDidUpdate({ name: 'X', resetKey: 'a', children: null });
+        expect(setState).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,141 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+/**
+ * Per-page error boundary. A render crash in one page shows a themed fallback
+ * (keeping the sidebar/layout intact) instead of taking down the whole app.
+ * React swallows the thrown error before window.onerror, so we log it here in
+ * componentDidCatch — the renderer error forwarder picks it up into main.log.
+ *
+ * Auto-resets when `resetKey` changes (pass the route pathname) so navigating
+ * away from a crashed page clears the error without a manual retry.
+ */
+interface ErrorBoundaryProps {
+    /** Human label for the area (shown in logs), e.g. the page name. */
+    name: string;
+    /** When this value changes, the boundary clears its error (e.g. route path). */
+    resetKey?: string;
+    children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+    error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    state: ErrorBoundaryState = { error: null };
+
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+        return { error };
+    }
+
+    componentDidUpdate(prevProps: ErrorBoundaryProps) {
+        // Clear the error when the reset key changes (navigation).
+        if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+            this.setState({ error: null });
+        }
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        // Forwarded to main.log by the renderer error bridge.
+        console.error(`[ErrorBoundary:${this.props.name}]`, error, info.componentStack);
+    }
+
+    private handleRetry = () => this.setState({ error: null });
+
+    private handleHome = () => {
+        this.setState({ error: null });
+        window.location.hash = '#/dashboard/home';
+    };
+
+    render() {
+        if (!this.state.error) return this.props.children;
+
+        return (
+            <>
+                <style>{errorBoundaryStyles}</style>
+                <div className="eb-screen">
+                    <div className="eb-card">
+                        <div className="eb-icon">⚠️</div>
+                        <h2 className="eb-title">Algo deu errado nesta tela</h2>
+                        <p className="eb-msg">
+                            Tente novamente. Se persistir, volte ao início — o resto do app continua funcionando.
+                        </p>
+                        <p className="eb-detail">{this.state.error.message}</p>
+                        <div className="eb-actions">
+                            <button className="eb-btn eb-btn-primary" onClick={this.handleRetry}>
+                                Tentar novamente
+                            </button>
+                            <button className="eb-btn" onClick={this.handleHome}>
+                                Voltar ao início
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </>
+        );
+    }
+}
+
+const errorBoundaryStyles = `
+.eb-screen {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    padding: 32px;
+}
+.eb-card {
+    max-width: 420px;
+    width: 100%;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 20px;
+    padding: 36px 28px;
+}
+.eb-icon { font-size: 44px; }
+.eb-title {
+    color: #fff;
+    font-size: 20px;
+    font-weight: 700;
+    margin: 14px 0 8px;
+}
+.eb-msg {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 14px;
+    line-height: 1.5;
+    margin: 0 0 12px;
+}
+.eb-detail {
+    color: rgba(255, 255, 255, 0.4);
+    font-size: 12px;
+    font-family: monospace;
+    word-break: break-word;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 8px;
+    padding: 8px 10px;
+    margin: 0 0 20px;
+}
+.eb-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+}
+.eb-btn {
+    padding: 10px 18px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.05);
+    color: #fff;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+.eb-btn:hover { background: rgba(255, 255, 255, 0.1); }
+.eb-btn-primary {
+    border: none;
+    background: linear-gradient(135deg, var(--ns-accent), var(--ns-accent-grad-to));
+}
+.eb-btn-primary:hover { transform: scale(1.04); }
+`;


### PR DESCRIPTION
## 🛡️ Error boundaries por página

Antes, um erro de render em qualquer página apagava o app inteiro (tela branca). Agora cada rota é envolvida por um **ErrorBoundary** que mostra um fallback temático (**"Tentar novamente" / "Voltar ao início"**) mantendo a sidebar e o resto do app vivos.

### Detalhes
- Loga o erro + component stack no `componentDidCatch` (vai pro `main.log` pelo bridge de erros do renderer — o React engole o throw antes do `window.onerror`)
- **Auto-reset ao navegar** (keyed pelo pathname): sair da página com erro limpa o estado sozinho
- 4 testes da lógica pura (captura estática + reset), sem adicionar dep de testing-library

### Verificação
tsc / eslint / vitest / vite build ✅ + check visual ao vivo (navegação entre páginas passa pelos boundaries sem afetar o caminho feliz)

> Rodada 10, PR 1/6.