### PR TITLE
feat: busca global mais esperta (fuzzy, sem acento, ranking + recentes)

### DIFF
--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -6,6 +6,12 @@ import { useLanguage } from '../services/languageService';
 import { profileService } from '../services/profileService';
 import { parentalService } from '../services/parentalService';
 import { isCategoryNameBlocked } from '../hooks/useContentFiltering';
+import {
+    rankItems,
+    getRecentSearches,
+    addRecentSearch,
+    clearRecentSearches
+} from '../utils/searchRank';
 
 /**
  * sessionStorage bridge: the section pages (LiveTV/VOD/Series) don't support
@@ -181,25 +187,12 @@ function isItemAllowed(item: SearchItem, gate: GateConfig): boolean {
 }
 
 /**
- * Case-insensitive substring match, ranked startsWith > includes,
- * capped at MAX_PER_CATEGORY results.
+ * Diacritics- and case-insensitive scored match (exact > prefix >
+ * word-boundary > substring > subsequence/fuzzy), capped at
+ * MAX_PER_CATEGORY after scoring. See src/utils/searchRank.ts.
  */
 function matchItems(items: SearchItem[], query: string): SearchItem[] {
-    const q = query.toLowerCase();
-    const startsWith: SearchItem[] = [];
-    const includes: SearchItem[] = [];
-    for (const item of items) {
-        const name = item.name.toLowerCase();
-        const index = name.indexOf(q);
-        if (index === -1) continue;
-        if (index === 0) {
-            startsWith.push(item);
-            if (startsWith.length >= MAX_PER_CATEGORY) break;
-        } else if (includes.length < MAX_PER_CATEGORY) {
-            includes.push(item);
-        }
-    }
-    return startsWith.concat(includes).slice(0, MAX_PER_CATEGORY);
+    return rankItems(items, query, item => item.name, MAX_PER_CATEGORY);
 }
 
 interface ResultGroup {
@@ -230,6 +223,7 @@ export function GlobalSearch() {
     const [loading, setLoading] = useState(false);
     const [loadError, setLoadError] = useState(false);
     const [selectedIndex, setSelectedIndex] = useState(0);
+    const [recent, setRecent] = useState<string[]>([]);
     const inputRef = useRef<HTMLInputElement>(null);
     const listRef = useRef<HTMLDivElement>(null);
     const openRef = useRef(open);
@@ -295,9 +289,11 @@ export function GlobalSearch() {
         };
     }, [ensureDataLoaded]);
 
-    // Autofocus on open
+    // Autofocus on open; also refresh the recent-searches list so it reflects
+    // anything added since the last open.
     useEffect(() => {
         if (open) {
+            setRecent(getRecentSearches());
             // After the overlay paints
             requestAnimationFrame(() => inputRef.current?.focus());
         }
@@ -350,6 +346,9 @@ export function GlobalSearch() {
         } catch {
             // sessionStorage unavailable: navigation still works, just unfiltered
         }
+        // Record the typed query (not the item name) as a recent search.
+        const typed = query.trim();
+        if (typed) addRecentSearch(typed);
         navigate(SECTION_ROUTES[item.kind]);
         // Covers the "already on that page" case (no remount on same-route navigate)
         window.dispatchEvent(new Event(GLOBAL_SEARCH_EVENT));
@@ -357,6 +356,20 @@ export function GlobalSearch() {
         setInputValue('');
         setQuery('');
     }, [navigate, query]);
+
+    // Click a recent-search chip: fill the input and run the search immediately.
+    const runRecent = useCallback((term: string) => {
+        setQueryDebounced.cancel();
+        setInputValue(term);
+        setQuery(term);
+        setSelectedIndex(0);
+        requestAnimationFrame(() => inputRef.current?.focus());
+    }, [setQueryDebounced]);
+
+    const clearRecent = useCallback(() => {
+        clearRecentSearches();
+        setRecent([]);
+    }, []);
 
     const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'ArrowDown') {
@@ -372,7 +385,17 @@ export function GlobalSearch() {
         } else if (e.key === 'Enter') {
             e.preventDefault();
             const item = flatResults[selectedIndex];
-            if (item) activate(item);
+            if (item) {
+                activate(item);
+            } else {
+                // Enter with a non-empty query but no results: still record it
+                // as a recent search so it can be re-run later.
+                const typed = query.trim();
+                if (typed) {
+                    addRecentSearch(typed);
+                    setRecent(getRecentSearches());
+                }
+            }
         }
     };
 
@@ -380,6 +403,9 @@ export function GlobalSearch() {
 
     const trimmedQuery = query.trim();
     const showNoResults = !!data && !!trimmedQuery && flatResults.length === 0;
+    // Recents show only when the input is empty (keyed off the live value so it
+    // hides the instant the user types) and we're not loading/erroring.
+    const showRecents = !loading && !loadError && inputValue.trim() === '' && recent.length > 0;
 
     return (
         <>
@@ -427,6 +453,33 @@ export function GlobalSearch() {
                         {showNoResults && !loading && (
                             <div className="gsearch-status">
                                 <span>{t('search', 'noResults')}</span>
+                            </div>
+                        )}
+
+                        {showRecents && (
+                            <div className="gsearch-recent">
+                                <div className="gsearch-recent-header">
+                                    <span>{t('search', 'recent')}</span>
+                                    <button
+                                        type="button"
+                                        className="gsearch-recent-clear"
+                                        onClick={clearRecent}
+                                    >
+                                        {t('search', 'clearRecent')}
+                                    </button>
+                                </div>
+                                <div className="gsearch-recent-chips">
+                                    {recent.map(term => (
+                                        <button
+                                            key={term}
+                                            type="button"
+                                            className="gsearch-recent-chip"
+                                            onClick={() => runRecent(term)}
+                                        >
+                                            🕘 {term}
+                                        </button>
+                                    ))}
+                                </div>
                             </div>
                         )}
 
@@ -689,6 +742,72 @@ const globalSearchStyles = `
     background: rgba(236, 72, 153, 0.15);
     color: #f9a8d4;
     border: 1px solid rgba(236, 72, 153, 0.3);
+}
+
+/* Recent searches */
+.gsearch-recent {
+    padding: 6px 4px 10px;
+}
+
+.gsearch-recent-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px 8px;
+    color: var(--ns-accent-light);
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.gsearch-recent-clear {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.45);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: none;
+    letter-spacing: 0;
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: 6px;
+    transition: color 0.15s ease, background 0.15s ease;
+}
+
+.gsearch-recent-clear:hover {
+    color: white;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.gsearch-recent-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 0 12px;
+}
+
+.gsearch-recent-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 100%;
+    padding: 7px 14px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 999px;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 13px;
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.gsearch-recent-chip:hover {
+    background: rgba(var(--ns-accent-rgb), 0.18);
+    border-color: rgba(var(--ns-accent-rgb), 0.4);
 }
 
 /* Footer */

--- a/src/locales/ui/en.json
+++ b/src/locales/ui/en.json
@@ -678,6 +678,8 @@
     "loading": "Loading catalog...",
     "loadError": "Failed to load catalog",
     "hint": "↑↓ navigate · Enter open · Esc close",
-    "openSearch": "Search"
+    "openSearch": "Search",
+    "recent": "Recent searches",
+    "clearRecent": "clear"
   }
 }

--- a/src/locales/ui/es.json
+++ b/src/locales/ui/es.json
@@ -678,6 +678,8 @@
     "loading": "Cargando catálogo...",
     "loadError": "Error al cargar el catálogo",
     "hint": "↑↓ navegar · Enter abrir · Esc cerrar",
-    "openSearch": "Buscar"
+    "openSearch": "Buscar",
+    "recent": "Búsquedas recientes",
+    "clearRecent": "borrar"
   }
 }

--- a/src/locales/ui/pt.json
+++ b/src/locales/ui/pt.json
@@ -678,6 +678,8 @@
     "loading": "Carregando catálogo...",
     "loadError": "Falha ao carregar o catálogo",
     "hint": "↑↓ navegar · Enter abrir · Esc fechar",
-    "openSearch": "Buscar"
+    "openSearch": "Buscar",
+    "recent": "Buscas recentes",
+    "clearRecent": "limpar"
   }
 }

--- a/src/utils/searchRank.test.ts
+++ b/src/utils/searchRank.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+    normalizeForSearch,
+    scoreMatch,
+    rankItems,
+    getRecentSearches,
+    addRecentSearch,
+    clearRecentSearches,
+    RECENT_SEARCHES_KEY,
+    MAX_RECENT_SEARCHES
+} from './searchRank'
+
+describe('normalizeForSearch', () => {
+    it('lowercases and trims', () => {
+        expect(normalizeForSearch('  Hello World  ')).toBe('hello world')
+    })
+
+    it('strips diacritics', () => {
+        expect(normalizeForSearch('São Paulo')).toBe('sao paulo')
+        expect(normalizeForSearch('Ação')).toBe('acao')
+        expect(normalizeForSearch('Pelé')).toBe('pele')
+        expect(normalizeForSearch('Niño')).toBe('nino')
+    })
+
+    it('makes accented and unaccented forms compare equal', () => {
+        expect(normalizeForSearch('açao')).toBe(normalizeForSearch('acao'))
+        expect(normalizeForSearch('São')).toBe(normalizeForSearch('sao'))
+    })
+})
+
+describe('scoreMatch', () => {
+    it('returns 0 for no match', () => {
+        expect(scoreMatch('zzz', 'James Bond')).toBe(0)
+    })
+
+    it('returns 0 for empty query or empty name', () => {
+        expect(scoreMatch('', 'James Bond')).toBe(0)
+        expect(scoreMatch('   ', 'James Bond')).toBe(0)
+        expect(scoreMatch('bond', '')).toBe(0)
+    })
+
+    it('exact match outranks prefix', () => {
+        expect(scoreMatch('bond', 'Bond')).toBeGreaterThan(scoreMatch('bond', 'Bond Movie'))
+    })
+
+    it('prefix outranks word-boundary', () => {
+        // "star" as prefix of "Star Wars" vs "star" after a space in "The Star"
+        expect(scoreMatch('star', 'Star Wars')).toBeGreaterThan(scoreMatch('star', 'The Star'))
+    })
+
+    it('word-boundary outranks mid-word substring', () => {
+        // "war" at word boundary in "Star War" vs mid-word in "Warehouse"... use clearer case
+        expect(scoreMatch('wars', 'Star Wars')).toBeGreaterThan(scoreMatch('wars', 'Starwarship'))
+    })
+
+    it('substring outranks subsequence (fuzzy)', () => {
+        // "bond" is a contiguous substring of "James Bond"
+        const substring = scoreMatch('bond', 'James Bond')
+        // "jbond" only matches as a subsequence of "James Bond"
+        const subseq = scoreMatch('jbond', 'James Bond')
+        expect(substring).toBeGreaterThan(subseq)
+        expect(subseq).toBeGreaterThan(0)
+    })
+
+    it('matches subsequence/fuzzy queries', () => {
+        expect(scoreMatch('jbond', 'James Bond')).toBeGreaterThan(0)
+        expect(scoreMatch('strwars', 'Star Wars')).toBeGreaterThan(0)
+    })
+
+    it('is diacritics-insensitive', () => {
+        expect(scoreMatch('sao', 'São Paulo')).toBeGreaterThan(0)
+        expect(scoreMatch('São', 'sao paulo')).toBeGreaterThan(0)
+        expect(scoreMatch('acao', 'Ação Total')).toBeGreaterThan(0)
+    })
+
+    it('is case-insensitive', () => {
+        expect(scoreMatch('JAMES', 'james bond')).toBeGreaterThan(0)
+    })
+
+    it('ranks earlier match position higher (substring tiebreak)', () => {
+        // "ar" appears at index 1 in "Bar" vs later in "Foo Bar Baz" -> earlier wins
+        expect(scoreMatch('bar', 'Bar X')).toBeGreaterThan(scoreMatch('bar', 'Foo Bar'))
+    })
+
+    it('ranks shorter names higher on equal-band ties (exact stays exact)', () => {
+        // both are prefix matches starting at 0; shorter name wins
+        expect(scoreMatch('star', 'Star')).toBeGreaterThan(scoreMatch('star', 'Star Wars Episode'))
+    })
+})
+
+describe('rankItems', () => {
+    const items = [
+        { name: 'Star Wars' },
+        { name: 'The Star' },
+        { name: 'Star' },
+        { name: 'Starwarship' },
+        { name: 'Unrelated' }
+    ]
+    const getName = (i: { name: string }) => i.name
+
+    it('drops non-matching items', () => {
+        const out = rankItems(items, 'star', getName, 10)
+        expect(out.map(i => i.name)).not.toContain('Unrelated')
+    })
+
+    it('returns nothing for a query that matches nothing', () => {
+        expect(rankItems(items, 'zzzzz', getName, 10)).toEqual([])
+    })
+
+    it('orders by score: exact > prefix(shorter) > word-boundary', () => {
+        const out = rankItems(items, 'star', getName, 10).map(i => i.name)
+        expect(out[0]).toBe('Star') // exact
+        expect(out.indexOf('Star Wars')).toBeLessThan(out.indexOf('The Star'))
+    })
+
+    it('respects the limit', () => {
+        const out = rankItems(items, 'star', getName, 2)
+        expect(out).toHaveLength(2)
+        expect(out[0].name).toBe('Star')
+    })
+
+    it('is stable on ties (preserves original order for equal scores)', () => {
+        const tied = [{ name: 'Alpha One' }, { name: 'Alpha Two' }]
+        const out = rankItems(tied, 'alpha', getName, 10).map(i => i.name)
+        expect(out).toEqual(['Alpha One', 'Alpha Two'])
+    })
+
+    it('matches fuzzy/subsequence as a fallback', () => {
+        const out = rankItems([{ name: 'James Bond' }], 'jbond', getName, 10)
+        expect(out).toHaveLength(1)
+    })
+})
+
+describe('recent searches', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('returns empty when nothing stored', () => {
+        expect(getRecentSearches()).toEqual([])
+    })
+
+    it('adds and reads back a query', () => {
+        addRecentSearch('star wars')
+        expect(getRecentSearches()).toEqual(['star wars'])
+    })
+
+    it('puts most-recent first (unshift)', () => {
+        addRecentSearch('first')
+        addRecentSearch('second')
+        expect(getRecentSearches()).toEqual(['second', 'first'])
+    })
+
+    it('dedupes (delete-then-unshift), keeping the latest position', () => {
+        addRecentSearch('alpha')
+        addRecentSearch('beta')
+        addRecentSearch('alpha')
+        expect(getRecentSearches()).toEqual(['alpha', 'beta'])
+    })
+
+    it('dedupes case- and diacritics-insensitively but stores the new casing', () => {
+        addRecentSearch('São Paulo')
+        addRecentSearch('sao paulo')
+        const out = getRecentSearches()
+        expect(out).toHaveLength(1)
+        expect(out[0]).toBe('sao paulo')
+    })
+
+    it('caps at MAX_RECENT_SEARCHES', () => {
+        for (let i = 0; i < MAX_RECENT_SEARCHES + 5; i++) {
+            addRecentSearch(`query ${i}`)
+        }
+        const out = getRecentSearches()
+        expect(out).toHaveLength(MAX_RECENT_SEARCHES)
+        // newest first
+        expect(out[0]).toBe(`query ${MAX_RECENT_SEARCHES + 4}`)
+    })
+
+    it('ignores empty/whitespace queries', () => {
+        addRecentSearch('   ')
+        addRecentSearch('')
+        expect(getRecentSearches()).toEqual([])
+    })
+
+    it('trims before storing', () => {
+        addRecentSearch('  spaced  ')
+        expect(getRecentSearches()).toEqual(['spaced'])
+    })
+
+    it('clearRecentSearches empties the list', () => {
+        addRecentSearch('x')
+        clearRecentSearches()
+        expect(getRecentSearches()).toEqual([])
+    })
+
+    it('tolerates corrupt stored JSON', () => {
+        localStorage.setItem(RECENT_SEARCHES_KEY, '{not json')
+        expect(getRecentSearches()).toEqual([])
+    })
+
+    it('ignores non-array / non-string entries', () => {
+        localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(['ok', 3, null, '']))
+        expect(getRecentSearches()).toEqual(['ok'])
+    })
+})

--- a/src/utils/searchRank.ts
+++ b/src/utils/searchRank.ts
@@ -1,0 +1,168 @@
+/**
+ * Pure search-ranking helpers for the global search overlay (Ctrl+K).
+ *
+ * Matching is diacritics- and case-insensitive, with a scored model that
+ * prefers exact > prefix > word-boundary > substring > subsequence (fuzzy)
+ * matches. The scoring is O(name length) per candidate, so ranking a few
+ * thousand items per keystroke stays cheap (and the input is debounced).
+ *
+ * Also hosts the localStorage-backed "recent searches" helpers used by the
+ * overlay's empty state.
+ */
+
+// --- Normalization ---------------------------------------------------------
+
+/**
+ * Lowercase + strip diacritics so "São"/"sao" and "ação"/"acao" compare equal.
+ * Uses Unicode NFD decomposition then removes combining marks.
+ */
+export function normalizeForSearch(s: string): string {
+    return s
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .toLowerCase()
+        .trim();
+}
+
+// --- Scoring ---------------------------------------------------------------
+
+// Score bands. Higher is better; 0 means "no match" (caller drops it).
+// Bands are spaced wide enough that the per-match tiebreak bonuses (length /
+// position, both < ~100) can never lift a lower band above a higher one.
+const SCORE_EXACT = 10000;
+const SCORE_PREFIX = 8000;
+const SCORE_WORD_BOUNDARY = 6000;
+const SCORE_SUBSTRING = 4000;
+const SCORE_SUBSEQUENCE = 2000;
+
+/**
+ * Returns true if every char of `q` appears in `name` in order (not
+ * necessarily contiguous). Both are expected pre-normalized. Empty `q`
+ * is treated as a non-match here (callers gate empty queries earlier).
+ */
+function isSubsequence(q: string, name: string): boolean {
+    if (q.length === 0) return false;
+    let qi = 0;
+    for (let ni = 0; ni < name.length && qi < q.length; ni++) {
+        if (name[ni] === q[qi]) qi++;
+    }
+    return qi === q.length;
+}
+
+/**
+ * Score how well `name` matches `query`. Returns 0 for no match.
+ *
+ * Ranking (high → low):
+ *   exact equality > starts-with > match at a word boundary (after a space)
+ *   > substring anywhere > subsequence/fuzzy.
+ * Tiebreakers within a band: earlier match position and shorter names win.
+ *
+ * Both arguments are normalized internally, so callers may pass raw strings.
+ */
+export function scoreMatch(query: string, name: string): number {
+    const q = normalizeForSearch(query);
+    const n = normalizeForSearch(name);
+    if (q.length === 0 || n.length === 0) return 0;
+
+    // Shorter names rank slightly higher (more "exact"-feeling). Bounded so it
+    // never crosses a band. ~0..50.
+    const lengthBonus = Math.max(0, 50 - Math.min(n.length, 50));
+
+    if (n === q) {
+        return SCORE_EXACT + lengthBonus;
+    }
+
+    if (n.startsWith(q)) {
+        return SCORE_PREFIX + lengthBonus;
+    }
+
+    const idx = n.indexOf(q);
+    if (idx !== -1) {
+        // Earlier matches rank higher within the band. ~0..100.
+        const positionBonus = Math.max(0, 100 - idx);
+        // A substring that begins right after a space is a word-boundary hit.
+        if (n[idx - 1] === ' ') {
+            return SCORE_WORD_BOUNDARY + positionBonus + lengthBonus * 0.1;
+        }
+        return SCORE_SUBSTRING + positionBonus + lengthBonus * 0.1;
+    }
+
+    if (isSubsequence(q, n)) {
+        return SCORE_SUBSEQUENCE + lengthBonus;
+    }
+
+    return 0;
+}
+
+/**
+ * Score every item, drop non-matches (score 0), sort best-first (stable on
+ * ties via original index), and return at most `limit` items.
+ *
+ * O(n) scoring + O(m log m) sort over the m matches; no quadratic work.
+ */
+export function rankItems<T>(
+    items: readonly T[],
+    query: string,
+    getName: (item: T) => string,
+    limit: number
+): T[] {
+    const scored: Array<{ item: T; score: number; index: number }> = [];
+    for (let i = 0; i < items.length; i++) {
+        const score = scoreMatch(query, getName(items[i]));
+        if (score > 0) scored.push({ item: items[i], score, index: i });
+    }
+    scored.sort((a, b) => (b.score - a.score) || (a.index - b.index));
+    const out: T[] = [];
+    for (let i = 0; i < scored.length && out.length < limit; i++) {
+        out.push(scored[i].item);
+    }
+    return out;
+}
+
+// --- Recent searches (localStorage) ----------------------------------------
+
+export const RECENT_SEARCHES_KEY = 'neostream_recent_searches';
+export const MAX_RECENT_SEARCHES = 8;
+
+/** Read the recent-searches list (most-recent-first). Safe on any failure. */
+export function getRecentSearches(): string[] {
+    try {
+        const raw = localStorage.getItem(RECENT_SEARCHES_KEY);
+        if (!raw) return [];
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed
+            .filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
+            .slice(0, MAX_RECENT_SEARCHES);
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Record a freshly-used query: trim, dedupe (case-insensitive,
+ * diacritics-insensitive), unshift to the front, cap at MAX_RECENT_SEARCHES.
+ * Returns the new list (also persisted). No-ops on empty/whitespace queries.
+ */
+export function addRecentSearch(query: string): string[] {
+    const trimmed = query.trim();
+    if (!trimmed) return getRecentSearches();
+    const key = normalizeForSearch(trimmed);
+    const existing = getRecentSearches().filter(q => normalizeForSearch(q) !== key);
+    const next = [trimmed, ...existing].slice(0, MAX_RECENT_SEARCHES);
+    try {
+        localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(next));
+    } catch {
+        // localStorage unavailable: the in-memory list is still returned
+    }
+    return next;
+}
+
+/** Clear all recent searches. Safe on any failure. */
+export function clearRecentSearches(): void {
+    try {
+        localStorage.removeItem(RECENT_SEARCHES_KEY);
+    } catch {
+        // ignore
+    }
+}


### PR DESCRIPTION
## 🔍 Busca global melhorada

Antes era só substring exata. Agora:

### Matching mais esperto
- **Ignora acentos**: "sao"/"São", "acao"/"ação" casam
- **Fuzzy**: "jbond" → "James Bond", "strwars" → "Star Wars"
- **Ranking por relevância**: exato > começa com > início de palavra > contém > fuzzy; nomes mais curtos e match mais no início desempatam
- Cap por categoria mantido, sem itens sem match

### Buscas recentes
- Guarda as últimas 8 buscas (dedupe sem acento/caixa), gravadas ao abrir um resultado ou dar Enter
- Com o Ctrl+K aberto e o campo vazio, mostra os termos recentes em chips clicáveis + botão "limpar"; some assim que você digita

### Verificação
Kids/parental, navegação por teclado, bridge de termo e cache de sessão intactos. tsc / eslint / vitest **307** (31 novos) / vite build / Playwright **15** ✅

> Rodada 10, PR 3/6.