### PR TITLE
feat(trailer): preview central estilo Netflix (voa pro centro e expande)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { PostUpdateChangelog } from './components/PostUpdateChangelog';
 import { EpisodeToast } from './components/EpisodeToast';
 import { MiniPlayerProvider } from './components/MiniPlayer';
 import { CustomTitleBar } from './components/CustomTitleBar';
+import { HoverPreviewOverlay } from './components/HoverPreviewOverlay';
 import { profileService } from './services/profileService';
 import { reminderService } from './services/reminderService';
 import { movieProgressService } from './services/movieProgressService';
@@ -147,6 +148,7 @@ function App() {
   return (
     <MiniPlayerProvider>
       <CustomTitleBar />
+      <HoverPreviewOverlay />
       <UpdateNotification />
       <PostUpdateChangelog />
       <HashRouter>

--- a/src/components/HoverPreviewCard.css
+++ b/src/components/HoverPreviewCard.css
@@ -48,52 +48,6 @@
     transform: scale(1.08);
 }
 
-/* Muted trailer preview that fades in over the poster */
-.preview-trailer {
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    overflow: hidden;
-    background: #000;
-    animation: trailerFadeIn 0.6s ease forwards;
-}
-
-@keyframes trailerFadeIn {
-    from {
-        opacity: 0;
-    }
-
-    to {
-        opacity: 1;
-    }
-}
-
-.preview-trailer iframe {
-    /* Fill the 2:3 poster area with a 16:9 video, cropping the sides. */
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 178%;
-    /* 16/9 of the height */
-    height: 100%;
-    min-width: 100%;
-    transform: translate(-50%, -50%) scale(1.01);
-    border: none;
-    pointer-events: none;
-}
-
-.preview-trailer-muted {
-    position: absolute;
-    top: 8px;
-    left: 8px;
-    z-index: 2;
-    font-size: 14px;
-    line-height: 1;
-    padding: 4px 6px;
-    border-radius: 8px;
-    background: rgba(0, 0, 0, 0.55);
-}
-
 /* Card info (below poster) */
 .card-info {
     padding: 14px;

--- a/src/components/HoverPreviewCard.tsx
+++ b/src/components/HoverPreviewCard.tsx
@@ -1,12 +1,12 @@
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { Play } from 'lucide-react';
 import { LazyImage } from './LazyImage';
-import { extractYouTubeId } from '../utils/youtube';
-import { fetchMovieTrailer, fetchSeriesTrailer } from '../services/tmdb';
+import { hoverPreviewBus } from './hoverPreviewBus';
 import './HoverPreviewCard.css';
 
-// Delay before the trailer starts so a quick mouse pass-over never loads it.
-const TRAILER_DELAY_MS = 1200;
+// Delay before the centered preview opens, so a quick mouse pass-over never
+// triggers it.
+const OPEN_DELAY_MS = 450;
 
 const prefersReducedMotion = () =>
     typeof window !== 'undefined' &&
@@ -34,24 +34,20 @@ interface HoverPreviewCardProps {
 function HoverPreviewCardComponent({
     type,
     cover,
+    backdrop,
     title,
     year,
+    rating,
+    genres,
     youtubeTrailer,
+    isFavorite,
+    onPlay,
     onMoreInfo,
+    onToggleFavorite,
     children
 }: HoverPreviewCardProps) {
-    // The provider's youtube_trailer field is empty for most items, so fall
-    // back to TMDB (same source the detail modal uses) — fetched lazily on
-    // first hover and cached for later hovers.
-    const [fetchedTrailer, setFetchedTrailer] = useState<string | null>(null);
-    const trailerId = extractYouTubeId(youtubeTrailer || fetchedTrailer || undefined);
-
-    // Only mount the iframe once the hover delay elapses; unmount on leave.
-    const [showTrailer, setShowTrailer] = useState(false);
+    const posterRef = useRef<HTMLDivElement>(null);
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const hoveringRef = useRef(false);
-    // 'idle' → not tried, 'loading' → in flight, 'done' → resolved (or no id).
-    const fetchStateRef = useRef<'idle' | 'loading' | 'done'>('idle');
 
     const clearTimer = () => {
         if (timerRef.current) {
@@ -60,42 +56,38 @@ function HoverPreviewCardComponent({
         }
     };
 
-    const maybeFetchTrailer = () => {
-        if (fetchStateRef.current !== 'idle') return;
-        if (youtubeTrailer || !title) return;
-        fetchStateRef.current = 'loading';
-        const fetcher = type === 'series' ? fetchSeriesTrailer : fetchMovieTrailer;
-        fetcher(title, year)
-            .then(url => setFetchedTrailer(url))
-            .catch(() => { /* no trailer — leave the poster as-is */ })
-            .finally(() => { fetchStateRef.current = 'done'; });
-    };
-
     const handleMouseEnter = () => {
         if (prefersReducedMotion()) return;
-        hoveringRef.current = true;
-        maybeFetchTrailer();
-        // Arm the delay timer even before the id resolves; the render is also
-        // gated on trailerId, so it appears as soon as both are ready.
         clearTimer();
         timerRef.current = setTimeout(() => {
             timerRef.current = null;
-            if (hoveringRef.current) setShowTrailer(true);
-        }, TRAILER_DELAY_MS);
+            const el = posterRef.current;
+            if (!el) return;
+            hoverPreviewBus.open({
+                anchor: el.getBoundingClientRect(),
+                type,
+                title,
+                year,
+                cover,
+                backdrop,
+                rating,
+                genres,
+                youtubeTrailer,
+                isFavorite,
+                onPlay,
+                onMoreInfo,
+                onToggleFavorite,
+            });
+        }, OPEN_DELAY_MS);
     };
 
     const handleMouseLeave = () => {
-        hoveringRef.current = false;
         clearTimer();
-        setShowTrailer(false);
+        hoverPreviewBus.scheduleClose();
     };
 
-    // Drop any pending timer / iframe on unmount.
+    // Drop any pending timer on unmount.
     useEffect(() => clearTimer, []);
-
-    const embedSrc = trailerId
-        ? `https://www.youtube-nocookie.com/embed/${trailerId}?autoplay=1&mute=1&controls=0&modestbranding=1&rel=0&playsinline=1&loop=1&playlist=${trailerId}`
-        : '';
 
     return (
         <div
@@ -105,7 +97,7 @@ function HoverPreviewCardComponent({
             onMouseLeave={handleMouseLeave}
         >
             {/* Poster */}
-            <div className="preview-poster" style={{ position: 'relative' }}>
+            <div className="preview-poster" ref={posterRef} style={{ position: 'relative' }}>
                 <LazyImage
                     src={cover}
                     alt={title}
@@ -115,20 +107,6 @@ function HoverPreviewCardComponent({
                         </div>
                     )}
                 />
-
-                {/* Muted trailer preview, fades in over the poster */}
-                {showTrailer && trailerId && (
-                    <div className="preview-trailer">
-                        <iframe
-                            src={embedSrc}
-                            title={`${title} trailer`}
-                            referrerPolicy="strict-origin-when-cross-origin"
-                            allow="autoplay; encrypted-media; picture-in-picture"
-                            tabIndex={-1}
-                        />
-                        <span className="preview-trailer-muted" aria-hidden="true">🔇</span>
-                    </div>
-                )}
 
                 {/* Overlay with play button */}
                 <div className="card-overlay">

--- a/src/components/HoverPreviewOverlay.css
+++ b/src/components/HoverPreviewOverlay.css
@@ -1,0 +1,147 @@
+.hp-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 4000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hp-dim {
+    position: absolute;
+    inset: 0;
+    background: rgba(6, 6, 18, 0.62);
+    animation: hpDimIn 0.3s ease forwards;
+}
+
+@keyframes hpDimIn {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+/* Centered preview panel — 65% of the viewport width, capped for big screens. */
+.hp-panel {
+    position: relative;
+    width: 65vw;
+    max-width: 1100px;
+    border-radius: 14px;
+    overflow: hidden;
+    background: var(--ns-bg-panel, #181829);
+    box-shadow: 0 30px 70px rgba(0, 0, 0, 0.6),
+        0 0 0 1px rgba(255, 255, 255, 0.04);
+    will-change: transform, opacity;
+}
+
+/* 16:9 video / still area */
+.hp-screen {
+    position: relative;
+    aspect-ratio: 16 / 9;
+    background: #000;
+    overflow: hidden;
+    cursor: pointer;
+}
+
+.hp-still {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    filter: brightness(0.9);
+}
+
+.hp-trailer {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    /* Fill 16:9 with the 16:9 embed, scaled slightly to hide letterboxing. */
+    width: 100%;
+    height: 100%;
+    transform: translate(-50%, -50%) scale(1.02);
+    border: none;
+    pointer-events: none;
+}
+
+.hp-muted {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 2;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hp-bar {
+    padding: 14px 18px 16px;
+    background: var(--ns-bg-panel, #181829);
+}
+
+.hp-actions {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.hp-btn {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    border: 1.5px solid rgba(255, 255, 255, 0.5);
+    background: transparent;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.hp-btn:hover {
+    transform: scale(1.12);
+    background: rgba(255, 255, 255, 0.14);
+    border-color: #fff;
+}
+
+.hp-btn-play {
+    background: #fff;
+    color: #111;
+    border-color: #fff;
+}
+
+.hp-btn-play:hover {
+    background: rgba(255, 255, 255, 0.85);
+}
+
+.hp-btn.is-active {
+    color: var(--ns-accent-light, #8b7bff);
+    border-color: var(--ns-accent-light, #8b7bff);
+}
+
+.hp-meta strong {
+    display: block;
+    color: #fff;
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 2px;
+}
+
+.hp-meta span {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 13px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hp-panel {
+        transition: opacity 0.2s ease !important;
+    }
+}

--- a/src/components/HoverPreviewOverlay.tsx
+++ b/src/components/HoverPreviewOverlay.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Play, Heart, Info, VolumeX } from 'lucide-react';
+import { extractYouTubeId } from '../utils/youtube';
+import { fetchMovieTrailer, fetchSeriesTrailer } from '../services/tmdb';
+import { hoverPreviewBus, type HoverPreviewPayload } from './hoverPreviewBus';
+import './HoverPreviewOverlay.css';
+
+// How long the card lingers (after the mouse leaves it) before the panel
+// closes — enough time to travel across the dim toward the centered panel.
+const CLOSE_FROM_CARD_MS = 380;
+// Shorter grace once the mouse is on/near the panel itself.
+const CLOSE_FROM_PANEL_MS = 160;
+
+const prefersReducedMotion = () =>
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+/**
+ * Single, app-wide overlay that renders the centered "fly to center + expand"
+ * trailer preview. Mounted once near the app root; driven by hoverPreviewBus.
+ */
+export function HoverPreviewOverlay() {
+    const [payload, setPayload] = useState<HoverPreviewPayload | null>(null);
+    // Trailer resolved from TMDB, tagged with the payload it belongs to so a
+    // late response for a previous item is ignored (derived, not reset in an
+    // effect).
+    const [fetched, setFetched] = useState<{ key: HoverPreviewPayload; id: string | null } | null>(null);
+    const [favorite, setFavorite] = useState(false);
+
+    const directId = extractYouTubeId(payload?.youtubeTrailer || undefined);
+    const trailerId = directId || (fetched && fetched.key === payload ? fetched.id : null);
+
+    const panelRef = useRef<HTMLDivElement>(null);
+    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Kept in a ref so the bus handlers (registered once) always see the latest.
+    const payloadRef = useRef<HoverPreviewPayload | null>(null);
+    useEffect(() => { payloadRef.current = payload; }, [payload]);
+
+    const clearCloseTimer = () => {
+        if (closeTimer.current) {
+            clearTimeout(closeTimer.current);
+            closeTimer.current = null;
+        }
+    };
+
+    // Reverse FLIP: shrink the panel back toward the originating poster, then
+    // unmount.
+    const animateOutAndClose = useCallback(() => {
+        const panel = panelRef.current;
+        const current = payloadRef.current;
+        if (!panel || !current || prefersReducedMotion()) {
+            setPayload(null);
+            return;
+        }
+        const target = panel.getBoundingClientRect();
+        const a = current.anchor;
+        const dx = (a.left + a.width / 2) - (target.left + target.width / 2);
+        const dy = (a.top + a.height / 2) - (target.top + target.height / 2);
+        const scale = a.width / target.width;
+        panel.style.transition = 'transform .3s ease, opacity .28s ease';
+        panel.style.transformOrigin = 'center center';
+        panel.style.transform = `translate(${dx}px, ${dy}px) scale(${scale})`;
+        panel.style.opacity = '0';
+        closeTimer.current = setTimeout(() => setPayload(null), 300);
+    }, []);
+
+    const scheduleClose = useCallback((delay: number) => {
+        clearCloseTimer();
+        closeTimer.current = setTimeout(animateOutAndClose, delay);
+    }, [animateOutAndClose]);
+
+    // Register with the bus once.
+    useEffect(() => {
+        const unregister = hoverPreviewBus.register({
+            open: (next) => {
+                clearCloseTimer();
+                setFavorite(!!next.isFavorite);
+                setPayload(next);
+            },
+            scheduleClose: () => scheduleClose(CLOSE_FROM_CARD_MS),
+            cancelClose: clearCloseTimer,
+        });
+        return () => {
+            unregister();
+            clearCloseTimer();
+        };
+    }, [scheduleClose]);
+
+    // Resolve the trailer from TMDB when the provider didn't supply one (same
+    // source the detail modal uses). The async callback tags its result with
+    // the current payload so a stale response is ignored by the derived value.
+    useEffect(() => {
+        if (!payload || directId) return;
+        const fetcher = payload.type === 'series' ? fetchSeriesTrailer : fetchMovieTrailer;
+        fetcher(payload.title, payload.year)
+            .then((url) => setFetched({ key: payload, id: extractYouTubeId(url || undefined) }))
+            .catch(() => { /* leave the still frame showing */ });
+    }, [payload, directId]);
+
+    // Enter FLIP: fly the panel from the poster rect to its centered rest state.
+    useLayoutEffect(() => {
+        const panel = panelRef.current;
+        if (!panel || !payload) return;
+        panel.style.opacity = '';
+        if (prefersReducedMotion()) {
+            panel.style.transform = '';
+            return;
+        }
+        const target = panel.getBoundingClientRect();
+        const a = payload.anchor;
+        const dx = (a.left + a.width / 2) - (target.left + target.width / 2);
+        const dy = (a.top + a.height / 2) - (target.top + target.height / 2);
+        const scale = a.width / target.width;
+        panel.style.transition = 'none';
+        panel.style.transformOrigin = 'center center';
+        panel.style.transform = `translate(${dx}px, ${dy}px) scale(${scale})`;
+        // Force reflow, then animate to the rest state.
+        void panel.getBoundingClientRect();
+        panel.style.transition = 'transform .34s cubic-bezier(.32,1.28,.5,1), opacity .22s ease';
+        panel.style.transform = 'translate(0, 0) scale(1)';
+    }, [payload]);
+
+    // Close on Escape.
+    useEffect(() => {
+        if (!payload) return;
+        const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') animateOutAndClose(); };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [payload, animateOutAndClose]);
+
+    if (!payload) return null;
+
+    const still = payload.backdrop || payload.cover;
+    const embedSrc = trailerId
+        ? `https://www.youtube-nocookie.com/embed/${trailerId}?autoplay=1&mute=1&controls=0&modestbranding=1&rel=0&playsinline=1&loop=1&playlist=${trailerId}`
+        : '';
+
+    const runAndClose = (fn?: () => void) => {
+        fn?.();
+        clearCloseTimer();
+        setPayload(null);
+    };
+
+    return createPortal(
+        <div className="hp-overlay" role="dialog" aria-label={`${payload.title} — prévia`}>
+            <div className="hp-dim" onClick={animateOutAndClose} />
+            <div
+                className="hp-panel"
+                ref={panelRef}
+                onMouseEnter={clearCloseTimer}
+                onMouseLeave={() => scheduleClose(CLOSE_FROM_PANEL_MS)}
+            >
+                <div className="hp-screen" onClick={() => runAndClose(payload.onMoreInfo)}>
+                    <div className="hp-still" style={{ backgroundImage: still ? `url("${still}")` : undefined }} />
+                    {trailerId && (
+                        <iframe
+                            className="hp-trailer"
+                            src={embedSrc}
+                            title={`${payload.title} trailer`}
+                            referrerPolicy="strict-origin-when-cross-origin"
+                            allow="autoplay; encrypted-media; picture-in-picture"
+                            tabIndex={-1}
+                        />
+                    )}
+                    <span className="hp-muted" aria-hidden="true"><VolumeX size={15} /></span>
+                </div>
+
+                <div className="hp-bar">
+                    <div className="hp-actions">
+                        <button
+                            className="hp-btn hp-btn-play"
+                            onClick={(e) => { e.stopPropagation(); runAndClose(payload.onPlay); }}
+                            aria-label="Assistir"
+                        >
+                            <Play size={18} fill="currentColor" />
+                        </button>
+                        {payload.onToggleFavorite && (
+                            <button
+                                className={`hp-btn ${favorite ? 'is-active' : ''}`}
+                                onClick={(e) => { e.stopPropagation(); payload.onToggleFavorite?.(); setFavorite((v) => !v); }}
+                                aria-label={favorite ? 'Remover dos favoritos' : 'Adicionar aos favoritos'}
+                            >
+                                <Heart size={17} fill={favorite ? 'currentColor' : 'none'} />
+                            </button>
+                        )}
+                        <button
+                            className="hp-btn"
+                            onClick={(e) => { e.stopPropagation(); runAndClose(payload.onMoreInfo); }}
+                            aria-label="Mais informações"
+                        >
+                            <Info size={18} />
+                        </button>
+                    </div>
+                    <div className="hp-meta">
+                        <strong>{payload.title}</strong>
+                        <span>
+                            {[payload.year, payload.rating ? `★ ${payload.rating}` : null, payload.genres?.[0]]
+                                .filter(Boolean)
+                                .join(' · ')}
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>,
+        document.body,
+    );
+}

--- a/src/components/hoverPreviewBus.ts
+++ b/src/components/hoverPreviewBus.ts
@@ -1,0 +1,56 @@
+/**
+ * Tiny pub/sub that connects grid cards to the single, app-wide centered
+ * preview overlay. Cards call `open()` on hover (after a delay) with a snapshot
+ * of the poster's on-screen rect + the item's data and action callbacks; the
+ * overlay (registered once near the app root) flies a panel from that rect to
+ * the center of the screen and plays the muted trailer.
+ */
+
+export interface HoverPreviewPayload {
+    /** Poster rect at open time — the FLIP animation flies from here to center. */
+    anchor: DOMRect
+    type: 'movie' | 'series'
+    title: string
+    year?: string
+    cover: string
+    backdrop?: string
+    rating?: string
+    genres?: string[]
+    /** Provider-supplied trailer (usually empty → overlay falls back to TMDB). */
+    youtubeTrailer?: string
+    isFavorite?: boolean
+    onPlay: () => void
+    onMoreInfo: () => void
+    onToggleFavorite?: () => void
+}
+
+interface OverlayHandlers {
+    open: (payload: HoverPreviewPayload) => void
+    scheduleClose: () => void
+    cancelClose: () => void
+}
+
+let handlers: OverlayHandlers | null = null
+
+export const hoverPreviewBus = {
+    /** The overlay registers itself once; returns an unsubscribe. */
+    register(next: OverlayHandlers): () => void {
+        handlers = next
+        return () => {
+            if (handlers === next) handlers = null
+        }
+    },
+    open(payload: HoverPreviewPayload) {
+        handlers?.open(payload)
+    },
+    scheduleClose() {
+        handlers?.scheduleClose()
+    },
+    cancelClose() {
+        handlers?.cancelClose()
+    },
+    /** True when an overlay is mounted (cards can skip work if not). */
+    get active() {
+        return handlers !== null
+    },
+}


### PR DESCRIPTION
## O quê

Preview de trailer estilo Netflix: passa o mouse num card (Filmes/Séries), espera ~0,45s, e um painel **voa do card até o centro da tela** e se expande para **65%** da largura, com o fundo **escurecido**. Trailer mudo (16:9) em cima; barra com **▶ Assistir**, **♥ Favorito** e **ⓘ Detalhes** embaixo. Ao **tirar o mouse**, encolhe de volta pro card.

Alinhado via prévia interativa: largura 65%, com dim, encolhe de volta ao sair.

## Como

- **`hoverPreviewBus.ts`** — pub/sub minúsculo que liga os cards da grade ao overlay único.
- **`HoverPreviewOverlay.tsx`** — montado **uma vez** no `App`; renderiza via portal em `document.body`. Animação **FLIP** (calcula o rect do poster e voa até o centro) na entrada e reversa na saída. Busca o trailer no **TMDB** quando o provedor não manda `youtube_trailer` (mesma fonte do modal); mostra o **still** (backdrop) enquanto carrega. Fecha no **Esc**, no clique do **dim**, ou ao sair do painel. Respeita `prefers-reduced-motion` (só fade, sem voo).
- **`HoverPreviewCard.tsx`** — não embute mais o iframe; agora só dispara o overlay no hover (com delay), passando o rect do poster e os callbacks (`onPlay`/`onMoreInfo`/`onToggleFavorite`).
- **Grace period** ao mover do card até o painel central, pra não fechar no meio do caminho.

## Testes

Gate verde: `tsc -b`, `eslint`, `vitest` (359), `vite build`. É renderer puro — comportamento idêntico em dev e empacotado.

## Ajustes fáceis depois

Largura (65%), delay (450ms), intensidade do dim e durações estão em constantes/CSS — simples de afinar se você quiser mais rápido/maior.
