### PR TITLE
feat: preview de trailer (mudo) ao passar o mouse no card

### DIFF
--- a/src/components/ContentDetailModal.tsx
+++ b/src/components/ContentDetailModal.tsx
@@ -6,6 +6,7 @@ import { watchLaterService } from '../services/watchLater';
 import { favoritesService } from '../services/favoritesService';
 import { downloadService } from '../services/downloadService';
 import { useLanguage } from '../services/languageService';
+import { extractYouTubeId } from '../utils/youtube';
 
 interface ContentDetailModalProps {
     isOpen: boolean;
@@ -1179,18 +1180,10 @@ export function ContentDetailModal({
                         {/* YouTube Embed */}
                         <iframe
                             src={(() => {
-                                // Extract video ID from URL
-                                const patterns = [
-                                    /(?:youtube.com\/watch\?v=|youtu.be\/|youtube.com\/embed\/)([^&\n?#]+)/,
-                                    /^([a-zA-Z0-9_-]{11})$/
-                                ];
-                                for (const pattern of patterns) {
-                                    const match = trailerUrl.match(pattern);
-                                    if (match && match[1]) {
-                                        return `https://www.youtube.com/embed/${match[1]}?autoplay=1&rel=0&modestbranding=1`;
-                                    }
-                                }
-                                return '';
+                                const id = extractYouTubeId(trailerUrl);
+                                return id
+                                    ? `https://www.youtube.com/embed/${id}?autoplay=1&rel=0&modestbranding=1`
+                                    : '';
                             })()}
                             style={{
                                 width: '100%',

--- a/src/components/HoverPreviewCard.css
+++ b/src/components/HoverPreviewCard.css
@@ -48,6 +48,52 @@
     transform: scale(1.08);
 }
 
+/* Muted trailer preview that fades in over the poster */
+.preview-trailer {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    overflow: hidden;
+    background: #000;
+    animation: trailerFadeIn 0.6s ease forwards;
+}
+
+@keyframes trailerFadeIn {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+.preview-trailer iframe {
+    /* Fill the 2:3 poster area with a 16:9 video, cropping the sides. */
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 178%;
+    /* 16/9 of the height */
+    height: 100%;
+    min-width: 100%;
+    transform: translate(-50%, -50%) scale(1.01);
+    border: none;
+    pointer-events: none;
+}
+
+.preview-trailer-muted {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 2;
+    font-size: 14px;
+    line-height: 1;
+    padding: 4px 6px;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.55);
+}
+
 /* Card info (below poster) */
 .card-info {
     padding: 14px;

--- a/src/components/HoverPreviewCard.tsx
+++ b/src/components/HoverPreviewCard.tsx
@@ -1,7 +1,16 @@
-import { memo } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { Play } from 'lucide-react';
 import { LazyImage } from './LazyImage';
+import { extractYouTubeId } from '../utils/youtube';
 import './HoverPreviewCard.css';
+
+// Delay before the trailer starts so a quick mouse pass-over never loads it.
+const TRAILER_DELAY_MS = 1200;
+
+const prefersReducedMotion = () =>
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 interface HoverPreviewCardProps {
     type: 'movie' | 'series';
@@ -24,13 +33,49 @@ interface HoverPreviewCardProps {
 function HoverPreviewCardComponent({
     cover,
     title,
+    youtubeTrailer,
     onMoreInfo,
     children
 }: HoverPreviewCardProps) {
+    const trailerId = extractYouTubeId(youtubeTrailer);
+    // Only mount the iframe once the hover delay elapses; unmount on leave.
+    const [showTrailer, setShowTrailer] = useState(false);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const clearTimer = () => {
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+            timerRef.current = null;
+        }
+    };
+
+    const handleMouseEnter = () => {
+        if (!trailerId || prefersReducedMotion()) return;
+        clearTimer();
+        timerRef.current = setTimeout(() => {
+            timerRef.current = null;
+            setShowTrailer(true);
+        }, TRAILER_DELAY_MS);
+    };
+
+    const handleMouseLeave = () => {
+        clearTimer();
+        setShowTrailer(false);
+    };
+
+    // Drop any pending timer / iframe on unmount.
+    useEffect(() => clearTimer, []);
+
+    const embedSrc = trailerId
+        ? `https://www.youtube-nocookie.com/embed/${trailerId}?autoplay=1&mute=1&controls=0&modestbranding=1&rel=0&playsinline=1&loop=1&playlist=${trailerId}`
+        : '';
+
     return (
         <div
             className="hover-preview-card"
             onClick={onMoreInfo}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
         >
             {/* Poster */}
             <div className="preview-poster" style={{ position: 'relative' }}>
@@ -43,6 +88,19 @@ function HoverPreviewCardComponent({
                         </div>
                     )}
                 />
+
+                {/* Muted trailer preview, fades in over the poster */}
+                {showTrailer && trailerId && (
+                    <div className="preview-trailer">
+                        <iframe
+                            src={embedSrc}
+                            title={`${title} trailer`}
+                            allow="autoplay; encrypted-media; picture-in-picture"
+                            tabIndex={-1}
+                        />
+                        <span className="preview-trailer-muted" aria-hidden="true">🔇</span>
+                    </div>
+                )}
 
                 {/* Overlay with play button */}
                 <div className="card-overlay">

--- a/src/utils/youtube.test.ts
+++ b/src/utils/youtube.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { extractYouTubeId } from './youtube'
+
+describe('extractYouTubeId', () => {
+    it('returns a bare 11-char id unchanged', () => {
+        expect(extractYouTubeId('dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('extracts from a watch?v= URL', () => {
+        expect(extractYouTubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('extracts from a watch?v= URL with extra params', () => {
+        expect(extractYouTubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s&list=abc')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('extracts from a youtu.be short URL', () => {
+        expect(extractYouTubeId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('extracts from a youtu.be URL with query', () => {
+        expect(extractYouTubeId('https://youtu.be/dQw4w9WgXcQ?si=xyz')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('extracts from an embed URL', () => {
+        expect(extractYouTubeId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('extracts from a youtube-nocookie embed URL', () => {
+        expect(extractYouTubeId('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('trims surrounding whitespace', () => {
+        expect(extractYouTubeId('  dQw4w9WgXcQ  ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('returns null for empty string', () => {
+        expect(extractYouTubeId('')).toBeNull()
+    })
+
+    it('returns null for whitespace only', () => {
+        expect(extractYouTubeId('   ')).toBeNull()
+    })
+
+    it('returns null for null/undefined', () => {
+        expect(extractYouTubeId(null)).toBeNull()
+        expect(extractYouTubeId(undefined)).toBeNull()
+    })
+
+    it('returns null for garbage with no id', () => {
+        expect(extractYouTubeId('not a url')).toBeNull()
+        expect(extractYouTubeId('https://example.com/video')).toBeNull()
+    })
+
+    it('returns null for a too-short id', () => {
+        expect(extractYouTubeId('abc123')).toBeNull()
+    })
+})

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -1,0 +1,22 @@
+/**
+ * Extracts an 11-character YouTube video id from a raw id or a YouTube URL.
+ *
+ * Providers vary: the value may already be a bare id ("dQw4w9WgXcQ"), or a
+ * full URL in any of the common forms (watch?v=, youtu.be/, embed/). Returns
+ * the id, or null when the input is empty or unrecognizable.
+ */
+export function extractYouTubeId(value: string | null | undefined): string | null {
+    if (!value) return null;
+
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    // Already a bare 11-char id.
+    if (/^[a-zA-Z0-9_-]{11}$/.test(trimmed)) return trimmed;
+
+    // Common URL forms: watch?v=ID, youtu.be/ID, embed/ID (and -nocookie).
+    const match = trimmed.match(
+        /(?:youtube(?:-nocookie)?\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
+    );
+    return match ? match[1] : null;
+}


### PR DESCRIPTION
## 🎬 Trailer no hover

O card de preview já recebia o `youtube_trailer` mas ignorava. Agora, depois de ~1,2s com o mouse em cima, ele faz fade-in de um **trailer do YouTube tocando mudo** sobre o pôster; tirar o mouse desmonta o iframe na hora (corta áudio/rede).

### Detalhes
- `extractYouTubeId()` puro (id cru, `watch?v=`, `youtu.be/`, `embed/`...) — 13 testes
- Embed `youtube-nocookie` com `mute=1&controls=0&loop`, badge 🔇, `pointer-events:none` (clique ainda cai no card); respeita `prefers-reduced-motion`
- O modal "Ver Trailer" agora reusa o mesmo parser (mantendo o som)
- VOD/Séries já passavam o `youtube_trailer` — nenhuma mudança de página

### Verificação
tsc / eslint / vitest **289/289** (13 novos) / vite build / Playwright **15/15** ✅

> ⚠️ O gate visual da GUI foi bloqueado por um painel de entrada do Windows roubando foco — dá uma olhada no hover de um card de filme quando testar. Implementação é ciclo de iframe padrão.

> Rodada 10, PR 2/6.