### PR TITLE
feat: diagnóstico opt-in + relatório de erro exportável

### DIFF
--- a/electron/diagnosticsHandlers.ts
+++ b/electron/diagnosticsHandlers.ts
@@ -1,0 +1,130 @@
+/**
+ * IPC handlers for the opt-in diagnostics / error-report feature.
+ *
+ *   - diagnostics:export-report  → gathers app/system info + the tail of
+ *       main.log, assembles a redacted .txt report (see diagnosticsProtocol),
+ *       prompts for a save location and writes it.
+ *   - diagnostics:open-logs      → opens the logs folder in the OS file manager.
+ *
+ * The pure assembly + secret redaction lives in diagnosticsProtocol.ts so it
+ * can be unit-tested without Electron.
+ */
+import { ipcMain, app, dialog, shell } from 'electron'
+import os from 'os'
+import path from 'path'
+import { promises as fs } from 'fs'
+import log from './logger'
+import { buildReportText, type ReportSystemInfo } from './diagnosticsProtocol'
+
+const getErrorMessage = (error: unknown): string =>
+    error instanceof Error ? error.message : String(error)
+
+/** Read at most the last `maxBytes` of main.log (best effort). */
+async function readLogTail(maxBytes: number): Promise<string> {
+    try {
+        const logFile = path.join(app.getPath('logs'), 'main.log')
+        const stat = await fs.stat(logFile)
+        const start = Math.max(0, stat.size - maxBytes)
+
+        const handle = await fs.open(logFile, 'r')
+        try {
+            const length = stat.size - start
+            const buf = Buffer.alloc(length)
+            await handle.read(buf, 0, length, start)
+            let text = buf.toString('utf-8')
+            // If we truncated mid-file, drop the partial first line.
+            if (start > 0) {
+                const nl = text.indexOf('\n')
+                if (nl >= 0) text = text.slice(nl + 1)
+            }
+            return text
+        } finally {
+            await handle.close()
+        }
+    } catch (error) {
+        log.warn('[Diagnostics] Could not read main.log tail:', getErrorMessage(error))
+        return ''
+    }
+}
+
+function gatherSystemInfo(): ReportSystemInfo {
+    let locale: string | undefined
+    try {
+        locale = Intl.DateTimeFormat().resolvedOptions().timeZone
+    } catch {
+        locale = undefined
+    }
+    return {
+        platform: process.platform,
+        arch: process.arch,
+        electron: process.versions.electron,
+        chrome: process.versions.chrome,
+        node: process.versions.node,
+        osRelease: os.release(),
+        osVersion: typeof os.version === 'function' ? os.version() : undefined,
+        locale,
+    }
+}
+
+/** Filename-friendly local timestamp: YYYY-MM-DD-HHmm. */
+function timestampForFilename(d = new Date()): string {
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+        + `-${pad(d.getHours())}${pad(d.getMinutes())}`
+}
+
+const LOG_TAIL_BYTES = 200 * 1024 // ~200KB
+
+export function setupDiagnosticsHandlers() {
+    // Assemble and save the error report. `breadcrumbs` is only supplied by the
+    // renderer when the opt-in is enabled — otherwise the report is system info
+    // + the main.log tail only.
+    ipcMain.handle('diagnostics:export-report', async (_, payload: { breadcrumbs?: string } = {}) => {
+        try {
+            const logTail = await readLogTail(LOG_TAIL_BYTES)
+            const report = buildReportText({
+                version: app.getVersion(),
+                timestamp: new Date().toISOString(),
+                system: gatherSystemInfo(),
+                breadcrumbs: typeof payload?.breadcrumbs === 'string' ? payload.breadcrumbs : undefined,
+                logTail,
+            })
+
+            const result = await dialog.showSaveDialog({
+                title: 'Salvar relatório de diagnóstico',
+                defaultPath: `neostream-relatorio-${timestampForFilename()}.txt`,
+                filters: [{ name: 'Text', extensions: ['txt'] }],
+            })
+
+            if (result.canceled || !result.filePath) {
+                return { success: false, canceled: true }
+            }
+
+            await fs.writeFile(result.filePath, report, 'utf-8')
+            log.info('[Diagnostics] Report saved to', result.filePath)
+            return { success: true, path: result.filePath }
+        } catch (error: unknown) {
+            log.error('[Diagnostics] Export error:', getErrorMessage(error))
+            return { success: false, error: getErrorMessage(error) }
+        }
+    })
+
+    // Open the logs folder in the OS file manager.
+    ipcMain.handle('diagnostics:open-logs', async () => {
+        try {
+            const logsDir = app.getPath('logs')
+            const result = await shell.openPath(logsDir)
+            // openPath returns '' on success, or an error string.
+            if (result) {
+                log.warn('[Diagnostics] openPath returned:', result)
+                return { success: false, error: result }
+            }
+            return { success: true }
+        } catch (error: unknown) {
+            log.error('[Diagnostics] Open logs error:', getErrorMessage(error))
+            return { success: false, error: getErrorMessage(error) }
+        }
+    })
+
+    log.info('Diagnostics handlers initialized')
+}

--- a/electron/diagnosticsProtocol.test.ts
+++ b/electron/diagnosticsProtocol.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the pure diagnostics report helpers (no Electron).
+ */
+import { describe, it, expect } from 'vitest'
+import { buildReportText, redactSecrets } from './diagnosticsProtocol'
+
+describe('redactSecrets', () => {
+    it('masks password= query params', () => {
+        const out = redactSecrets('http://host/api?username=joe&password=s3cr3t&x=1')
+        expect(out).toContain('username=***REDACTED***')
+        expect(out).toContain('password=***REDACTED***')
+        expect(out).not.toContain('s3cr3t')
+        expect(out).not.toContain('=joe')
+        // Non-secret params are preserved.
+        expect(out).toContain('x=1')
+    })
+
+    it('masks "password":"..." JSON fields', () => {
+        const out = redactSecrets('{"user":"joe","password":"hunter2"}')
+        expect(out).not.toContain('hunter2')
+        expect(out).toContain('"password":"***REDACTED***"')
+        // Other JSON fields untouched.
+        expect(out).toContain('"user":"joe"')
+    })
+
+    it('handles single quotes and spaces around the JSON colon', () => {
+        const out = redactSecrets("{'password' : 'abc123'}")
+        expect(out).not.toContain('abc123')
+        expect(out).toContain('***REDACTED***')
+    })
+
+    it('is case-insensitive on the key', () => {
+        expect(redactSecrets('PASSWORD=topsecret')).not.toContain('topsecret')
+        expect(redactSecrets('Username=admin')).toContain('Username=***REDACTED***')
+    })
+
+    it('does not over-eat past the value boundary', () => {
+        const out = redactSecrets('password=abc&keep=this')
+        expect(out).toContain('keep=this')
+    })
+
+    it('returns empty input unchanged', () => {
+        expect(redactSecrets('')).toBe('')
+    })
+})
+
+describe('buildReportText', () => {
+    const base = {
+        version: '3.14.0',
+        timestamp: '2026-06-30T12:00:00.000Z',
+        system: {
+            platform: 'win32',
+            arch: 'x64',
+            electron: '42.0.0',
+            chrome: '130.0.0',
+            node: '20.0.0',
+            osRelease: '10.0.26200',
+            osVersion: 'Windows 11 Pro',
+            locale: 'America/Sao_Paulo',
+        },
+    }
+
+    it('includes a header with version, timestamp and system info', () => {
+        const out = buildReportText(base)
+        expect(out).toContain('App version : 3.14.0')
+        expect(out).toContain('2026-06-30T12:00:00.000Z')
+        expect(out).toContain('win32 x64')
+        expect(out).toContain('Electron    : 42.0.0')
+        expect(out).toContain('main.log (tail)')
+    })
+
+    it('omits the breadcrumbs section when breadcrumbs are absent', () => {
+        const out = buildReportText(base)
+        expect(out).not.toContain('--- Breadcrumbs ---')
+    })
+
+    it('includes the breadcrumbs section when provided', () => {
+        const out = buildReportText({ ...base, breadcrumbs: '[t] [error] boom' })
+        expect(out).toContain('--- Breadcrumbs ---')
+        expect(out).toContain('boom')
+    })
+
+    it('redacts secrets in the embedded log tail and breadcrumbs', () => {
+        const out = buildReportText({
+            ...base,
+            breadcrumbs: 'failed http://h/?password=brkdcrumb',
+            logTail: 'GET http://h/api?username=joe&password=logsecret 200',
+        })
+        expect(out).not.toContain('logsecret')
+        expect(out).not.toContain('brkdcrumb')
+        expect(out).toContain('***REDACTED***')
+    })
+
+    it('shows a placeholder when the log tail is empty', () => {
+        const out = buildReportText({ ...base, logTail: '' })
+        expect(out).toContain('(empty or unavailable)')
+    })
+})

--- a/electron/diagnosticsProtocol.ts
+++ b/electron/diagnosticsProtocol.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure helpers for the opt-in diagnostics / error-report feature — no Electron,
+ * no fs, no network, no state. The side-effectful parts (reading main.log,
+ * showSaveDialog, writeFile, shell.openPath) live in diagnosticsHandlers.ts.
+ *
+ * Two pure functions are unit-tested here:
+ *   - redactSecrets(text): masks obvious credentials that may have leaked into
+ *     logs (username=/password= query params, "password":"..." JSON).
+ *   - buildReportText({...}): assembles the human-readable .txt report. The
+ *     log tail and breadcrumbs are redacted before being embedded.
+ */
+
+export interface ReportSystemInfo {
+    platform: string
+    arch: string
+    electron?: string
+    chrome?: string
+    node?: string
+    osRelease?: string
+    osVersion?: string
+    /** e.g. "America/Sao_Paulo" or a UTC offset string — best effort. */
+    locale?: string
+}
+
+export interface BuildReportInput {
+    version: string
+    /** ISO-8601 timestamp for the report header. */
+    timestamp: string
+    system: ReportSystemInfo
+    /** Detailed breadcrumbs — only present when the opt-in is enabled. */
+    breadcrumbs?: string
+    /** Tail of main.log (already truncated to the size budget). */
+    logTail?: string
+}
+
+/**
+ * Masks obvious secrets that may appear in the assembled report text:
+ *   - `username=<v>` / `password=<v>` query-string params → value replaced.
+ *   - `"password":"<v>"` JSON fields → value replaced.
+ *
+ * Conservative on purpose: only touches well-known credential shapes so the
+ * report stays useful for debugging.
+ */
+export function redactSecrets(text: string): string {
+    if (!text) return text
+
+    return text
+        // username= / password= in URLs or query strings. Value runs until the
+        // next & or whitespace (so we don't eat the rest of the line/URL).
+        .replace(/\b(username|password)=([^&\s"']*)/gi, '$1=***REDACTED***')
+        // "password":"..." (and 'password':'...') JSON-ish fields. Tolerates
+        // spaces around the colon.
+        .replace(/(["']password["']\s*:\s*)["']([^"']*)["']/gi, '$1"***REDACTED***"')
+}
+
+/**
+ * Assembles the readable .txt diagnostics report. Breadcrumbs and the main.log
+ * tail are redacted before being embedded so leaked credentials never reach the
+ * shareable file.
+ */
+export function buildReportText(input: BuildReportInput): string {
+    const { version, timestamp, system, breadcrumbs, logTail } = input
+
+    const lines: string[] = []
+    lines.push('NeoStream — Relatório de diagnóstico / Error report')
+    lines.push('='.repeat(60))
+    lines.push(`App version : ${version}`)
+    lines.push(`Generated   : ${timestamp}`)
+    lines.push(`Platform    : ${system.platform} ${system.arch}`)
+    if (system.osVersion || system.osRelease) {
+        lines.push(`OS          : ${[system.osVersion, system.osRelease].filter(Boolean).join(' / ')}`)
+    }
+    lines.push(`Electron    : ${system.electron ?? 'n/a'}`)
+    lines.push(`Chrome      : ${system.chrome ?? 'n/a'}`)
+    lines.push(`Node        : ${system.node ?? 'n/a'}`)
+    if (system.locale) {
+        lines.push(`Locale/TZ   : ${system.locale}`)
+    }
+    lines.push('')
+
+    if (breadcrumbs && breadcrumbs.trim()) {
+        lines.push('--- Breadcrumbs ---')
+        lines.push(redactSecrets(breadcrumbs.trim()))
+        lines.push('')
+    }
+
+    lines.push('--- main.log (tail) ---')
+    if (logTail && logTail.trim()) {
+        lines.push(redactSecrets(logTail.trimEnd()))
+    } else {
+        lines.push('(empty or unavailable)')
+    }
+    lines.push('')
+
+    return lines.join('\n')
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,7 @@ import { setupPipHandlers } from './pipHandlers'
 import { setupCertificateErrorHandler } from './certificatePolicy'
 import { setupMpvHandlers } from './mpvPlayer'
 import { setupNotifyHandlers } from './notifyHandlers'
+import { setupDiagnosticsHandlers } from './diagnosticsHandlers'
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url)
@@ -34,6 +35,7 @@ setupAirPlayHandlers()
 setupDownloadHandlers()
 setupCertificateErrorHandler()
 setupMpvHandlers() // EXPERIMENTAL — MPV PoC
+setupDiagnosticsHandlers()
 
 process.env.DIST = path.join(__dirname, '../dist')
 process.env.VITE_PUBLIC = app.isPackaged ? process.env.DIST : path.join(process.env.DIST, '../public')

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -17,6 +17,8 @@ const invokeChannels = new Set([
     'categories:get-series',
     'categories:get-vod',
     'content:get-counts',
+    'diagnostics:export-report',
+    'diagnostics:open-logs',
     'dlna:add-device',
     'dlna:cast',
     'dlna:discover',

--- a/src/locales/ui/en.json
+++ b/src/locales/ui/en.json
@@ -7,6 +7,7 @@
     "epg": "EPG",
     "stats": "Statistics",
     "parental": "Parental Control",
+    "diagnostics": "Diagnostics",
     "about": "About",
     "home": "Home",
     "liveTV": "Live TV",
@@ -356,6 +357,21 @@
     "confirmImportCancel": "Cancel",
     "importSuccess": "Backup restored successfully! Restart the app to apply all changes.",
     "credentialsNote": "IPTV provider credentials are NOT included in the backup."
+  },
+  "diagnostics": {
+    "title": "Diagnostics",
+    "description": "Generate an error report you can share to help troubleshoot issues",
+    "enableDetailed": "Enable detailed diagnostics",
+    "enableDetailedDesc": "Keeps a small history of recent UI errors in memory. It stays on your device and is only included when you export a report.",
+    "note": "Nothing is sent automatically. Diagnostics stay local and only leave the app when you manually export and share the report.",
+    "exportReport": "Export error report",
+    "exportReportDesc": "Creates a .txt file with the app version, system info and the tail of the log (main.log)",
+    "exported": "✓ Report saved to:",
+    "exportCanceled": "Export canceled",
+    "exportError": "Error exporting the report",
+    "openLogs": "Open logs folder",
+    "openLogsDesc": "Opens the folder where main.log is written",
+    "openLogsError": "Could not open the logs folder"
   },
   "epg": {
     "title": "Program Guide (EPG)",

--- a/src/locales/ui/es.json
+++ b/src/locales/ui/es.json
@@ -7,6 +7,7 @@
     "epg": "EPG",
     "stats": "Estadísticas",
     "parental": "Control Parental",
+    "diagnostics": "Diagnóstico",
     "about": "Acerca de",
     "home": "Inicio",
     "liveTV": "TV en Vivo",
@@ -356,6 +357,21 @@
     "confirmImportCancel": "Cancelar",
     "importSuccess": "¡Copia restaurada con éxito! Reinicia la aplicación para aplicar todos los cambios.",
     "credentialsNote": "Las credenciales del proveedor IPTV NO se incluyen en la copia de seguridad."
+  },
+  "diagnostics": {
+    "title": "Diagnóstico",
+    "description": "Genera un informe de error que puedes compartir para ayudar a resolver problemas",
+    "enableDetailed": "Activar diagnóstico detallado",
+    "enableDetailedDesc": "Mantiene un pequeño historial de errores recientes de la interfaz en memoria. Permanece en tu dispositivo y solo se incluye cuando exportas un informe.",
+    "note": "No se envía nada automáticamente. El diagnóstico permanece local y solo sale de la aplicación cuando exportas y compartes el informe manualmente.",
+    "exportReport": "Exportar informe de error",
+    "exportReportDesc": "Crea un archivo .txt con la versión de la app, información del sistema y el final del registro (main.log)",
+    "exported": "✓ Informe guardado en:",
+    "exportCanceled": "Exportación cancelada",
+    "exportError": "Error al exportar el informe",
+    "openLogs": "Abrir carpeta de registros",
+    "openLogsDesc": "Abre la carpeta donde se escribe main.log",
+    "openLogsError": "No se pudo abrir la carpeta de registros"
   },
   "epg": {
     "title": "Guía de Programación (EPG)",

--- a/src/locales/ui/pt.json
+++ b/src/locales/ui/pt.json
@@ -7,6 +7,7 @@
     "epg": "EPG",
     "stats": "Estatísticas",
     "parental": "Controle Parental",
+    "diagnostics": "Diagnóstico",
     "about": "Sobre",
     "home": "Início",
     "liveTV": "TV ao Vivo",
@@ -256,6 +257,21 @@
     "confirmImportCancel": "Cancelar",
     "importSuccess": "Backup restaurado com sucesso! Reinicie o aplicativo para aplicar todas as alterações.",
     "credentialsNote": "As credenciais do provedor IPTV não são incluídas no backup."
+  },
+  "diagnostics": {
+    "title": "Diagnóstico",
+    "description": "Gere um relatório de erro que você pode compartilhar para ajudar a resolver problemas",
+    "enableDetailed": "Ativar diagnóstico detalhado",
+    "enableDetailedDesc": "Mantém um pequeno histórico de erros recentes da interface em memória. Fica apenas no seu dispositivo e só é incluído quando você exporta um relatório.",
+    "note": "Nada é enviado automaticamente. O diagnóstico permanece local e só sai do app quando você exporta e compartilha o relatório manualmente.",
+    "exportReport": "Exportar relatório de erro",
+    "exportReportDesc": "Cria um arquivo .txt com a versão do app, informações do sistema e o final do log (main.log)",
+    "exported": "✓ Relatório salvo em:",
+    "exportCanceled": "Exportação cancelada",
+    "exportError": "Erro ao exportar o relatório",
+    "openLogs": "Abrir pasta de logs",
+    "openLogsDesc": "Abre a pasta onde o main.log é gravado",
+    "openLogsError": "Não foi possível abrir a pasta de logs"
   },
   "epg": {
     "title": "Guia de Programação (EPG)",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { themeService } from './services/themeService'
+import { diagnosticsService } from './services/diagnosticsService'
 
 // Apply the persisted theme (CSS custom properties on <html>) before the
 // first render so themed surfaces never flash the default palette.
@@ -14,6 +15,14 @@ const REPORT_LIMIT = 20
 let reportedErrors = 0
 
 function reportRendererError(message: string, stack?: string, level: 'error' | 'warn' = 'error') {
+  // Always record into the in-memory diagnostics ring buffer (cheap, never
+  // persisted; only included in an export when the opt-in is enabled).
+  try {
+    diagnosticsService.record({ time: new Date().toISOString(), level, message })
+  } catch {
+    // Buffer unavailable — ignore.
+  }
+
   if (reportedErrors >= REPORT_LIMIT) return
   reportedErrors += 1
   try {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -11,6 +11,7 @@ import { ParentalSection } from './settings/ParentalSection';
 import { BackupSection } from './settings/BackupSection';
 import { AboutSection } from './settings/AboutSection';
 import { PlaylistsSection } from './settings/PlaylistsSection';
+import { DiagnosticsSection } from './settings/DiagnosticsSection';
 
 
 export function Settings() {
@@ -43,6 +44,7 @@ export function Settings() {
         { id: 'stats', icon: '📊', label: t('nav', 'stats'), color: '#8b5cf6' },
         { id: 'parental', icon: '👨‍👩‍👧', label: t('nav', 'parental'), color: '#ef4444' },
         { id: 'backup', icon: '💾', label: t('nav', 'backup'), color: '#64748b' },
+        { id: 'diagnostics', icon: '🩺', label: t('nav', 'diagnostics'), color: '#ec4899' },
         { id: 'about', icon: 'ℹ️', label: t('nav', 'about'), color: '#f59e0b' }
     ];
 
@@ -121,6 +123,9 @@ export function Settings() {
 
                         {/* Backup Section */}
                         {activeSection === 'backup' && <BackupSection />}
+
+                        {/* Diagnostics Section */}
+                        {activeSection === 'diagnostics' && <DiagnosticsSection />}
 
                         {/* About Section */}
                         {activeSection === 'about' && <AboutSection />}

--- a/src/pages/settings/DiagnosticsSection.tsx
+++ b/src/pages/settings/DiagnosticsSection.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { useLanguage } from '../../services/languageService';
+import { diagnosticsService } from '../../services/diagnosticsService';
+
+interface ExportReportResult {
+    success: boolean;
+    canceled?: boolean;
+    path?: string;
+    error?: string;
+}
+
+export function DiagnosticsSection() {
+    const { t } = useLanguage();
+    const [enabled, setEnabled] = useState<boolean>(diagnosticsService.isEnabled());
+    const [busy, setBusy] = useState(false);
+    const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    const handleToggle = (value: boolean) => {
+        setEnabled(value);
+        diagnosticsService.setEnabled(value);
+    };
+
+    const handleExport = async () => {
+        setErrorMessage(null);
+        setSuccessMessage(null);
+        setBusy(true);
+        try {
+            // Detailed breadcrumbs are only included when the user opted in.
+            const breadcrumbs = diagnosticsService.isEnabled()
+                ? diagnosticsService.formatBreadcrumbs()
+                : undefined;
+
+            const result = await window.ipcRenderer.invoke(
+                'diagnostics:export-report',
+                { breadcrumbs }
+            ) as ExportReportResult;
+
+            if (result.success) {
+                setSuccessMessage(`${t('diagnostics', 'exported')}${result.path ? `\n${result.path}` : ''}`);
+            } else if (result.canceled) {
+                setSuccessMessage(t('diagnostics', 'exportCanceled'));
+            } else {
+                setErrorMessage(t('diagnostics', 'exportError'));
+            }
+        } catch (error) {
+            console.error('[Diagnostics] Export failed:', error);
+            setErrorMessage(t('diagnostics', 'exportError'));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleOpenLogs = async () => {
+        setErrorMessage(null);
+        setSuccessMessage(null);
+        try {
+            const result = await window.ipcRenderer.invoke('diagnostics:open-logs') as { success: boolean };
+            if (!result.success) {
+                setErrorMessage(t('diagnostics', 'openLogsError'));
+            }
+        } catch (error) {
+            console.error('[Diagnostics] Open logs failed:', error);
+            setErrorMessage(t('diagnostics', 'openLogsError'));
+        }
+    };
+
+    return (
+        <div className="section-card">
+            <div className="section-header">
+                <div className="section-icon" style={{ background: 'linear-gradient(135deg, #ec4899, #db2777)' }}>🩺</div>
+                <div>
+                    <h2>{t('diagnostics', 'title')}</h2>
+                    <p>{t('diagnostics', 'description')}</p>
+                </div>
+            </div>
+
+            <div className="settings-group">
+                {/* Detailed diagnostics opt-in */}
+                <div className="setting-item">
+                    <div className="setting-info">
+                        <label>{t('diagnostics', 'enableDetailed')}</label>
+                        <p>{t('diagnostics', 'enableDetailedDesc')}</p>
+                    </div>
+                    <label className="toggle-switch">
+                        <input
+                            type="checkbox"
+                            checked={enabled}
+                            onChange={(e) => handleToggle(e.target.checked)}
+                        />
+                        <span className="toggle-slider"></span>
+                    </label>
+                </div>
+
+                <div className="certificate-warning">
+                    {t('diagnostics', 'note')}
+                </div>
+
+                {/* Export report */}
+                <div className="setting-item">
+                    <div className="setting-info">
+                        <label>{t('diagnostics', 'exportReport')}</label>
+                        <p>{t('diagnostics', 'exportReportDesc')}</p>
+                    </div>
+                    <button
+                        className="check-btn"
+                        style={{ width: 'auto', padding: '14px 24px' }}
+                        onClick={handleExport}
+                        disabled={busy}
+                    >
+                        <span>📄</span>
+                        <span>{t('diagnostics', 'exportReport')}</span>
+                    </button>
+                </div>
+
+                {/* Open logs folder */}
+                <div className="setting-item">
+                    <div className="setting-info">
+                        <label>{t('diagnostics', 'openLogs')}</label>
+                        <p>{t('diagnostics', 'openLogsDesc')}</p>
+                    </div>
+                    <button
+                        className="about-link"
+                        style={{ whiteSpace: 'nowrap' }}
+                        onClick={handleOpenLogs}
+                    >
+                        📂 {t('diagnostics', 'openLogs')}
+                    </button>
+                </div>
+
+                {errorMessage && (
+                    <div className="certificate-warning" style={{ borderColor: 'rgba(239, 68, 68, 0.4)', background: 'rgba(239, 68, 68, 0.12)' }}>
+                        ⚠️ {errorMessage}
+                    </div>
+                )}
+
+                {successMessage && (
+                    <div className="last-check" style={{ whiteSpace: 'pre-line' }}>
+                        <span className="check-icon">✅</span>
+                        <span>{successMessage}</span>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/services/diagnosticsService.test.ts
+++ b/src/services/diagnosticsService.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for the diagnostics ring buffer and opt-in flag.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    record,
+    getBreadcrumbs,
+    formatBreadcrumbs,
+    isEnabled,
+    setEnabled,
+    _resetBuffer,
+} from './diagnosticsService';
+
+beforeEach(() => {
+    _resetBuffer();
+    localStorage.clear();
+});
+
+describe('diagnostics ring buffer', () => {
+    it('records entries and returns them oldest → newest', () => {
+        record({ time: 't1', level: 'error', message: 'a' });
+        record({ time: 't2', level: 'warn', message: 'b' });
+
+        const crumbs = getBreadcrumbs();
+        expect(crumbs).toHaveLength(2);
+        expect(crumbs[0].message).toBe('a');
+        expect(crumbs[1].message).toBe('b');
+    });
+
+    it('caps the buffer at 50 entries, dropping the oldest', () => {
+        for (let i = 0; i < 60; i++) {
+            record({ time: `t${i}`, level: 'info', message: `m${i}` });
+        }
+
+        const crumbs = getBreadcrumbs();
+        expect(crumbs).toHaveLength(50);
+        // Oldest 10 dropped → first remaining is m10, last is m59.
+        expect(crumbs[0].message).toBe('m10');
+        expect(crumbs[crumbs.length - 1].message).toBe('m59');
+    });
+
+    it('getBreadcrumbs returns a copy (mutation does not affect the buffer)', () => {
+        record({ time: 't1', level: 'error', message: 'a' });
+        const crumbs = getBreadcrumbs();
+        crumbs.push({ time: 't2', level: 'error', message: 'injected' });
+        expect(getBreadcrumbs()).toHaveLength(1);
+    });
+
+    it('formats breadcrumbs as plain text lines', () => {
+        record({ time: '2026-06-30T00:00:00Z', level: 'error', message: 'boom' });
+        expect(formatBreadcrumbs()).toBe('[2026-06-30T00:00:00Z] [error] boom');
+    });
+});
+
+describe('diagnostics opt-in flag', () => {
+    it('defaults to false', () => {
+        expect(isEnabled()).toBe(false);
+    });
+
+    it('persists when enabled', () => {
+        setEnabled(true);
+        expect(isEnabled()).toBe(true);
+        expect(localStorage.getItem('neostream_diagnostics_enabled')).toBe('true');
+    });
+
+    it('can be disabled again', () => {
+        setEnabled(true);
+        setEnabled(false);
+        expect(isEnabled()).toBe(false);
+    });
+});

--- a/src/services/diagnosticsService.ts
+++ b/src/services/diagnosticsService.ts
@@ -1,0 +1,83 @@
+// Diagnostics Service (renderer)
+//
+// Two responsibilities:
+//   1) An opt-in "detailed diagnostics" flag (localStorage, default FALSE).
+//      When OFF, an exported report still includes the main.log tail + system
+//      info; only the extra in-app breadcrumbs are withheld (privacy-conscious).
+//   2) A tiny in-memory ring buffer of recent breadcrumbs/errors. This is
+//      always recorded (it's just memory and never persisted), but is only
+//      INCLUDED in an exported report when the opt-in is enabled.
+//
+// The buffer is intentionally cheap: a fixed-size array, no I/O, no React.
+
+export interface DiagnosticEntry {
+    /** ISO-8601 timestamp. */
+    time: string;
+    level: 'error' | 'warn' | 'info';
+    message: string;
+}
+
+const STORAGE_KEY = 'neostream_diagnostics_enabled';
+const BUFFER_CAP = 50;
+
+// Ring buffer: when full, the oldest entry is dropped. Order preserved
+// (oldest → newest).
+const buffer: DiagnosticEntry[] = [];
+
+/** Whether detailed diagnostics (breadcrumbs in exports) are opted in. */
+export function isEnabled(): boolean {
+    try {
+        return localStorage.getItem(STORAGE_KEY) === 'true';
+    } catch {
+        return false;
+    }
+}
+
+/** Persist the opt-in flag. */
+export function setEnabled(enabled: boolean): void {
+    try {
+        localStorage.setItem(STORAGE_KEY, enabled ? 'true' : 'false');
+    } catch {
+        // localStorage unavailable (e.g. tests) — nothing to persist.
+    }
+}
+
+/**
+ * Records a breadcrumb/error into the in-memory ring buffer. Always cheap and
+ * always on — recording does not depend on the opt-in flag (only the EXPORT
+ * does). Drops the oldest entry once the cap is reached.
+ */
+export function record(entry: DiagnosticEntry): void {
+    buffer.push(entry);
+    if (buffer.length > BUFFER_CAP) {
+        buffer.splice(0, buffer.length - BUFFER_CAP);
+    }
+}
+
+/** Returns a copy of the current breadcrumbs (oldest → newest). */
+export function getBreadcrumbs(): DiagnosticEntry[] {
+    return buffer.slice();
+}
+
+/** Test-only: clears the in-memory buffer. */
+export function _resetBuffer(): void {
+    buffer.length = 0;
+}
+
+/** Formats the breadcrumbs as a plain-text block for the exported report. */
+export function formatBreadcrumbs(entries: DiagnosticEntry[] = getBreadcrumbs()): string {
+    return entries
+        .map((e) => `[${e.time}] [${e.level}] ${e.message}`)
+        .join('\n');
+}
+
+export const diagnosticsService = {
+    isEnabled,
+    setEnabled,
+    record,
+    getBreadcrumbs,
+    formatBreadcrumbs,
+    _resetBuffer,
+};
+
+export default diagnosticsService;


### PR DESCRIPTION
## 🩺 Diagnóstico & relatório de erro

Os erros já vão pro `main.log`; este PR dá uma forma de **você exportar um relatório pra compartilhar** + um opt-in de diagnóstico mais detalhado. **Sem servidor de telemetria** — nada sai da sua máquina sem você mandar.

### O que tem
- **Configurações → 🩺 Diagnóstico**: toggle "Ativar diagnóstico detalhado" (padrão **desligado**) + nota de privacidade, botão **"Exportar relatório de erro"** e **"Abrir pasta de logs"**
- O relatório junta: versão do app, sistema (plataforma/arch/electron/chrome/node/OS) e o final do `main.log` (~200KB), salvo num `.txt` que você escolhe onde gravar
- **Redação de segredos**: mascara `username=`/`password=` e `"password":"..."` no relatório antes de salvar (a senha do provedor não vaza)
- Breadcrumbs (rastro de erros recentes, em memória) só entram no relatório quando o opt-in está ligado

### Verificação
tsc / eslint / vitest **294** (redação + montagem + ring buffer + opt-in) / vite build / Playwright **15** ✅

> ⚠️ O gate visual da GUI foi bloqueado de novo por um painel de entrada do Windows roubando foco — a parte sensível (redação de senha) está coberta por testes. Dá uma olhada na seção Diagnóstico quando testar.

> **Fecha a Rodada 10.** PR 6/6.