### PR TITLE
fix(trailer): corrige embed do YouTube (Erro 153) injetando Referer/Origin

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,6 +17,7 @@ import { setupCertificateErrorHandler } from './certificatePolicy'
 import { setupMpvHandlers } from './mpvPlayer'
 import { setupNotifyHandlers } from './notifyHandlers'
 import { setupDiagnosticsHandlers } from './diagnosticsHandlers'
+import { setupYouTubeEmbedFix } from './youtubeEmbedFix'
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url)
@@ -62,6 +63,11 @@ function createWindow() {
             webSecurity: true,
         },
     })
+
+    // YouTube trailer embeds throw "Erro 153" from the packaged file:// origin
+    // because they lack a valid Referer/Origin. Inject one for YouTube hosts so
+    // both the "Ver Trailer" modal and the hover preview play inline.
+    setupYouTubeEmbedFix(win.webContents.session)
 
     // Prevent any native maximize attempts (Win+Up, etc.)
     win.on('maximize', () => {

--- a/electron/youtubeEmbedFix.test.ts
+++ b/electron/youtubeEmbedFix.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for the pure YouTube embed-fix helpers.
+ */
+import { describe, it, expect } from 'vitest'
+import { isYouTubeRequest, withYouTubeReferer, YOUTUBE_URL_FILTER } from './youtubeEmbedFix'
+
+describe('isYouTubeRequest', () => {
+    it('matches youtube.com and subdomains', () => {
+        expect(isYouTubeRequest('https://www.youtube.com/embed/abc123?autoplay=1')).toBe(true)
+        expect(isYouTubeRequest('https://youtube.com/watch?v=abc')).toBe(true)
+        expect(isYouTubeRequest('https://m.youtube.com/')).toBe(true)
+    })
+
+    it('matches youtube-nocookie.com (hover preview)', () => {
+        expect(isYouTubeRequest('https://www.youtube-nocookie.com/embed/abc123')).toBe(true)
+    })
+
+    it('matches thumbnail and video CDN hosts', () => {
+        expect(isYouTubeRequest('https://i.ytimg.com/vi/abc/hqdefault.jpg')).toBe(true)
+        expect(isYouTubeRequest('https://r1---sn-x.googlevideo.com/videoplayback?x=1')).toBe(true)
+    })
+
+    it('rejects unrelated and look-alike hosts', () => {
+        expect(isYouTubeRequest('https://example.com/embed/abc')).toBe(false)
+        expect(isYouTubeRequest('https://notyoutube.com/')).toBe(false)
+        expect(isYouTubeRequest('https://youtube.com.evil.com/')).toBe(false)
+        expect(isYouTubeRequest('file:///C:/app/index.html')).toBe(false)
+    })
+
+    it('does not throw on malformed input', () => {
+        expect(isYouTubeRequest('not a url')).toBe(false)
+        expect(isYouTubeRequest('')).toBe(false)
+    })
+})
+
+describe('withYouTubeReferer', () => {
+    it('sets a valid youtube.com Referer and Origin', () => {
+        const out = withYouTubeReferer({ 'User-Agent': 'x' })
+        expect(out.Referer).toBe('https://www.youtube.com/')
+        expect(out.Origin).toBe('https://www.youtube.com')
+    })
+
+    it('preserves other headers and does not mutate the input', () => {
+        const input = { 'User-Agent': 'x', 'Accept-Language': 'pt-BR' }
+        const out = withYouTubeReferer(input)
+        expect(out['User-Agent']).toBe('x')
+        expect(out['Accept-Language']).toBe('pt-BR')
+        expect(input).not.toHaveProperty('Referer')
+    })
+
+    it('overrides any pre-existing file:// referer', () => {
+        const out = withYouTubeReferer({ Referer: 'file:///C:/app/index.html' })
+        expect(out.Referer).toBe('https://www.youtube.com/')
+    })
+})
+
+describe('YOUTUBE_URL_FILTER', () => {
+    it('covers youtube, nocookie, ytimg and googlevideo', () => {
+        expect(YOUTUBE_URL_FILTER).toContain('*://*.youtube.com/*')
+        expect(YOUTUBE_URL_FILTER).toContain('*://*.youtube-nocookie.com/*')
+        expect(YOUTUBE_URL_FILTER).toContain('*://*.ytimg.com/*')
+        expect(YOUTUBE_URL_FILTER).toContain('*://*.googlevideo.com/*')
+    })
+})

--- a/electron/youtubeEmbedFix.ts
+++ b/electron/youtubeEmbedFix.ts
@@ -1,0 +1,53 @@
+import type { Session } from 'electron'
+
+/**
+ * YouTube trailer embeds fail with "Erro 153 / player configuration error"
+ * (the player shows a "Watch on YouTube" link instead of playing) when the
+ * app is loaded from file:// in the packaged build: the embedded player has
+ * no valid HTTP referrer/origin, so YouTube refuses to play the video inline.
+ * In dev it works because the window loads from http://localhost.
+ *
+ * Fix: for requests to YouTube domains, present a legit youtube.com
+ * Referer/Origin so the embed is accepted. Scoped strictly to YouTube hosts
+ * so nothing else is touched.
+ */
+
+export const YOUTUBE_URL_FILTER = [
+    '*://*.youtube.com/*',
+    '*://*.youtube-nocookie.com/*',
+    '*://*.ytimg.com/*',
+    '*://*.googlevideo.com/*',
+]
+
+const YOUTUBE_REFERER = 'https://www.youtube.com/'
+const YOUTUBE_ORIGIN = 'https://www.youtube.com'
+
+/** Pure host check (unit-tested): does this URL target a YouTube-owned host? */
+export function isYouTubeRequest(url: string): boolean {
+    try {
+        const host = new URL(url).hostname.toLowerCase()
+        return (
+            host === 'youtube.com' || host.endsWith('.youtube.com') ||
+            host === 'youtube-nocookie.com' || host.endsWith('.youtube-nocookie.com') ||
+            host.endsWith('.ytimg.com') ||
+            host.endsWith('.googlevideo.com')
+        )
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Rewrite the outgoing headers for a YouTube request so the embed plays
+ * inline. Pure so it can be unit-tested; the caller wires it into webRequest.
+ */
+export function withYouTubeReferer(headers: Record<string, string>): Record<string, string> {
+    return { ...headers, Referer: YOUTUBE_REFERER, Origin: YOUTUBE_ORIGIN }
+}
+
+/** Install the referer/origin rewrite on a session's webRequest. */
+export function setupYouTubeEmbedFix(session: Session): void {
+    session.webRequest.onBeforeSendHeaders({ urls: YOUTUBE_URL_FILTER }, (details, callback) => {
+        callback({ requestHeaders: withYouTubeReferer(details.requestHeaders as Record<string, string>) })
+    })
+}


### PR DESCRIPTION
## Problema

Clicar em **Ver Trailer** (e o **preview de trailer no hover**) mostrava:

> Assistir o vídeo no YouTube · **Erro 153** · Erro de configuração do player de vídeo

Causa raiz: na build empacotada a janela carrega de `file://`, então o iframe do YouTube não tem `Referer`/`Origin` HTTP válidos e o YouTube recusa reproduzir o embed inline (em dev funciona porque carrega de `http://localhost`). Por isso o hover de trailer (#48) também nunca aparecia.

## Correção

- `electron/youtubeEmbedFix.ts`: `setupYouTubeEmbedFix(session)` instala um `onBeforeSendHeaders` **restrito a hosts do YouTube** (`youtube.com`, `youtube-nocookie.com`, `ytimg.com`, `googlevideo.com`) que define `Referer: https://www.youtube.com/` e `Origin: https://www.youtube.com`. Nada fora do YouTube é tocado.
- `electron/main.ts`: chama `setupYouTubeEmbedFix(win.webContents.session)` logo após criar a janela.
- Beneficia os dois caminhos: o modal (`youtube.com/embed`) e o hover (`youtube-nocookie.com/embed`).

## Testes

- Helpers puros `isYouTubeRequest` / `withYouTubeReferer` com 9 testes de unidade (`youtubeEmbedFix.test.ts`), incluindo rejeição de look-alikes (`youtube.com.evil.com`).
- Gate completo verde: `tsc -b`, `eslint`, `vitest` (357 testes), `vite build`.

## Observação

O comportamento só pode ser 100% confirmado na build empacotada (`file://`) — não dá pra reproduzir o `file://` no `npm run dev`. A injeção de Referer é a correção padrão para o erro 153 em apps Electron `file://`. Sugiro validar após instalar a próxima release.
