### PR TITLE
fix(trailer): preview central fechava na hora + travava troca de card

### DIFF
--- a/src/components/HoverPreviewCard.tsx
+++ b/src/components/HoverPreviewCard.tsx
@@ -82,8 +82,11 @@ function HoverPreviewCardComponent({
     };
 
     const handleMouseLeave = () => {
+        // Only cancel a not-yet-opened preview. Once open, the overlay owns
+        // closing (it tracks the pointer against the card + panel rects) — the
+        // full-screen dim would otherwise fire mouseleave here immediately and
+        // close the preview before it's even visible.
         clearTimer();
-        hoverPreviewBus.scheduleClose();
     };
 
     // Drop any pending timer on unmount.

--- a/src/components/HoverPreviewOverlay.css
+++ b/src/components/HoverPreviewOverlay.css
@@ -5,6 +5,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    /* Let the grid underneath stay hoverable so the pointer can move from one
+       card to another while a preview is open — only the panel itself grabs
+       the pointer (below). */
+    pointer-events: none;
 }
 
 .hp-dim {
@@ -12,6 +16,11 @@
     inset: 0;
     background: rgba(6, 6, 18, 0.62);
     animation: hpDimIn 0.3s ease forwards;
+    pointer-events: none;
+}
+
+.hp-panel {
+    pointer-events: auto;
 }
 
 @keyframes hpDimIn {

--- a/src/components/HoverPreviewOverlay.tsx
+++ b/src/components/HoverPreviewOverlay.tsx
@@ -6,11 +6,9 @@ import { fetchMovieTrailer, fetchSeriesTrailer } from '../services/tmdb';
 import { hoverPreviewBus, type HoverPreviewPayload } from './hoverPreviewBus';
 import './HoverPreviewOverlay.css';
 
-// How long the card lingers (after the mouse leaves it) before the panel
-// closes — enough time to travel across the dim toward the centered panel.
-const CLOSE_FROM_CARD_MS = 380;
-// Shorter grace once the mouse is on/near the panel itself.
-const CLOSE_FROM_PANEL_MS = 160;
+// Grace period once the pointer is over neither the card nor the panel —
+// long enough to travel across the dim from the card to the centered panel.
+const CLOSE_GRACE_MS = 340;
 
 const prefersReducedMotion = () =>
     typeof window !== 'undefined' &&
@@ -66,11 +64,6 @@ export function HoverPreviewOverlay() {
         closeTimer.current = setTimeout(() => setPayload(null), 300);
     }, []);
 
-    const scheduleClose = useCallback((delay: number) => {
-        clearCloseTimer();
-        closeTimer.current = setTimeout(animateOutAndClose, delay);
-    }, [animateOutAndClose]);
-
     // Register with the bus once.
     useEffect(() => {
         const unregister = hoverPreviewBus.register({
@@ -79,14 +72,39 @@ export function HoverPreviewOverlay() {
                 setFavorite(!!next.isFavorite);
                 setPayload(next);
             },
-            scheduleClose: () => scheduleClose(CLOSE_FROM_CARD_MS),
+            scheduleClose: () => {
+                clearCloseTimer();
+                closeTimer.current = setTimeout(animateOutAndClose, CLOSE_GRACE_MS);
+            },
             cancelClose: clearCloseTimer,
         });
         return () => {
             unregister();
             clearCloseTimer();
         };
-    }, [scheduleClose]);
+    }, [animateOutAndClose]);
+
+    // Keep the preview open while the pointer is over the originating card OR
+    // the centered panel; close (after a grace) once it's over neither. This
+    // is coordinate-based on purpose: the full-screen dim covers the card, so
+    // DOM hover/mouseleave can't be trusted, and the panel sits far away at
+    // the center — the pointer has to travel across the dim to reach it.
+    useEffect(() => {
+        if (!payload) return;
+        const onMove = (e: MouseEvent) => {
+            const a = payload.anchor;
+            const inCard = e.clientX >= a.left && e.clientX <= a.right && e.clientY >= a.top && e.clientY <= a.bottom;
+            const p = panelRef.current?.getBoundingClientRect();
+            const inPanel = !!p && e.clientX >= p.left && e.clientX <= p.right && e.clientY >= p.top && e.clientY <= p.bottom;
+            if (inCard || inPanel) {
+                clearCloseTimer();
+            } else if (!closeTimer.current) {
+                closeTimer.current = setTimeout(animateOutAndClose, CLOSE_GRACE_MS);
+            }
+        };
+        window.addEventListener('mousemove', onMove);
+        return () => window.removeEventListener('mousemove', onMove);
+    }, [payload, animateOutAndClose]);
 
     // Resolve the trailer from TMDB when the provider didn't supply one (same
     // source the detail modal uses). The async callback tags its result with
@@ -145,12 +163,11 @@ export function HoverPreviewOverlay() {
 
     return createPortal(
         <div className="hp-overlay" role="dialog" aria-label={`${payload.title} — prévia`}>
-            <div className="hp-dim" onClick={animateOutAndClose} />
+            <div className="hp-dim" />
             <div
                 className="hp-panel"
                 ref={panelRef}
                 onMouseEnter={clearCloseTimer}
-                onMouseLeave={() => scheduleClose(CLOSE_FROM_PANEL_MS)}
             >
                 <div className="hp-screen" onClick={() => runAndClose(payload.onMoreInfo)}>
                     <div className="hp-still" style={{ backgroundImage: still ? `url("${still}")` : undefined }} />


### PR DESCRIPTION
## Problema (v3.17.4)

Ao passar o mouse, o fundo escurecia mas o painel **sumia na hora** e o trailer **não tocava** — "ficava só escuro". Verifiquei ao vivo no app: eram **dois** bugs.

## Correções

**1. Fechava antes de aparecer.** O dim em tela cheia cobria o card no momento em que o painel abria, disparando o `mouseleave` do card → fechamento imediato. O painel voava pro centro e sumia antes do trailer carregar.
→ O card **não agenda mais o fechamento**. O overlay decide fechar por **hit-test de coordenadas**: fica aberto enquanto o ponteiro está sobre o card **ou** o painel; fecha após uma folga (340ms) ao sair dos dois. Imune ao dim e à distância até o centro.

**2. Não dava pra trocar de card.** O dim engolia o hover dos outros cards.
→ `dim` e `overlay` com `pointer-events: none`; só o **painel** captura o mouse. A grade continua "hovereável" por baixo, então dá pra passar de um card pro outro.

## Verificado ao vivo (dev)

- Painel **voa pro centro e fica**.
- **Trailer mudo toca** quando existe (confirmado com "Dolly: A Boneca Maldita" — o frame do vídeo mudou).
- **Still** do pôster aparece quando não há trailer (nada de tela preta).
- **Troca de card** funciona.

Gate verde: `tsc -b`, `eslint`, `vitest` (359), `vite build`.
