### PR TITLE
feat: "Assistir depois" por playlist (fecha o gap de persistência)

### DIFF
--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -33,6 +33,7 @@ const EXACT_KEYS = [
 // Keys included when they start with one of these prefixes
 const PREFIX_KEYS = [
     'neostream_profile_',     // per-profile favorites, incl. _<profileId>__pl_<playlistId>
+    'neostream_watchlater_',  // per-(profile,playlist) watch-later, _<profileId>__pl_<playlistId>
     'playbackConfig',         // playbackConfig and playbackConfig_<profileId>
     'movie_watch_progress',   // movie resume positions, incl. per-(profile,playlist)
     'series_watch_progress',  // series progress, incl. per-(profile,playlist)

--- a/src/services/watchLater.test.ts
+++ b/src/services/watchLater.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Profile, WatchLaterItem } from '../types/profile';
+
+// Mutable mock state for the active profile + playlist.
+let activeProfile: Profile | null = null;
+const profiles: Profile[] = [];
+
+const makeProfile = (id: string, watchLater: WatchLaterItem[] = []): Profile => ({
+    id,
+    name: id,
+    avatar: '',
+    watchLater,
+    continueWatching: [],
+    createdAt: 'x',
+    lastUsed: 'x'
+});
+
+vi.mock('./profileService', () => ({
+    profileService: {
+        getActiveProfile: () => activeProfile,
+        getAllProfiles: () => profiles
+    }
+}));
+
+let playlistId = 'plA';
+vi.mock('./activePlaylistService', () => ({
+    getActivePlaylistId: () => playlistId,
+    hasKnownPlaylistId: () => playlistId !== 'default',
+    playlistScopedKey: (base: string, profileId: string) =>
+        `${base}_${profileId}__pl_${playlistId}`
+}));
+
+import { watchLaterService } from './watchLater';
+
+const item = (id: string) => ({
+    id,
+    type: 'movie' as const,
+    name: 'T',
+    cover: 'c'
+});
+
+function setActive(p: Profile) {
+    activeProfile = p;
+    profiles.length = 0;
+    profiles.push(p);
+}
+
+describe('watchLaterService — per-playlist scoping', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        playlistId = 'plA';
+        setActive(makeProfile('p1'));
+    });
+
+    it('an item added under playlist A is not present under B; present again under A', () => {
+        playlistId = 'plA';
+        expect(watchLaterService.add(item('m1'))).toBe(true);
+        expect(watchLaterService.has('m1', 'movie')).toBe(true);
+
+        playlistId = 'plB';
+        expect(watchLaterService.has('m1', 'movie')).toBe(false);
+        expect(watchLaterService.getAll()).toEqual([]);
+
+        playlistId = 'plA';
+        expect(watchLaterService.has('m1', 'movie')).toBe(true);
+        expect(localStorage.getItem('neostream_watchlater_p1__pl_plA')).toBeTruthy();
+        expect(localStorage.getItem('neostream_watchlater_p1__pl_plB')).toBeNull();
+    });
+
+    it('remove and clear operate within the active playlist scope', () => {
+        watchLaterService.add(item('m1'));
+        watchLaterService.add(item('m2'));
+        expect(watchLaterService.getAll().map(i => i.id)).toEqual(['m1', 'm2']);
+
+        watchLaterService.remove('m1', 'movie');
+        expect(watchLaterService.getAll().map(i => i.id)).toEqual(['m2']);
+
+        watchLaterService.clear();
+        expect(watchLaterService.getAll()).toEqual([]);
+    });
+
+    it('isolates watch-later across profiles too', () => {
+        setActive(makeProfile('p1'));
+        watchLaterService.add(item('m1'));
+        setActive(makeProfile('p2'));
+        expect(watchLaterService.has('m1', 'movie')).toBe(false);
+    });
+});
+
+describe('watchLaterService — legacy profile.watchLater → per-playlist migration', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        playlistId = 'plA';
+    });
+
+    it('drains the legacy profile.watchLater into the active playlist scope, then clears it', () => {
+        const legacy: WatchLaterItem[] = [{ ...item('m1'), addedAt: 'x' }];
+        setActive(makeProfile('p1', legacy));
+
+        // Any access migrates.
+        expect(watchLaterService.has('m1', 'movie')).toBe(true);
+
+        const scoped = JSON.parse(localStorage.getItem('neostream_watchlater_p1__pl_plA')!) as WatchLaterItem[];
+        expect(scoped.map(i => i.id)).toEqual(['m1']);
+        // Legacy field cleared + persisted to neostream_profiles.
+        expect(activeProfile!.watchLater).toEqual([]);
+        const stored = JSON.parse(localStorage.getItem('neostream_profiles')!);
+        expect(stored.profiles[0].watchLater).toEqual([]);
+    });
+
+    it('is idempotent and does not clobber existing scoped items', () => {
+        setActive(makeProfile('p1', [{ ...item('old'), addedAt: 'x' }]));
+        localStorage.setItem(
+            'neostream_watchlater_p1__pl_plA',
+            JSON.stringify([{ ...item('keep'), addedAt: 'x' }])
+        );
+
+        watchLaterService.getAll(); // migrate
+        watchLaterService.getAll(); // no-op
+
+        const scoped = JSON.parse(localStorage.getItem('neostream_watchlater_p1__pl_plA')!) as WatchLaterItem[];
+        expect(scoped.map(i => i.id)).toEqual(['keep']);
+        expect(activeProfile!.watchLater).toEqual([]);
+    });
+
+    it('is skipped while the active playlist id is unknown (default fallback)', () => {
+        playlistId = 'default';
+        const legacy: WatchLaterItem[] = [{ ...item('m1'), addedAt: 'x' }];
+        setActive(makeProfile('p1', legacy));
+
+        watchLaterService.getAll();
+
+        // Legacy field untouched; no scoped key written under 'default'.
+        expect(activeProfile!.watchLater.map(i => i.id)).toEqual(['m1']);
+        expect(localStorage.getItem('neostream_watchlater_p1__pl_default')).toBeNull();
+    });
+});

--- a/src/services/watchLater.ts
+++ b/src/services/watchLater.ts
@@ -1,15 +1,31 @@
-// Watch Later localStorage utility (adapted for profiles)
+// Watch Later localStorage utility (adapted for profiles, per-playlist scoped)
 import { profileService } from './profileService';
+import { playlistScopedKey, hasKnownPlaylistId } from './activePlaylistService';
 import type { Profile, WatchLaterItem } from '../types/profile';
 
 // Re-export type for compatibility
 export type { WatchLaterItem };
 
+// localStorage key base. Per-profile per-playlist key is
+// `neostream_watchlater_${profileId}__pl_${activePlaylistId}` and stores the
+// WatchLaterItem[] array. The legacy location is the active profile's
+// `watchLater` field inside `neostream_profiles`, which migrate() drains once.
+const KEY_BASE = 'neostream_watchlater';
+
 export const watchLaterService = {
-    // Get all watch later items for active profile
+    // Get all watch later items for active profile (current playlist scope)
     getAll(): WatchLaterItem[] {
         const activeProfile = profileService.getActiveProfile();
-        return activeProfile ? activeProfile.watchLater : [];
+        if (!activeProfile) return [];
+
+        this.migrate();
+        try {
+            const key = playlistScopedKey(KEY_BASE, activeProfile.id);
+            const data = localStorage.getItem(key);
+            return data ? (JSON.parse(data) as WatchLaterItem[]) : [];
+        } catch {
+            return [];
+        }
     },
 
     // Add item to watch later
@@ -18,8 +34,10 @@ export const watchLaterService = {
         if (!activeProfile) return false;
 
         try {
+            const items = this.getAll();
+
             // Check if already exists
-            if (activeProfile.watchLater.some(i => i.id === item.id && i.type === item.type)) {
+            if (items.some(i => i.id === item.id && i.type === item.type)) {
                 return false; // Already in list
             }
 
@@ -28,8 +46,8 @@ export const watchLaterService = {
                 addedAt: new Date().toISOString()
             };
 
-            activeProfile.watchLater.push(watchLaterItem);
-            this.saveProfile(activeProfile);
+            items.push(watchLaterItem);
+            this.save(activeProfile, items);
             return true;
         } catch (error) {
             console.error('Error adding to watch later:', error);
@@ -43,10 +61,10 @@ export const watchLaterService = {
         if (!activeProfile) return false;
 
         try {
-            activeProfile.watchLater = activeProfile.watchLater.filter(
+            const items = this.getAll().filter(
                 i => !(i.id === id && i.type === type)
             );
-            this.saveProfile(activeProfile);
+            this.save(activeProfile, items);
             return true;
         } catch (error) {
             console.error('Error removing from watch later:', error);
@@ -60,20 +78,52 @@ export const watchLaterService = {
         return items.some(i => i.id === id && i.type === type);
     },
 
-    // Clear all from active profile
+    // Clear all from active profile (current playlist scope)
     clear(): void {
         const activeProfile = profileService.getActiveProfile();
         if (!activeProfile) return;
 
+        this.save(activeProfile, []);
+    },
+
+    // Persist the array to the per-(profile,playlist) key.
+    save(profile: Profile, items: WatchLaterItem[]): void {
+        const key = playlistScopedKey(KEY_BASE, profile.id);
+        localStorage.setItem(key, JSON.stringify(items));
+    },
+
+    /**
+     * One-time, idempotent migration: drain the legacy per-profile `watchLater`
+     * field (stored inside `neostream_profiles`) into the per-(profile,playlist)
+     * key for the CURRENT active playlist (the only playlist data existed under
+     * until now), then clear the legacy field so it is not migrated twice.
+     * Skipped while the active playlist id is unknown ('default' race) — it
+     * re-runs next access once known. Runs for the active profile on access,
+     * which is sufficient since watch-later is read per active profile.
+     */
+    migrate(): void {
+        const activeProfile = profileService.getActiveProfile();
+        if (!activeProfile) return;
+        if (!hasKnownPlaylistId()) return;
+
+        const legacy = activeProfile.watchLater;
+        if (!legacy || legacy.length === 0) return;
+
+        const newKey = playlistScopedKey(KEY_BASE, activeProfile.id);
+        if (localStorage.getItem(newKey) === null) {
+            localStorage.setItem(newKey, JSON.stringify(legacy));
+        }
+
+        // Clear the legacy field in the profiles store so it isn't re-migrated.
         activeProfile.watchLater = [];
         this.saveProfile(activeProfile);
     },
 
-    // Helper to save profile back to storage
+    // Helper to save the profile (with cleared legacy field) back to storage.
     saveProfile(profile: Profile): void {
         const allProfiles = profileService.getAllProfiles();
         const data = {
-            profiles: allProfiles.map(p => p.id === profile.id ? profile : p),
+            profiles: allProfiles.map(p => (p.id === profile.id ? profile : p)),
             activeProfileId: profile.id
         };
         localStorage.setItem('neostream_profiles', JSON.stringify(data));


### PR DESCRIPTION
## 📌 "Assistir depois" por playlist

Era o último ponto que ainda vazava entre playlists — o "assistir depois" vivia dentro do objeto de perfil (por perfil, mas global entre provedores). Movido pra uma chave própria escopada por **(perfil × playlist)**, igual aos favoritos.

### Detalhes
- `neostream_watchlater_${profileId}__pl_${playlistId}` — mesmas assinaturas dos métodos, nenhum caller mudou
- **Migração automática**: drena o `watchLater` antigo do perfil pra chave escopada da playlist atual (idempotente, pula se o id ainda não é conhecido)
- Backup atualizado pra capturar as chaves novas

### Verificação
tsc / eslint / vitest **282** (6 novos) / vite build / Playwright **15** ✅

> Rodada 10, PR 4/6. Falta só o relatório de erro opt-in.